### PR TITLE
Fix MEAT transferFrom usage

### DIFF
--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -100,7 +100,7 @@ contract MEAT is ERC20 {
         require(swapEnabled, "Swap disabled");
         require(meatAmount > 0, "Amount must be > 0");
         require(allowance(msg.sender, address(this)) >= meatAmount, "Not approved");
-        require(transferFrom(msg.sender, address(this), meatAmount), "MEAT transfer failed");
+        require(IERC20(address(this)).transferFrom(msg.sender, address(this), meatAmount), "MEAT transfer failed");
 
         uint256 goatAmount = meatAmount / SwapRate;
         uint256 goatBalance = GOAT.balanceOf(address(this));

--- a/test/stakingSwap.test.js
+++ b/test/stakingSwap.test.js
@@ -25,9 +25,6 @@ describe("GOAT staking and MEAT swap", function () {
   it("should stake, attempt claim, unstake and swap", async function () {
     const meatAmount = ethers.parseEther("100");
     await meat.connect(user).approve(meat.target, meatAmount);
-    // swapMEATForGOAT calls transferFrom internally so msg.sender remains the user
-    // Require self-approval due to contract implementation
-    await meat.connect(user).approve(user.address, meatAmount);
 
     await meat.connect(user).swapMEATForGOAT(meatAmount);
     const goatAmount = await goat.balanceOf(user.address);


### PR DESCRIPTION
## Summary
- call `IERC20(address(this)).transferFrom` within `swapMEATForGOAT`
- update staking swap test to only approve the contract

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68406821d8cc8325a53d00c13945aa8c