### PR TITLE
Add MEAT deployment script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ This repository contains two ERC20 tokens:
 4. Deploy the contracts with your preferred Hardhat network configuration. A simple script might look like:
    ```javascript
    const GOAT = await ethers.getContractFactory('GOAT');
-   const goat = await GOAT.deploy(meatAddress);
+   const goat = await GOAT.deploy(ethers.ZeroAddress);
    await goat.deployed();
+
+   const MEAT = await ethers.getContractFactory('MEAT');
+   const meat = await MEAT.deploy(goat.address);
+   await meat.deployed();
+
+   await goat.setMEATAddress(meat.address);
+
    console.log('GOAT deployed to:', goat.address);
+   console.log('MEAT deployed to:', meat.address);
    ```
-   Run using `npx hardhat run scripts/deploy.js --network <network>`.
+   Run using `npx hardhat run scripts/deploy.js --network <network>` and specify your desired Hardhat network with the `--network` option.
 
 ## Running Tests
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -2,10 +2,19 @@ const hre = require("hardhat");
 
 async function main() {
   const [deployer] = await hre.ethers.getSigners();
+
   const GOAT = await hre.ethers.getContractFactory("GOAT");
-  const goat = await GOAT.deploy(deployer.address);
+  const goat = await GOAT.deploy(hre.ethers.ZeroAddress);
   await goat.waitForDeployment();
+
+  const MEAT = await hre.ethers.getContractFactory("MEAT");
+  const meat = await MEAT.deploy(goat.target);
+  await meat.waitForDeployment();
+
+  await goat.setMEATAddress(meat.target);
+
   console.log(`GOAT deployed to: ${goat.target}`);
+  console.log(`MEAT deployed to: ${meat.target}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- deploy MEAT in `scripts/deploy.js` and link it to GOAT
- show both contract addresses after deployment
- document the new deployment flow and the `--network` usage

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68406318883c832595debc2661cdaa60