### PR TITLE
Fix claim reward timing and tests

### DIFF
--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -91,10 +91,10 @@ function unstake() external {
 }
 /// @notice Claim only the reward without unstaking
 function claimReward() external {
+    uint256 lastTime = lastStakedTime[msg.sender];
     uint256 reward = calculateReward(msg.sender);
     require(reward > 0, "No reward to claim");
-    lastStakedTime[msg.sender] = block.timestamp;
-    require(block.timestamp - lastStakedTime[msg.sender] >= minClaimInterval, "Claim not allowed yet");
+    require(block.timestamp - lastTime >= minClaimInterval, "Claim not allowed yet");
     uint256 available = balanceOf(address(this));
     if (available >= reward) {
         _transfer(address(this), msg.sender, reward);
@@ -102,6 +102,7 @@ function claimReward() external {
         if (available > 0) _transfer(address(this), msg.sender, available);
         _mint(msg.sender, reward - available);
     }
+    lastStakedTime[msg.sender] = block.timestamp;
     emit RewardClaimed(msg.sender, reward);
 }
 /// @notice Compound current reward into staked balance

--- a/test/claim.test.js
+++ b/test/claim.test.js
@@ -1,0 +1,36 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("GOAT claim timing", function () {
+  let owner, user, goat;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+    const amount = ethers.parseEther("10");
+    await goat.mintTo(user.address, amount);
+  });
+
+  it("reverts when claiming too early", async function () {
+    const stakeAmt = await goat.balanceOf(user.address);
+    await goat.connect(user).stake(stakeAmt);
+    await expect(goat.connect(user).claimReward()).to.be.revertedWith(
+      "Claim not allowed yet"
+    );
+  });
+
+  it("allows claiming after the interval", async function () {
+    const stakeAmt = await goat.balanceOf(user.address);
+    await goat.connect(user).stake(stakeAmt);
+
+    await ethers.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
+
+    const before = await goat.lastStakedTime(user.address);
+    await expect(goat.connect(user).claimReward()).to.not.be.reverted;
+    const after = await goat.lastStakedTime(user.address);
+    expect(after).to.be.gt(before);
+  });
+});

--- a/test/stakingSwap.test.js
+++ b/test/stakingSwap.test.js
@@ -22,7 +22,7 @@ describe("GOAT staking and MEAT swap", function () {
     await meat.transfer(user.address, initialMeat);
   });
 
-  it("should stake, attempt claim, unstake and swap", async function () {
+  it("should stake, claim, unstake and swap", async function () {
     const meatAmount = ethers.parseEther("100");
     await meat.connect(user).approve(meat.target, meatAmount);
     // swapMEATForGOAT calls transferFrom internally so msg.sender remains the user
@@ -42,7 +42,10 @@ describe("GOAT staking and MEAT swap", function () {
     const pending = await goat.pendingReward(user.address);
     expect(pending).to.be.gt(0n);
 
-    await expect(goat.connect(user).claimReward()).to.be.revertedWith("Claim not allowed yet");
+    await goat.connect(user).claimReward();
+
+    await ethers.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
 
     await goat.connect(user).unstake();
     expect(await goat.stakingBalance(user.address)).to.equal(0n);


### PR DESCRIPTION
## Summary
- fix `claimReward` time check to use previous timestamp
- update stakingSwap scenario for correct claim behaviour
- add dedicated tests for claim timing

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684067ac47cc8325933392a878622243