### PR TITLE
Add require for GOAT transfer

### DIFF
--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -107,7 +107,7 @@ contract MEAT is ERC20 {
         if (goatBalance < goatAmount) {
             GOAT.mintTo(address(this), goatAmount - goatBalance);
         }
-        GOAT.transfer(msg.sender, goatAmount);
+        require(GOAT.transfer(msg.sender, goatAmount), "GOAT transfer failed");
         emit SwappedMEATForGOAT(msg.sender, meatAmount, goatAmount);
     }
 

--- a/contracts/mocks/FailingGOAT.sol
+++ b/contracts/mocks/FailingGOAT.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IGOAT} from "../interfaces/IGOAT.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title Mock GOAT token that can simulate transfer failures
+contract FailingGOAT is ERC20, IGOAT {
+    bool public failTransfer;
+
+    constructor() ERC20("Failing GOAT", "FGOAT") {}
+
+    /// @notice Toggle transfer failure mode
+    function setFailTransfer(bool value) external {
+        failTransfer = value;
+    }
+
+    function transfer(address to, uint256 amount)
+        public
+        override(ERC20, IERC20)
+        returns (bool)
+    {
+        if (failTransfer) {
+            return false;
+        }
+        return super.transfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount)
+        public
+        override(ERC20, IERC20)
+        returns (bool)
+    {
+        if (failTransfer) {
+            return false;
+        }
+        return super.transferFrom(from, to, amount);
+    }
+
+    /// @inheritdoc IGOAT
+    function mintTo(address to, uint256 amount) external override {
+        _mint(to, amount);
+    }
+}

--- a/test/meat.test.js
+++ b/test/meat.test.js
@@ -16,4 +16,28 @@ describe("MEAT", function () {
     const balance = await meat.balanceOf(owner.address);
     expect(balance).to.equal(ethers.parseEther("1000"));
   });
+
+  it("should revert swapMEATForGOAT when GOAT transfer fails", async function () {
+    const [owner, user] = await ethers.getSigners();
+
+    const FailingGOAT = await ethers.getContractFactory("FailingGOAT");
+    const failingGoat = await FailingGOAT.deploy();
+    await failingGoat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const meat = await MEAT.deploy(failingGoat.target);
+    await meat.waitForDeployment();
+
+    const meatAmount = ethers.parseEther("100");
+    await meat.transfer(user.address, meatAmount);
+
+    await meat.connect(user).approve(meat.target, meatAmount);
+    await meat.connect(user).approve(user.address, meatAmount);
+
+    await failingGoat.setFailTransfer(true);
+
+    await expect(
+      meat.connect(user).swapMEATForGOAT(meatAmount)
+    ).to.be.revertedWith("GOAT transfer failed");
+  });
 });


### PR DESCRIPTION
## Summary
- enforce GOAT transfer success in `swapMEATForGOAT`
- add `FailingGOAT` mock to simulate failing transfers
- test revert when GOAT transfer fails

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684068425524832596da42cb8e02ca4e