### PR TITLE
Add claim interval check for compoundReward

### DIFF
--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -106,9 +106,13 @@ function claimReward() external {
     emit RewardClaimed(msg.sender, reward);
 }
 /// @notice Compound current reward into staked balance
-function compoundReward() external {    
+function compoundReward() external {
     uint256 reward = calculateReward(msg.sender);
     require(reward > 0, "No reward to compound");
+    require(
+        block.timestamp - lastStakedTime[msg.sender] >= minClaimInterval,
+        "Claim not allowed yet"
+    );
     uint256 available = balanceOf(address(this));
     if (available < reward) {
         _mint(address(this), reward - available);

--- a/test/claim.test.js
+++ b/test/claim.test.js
@@ -21,6 +21,14 @@ describe("GOAT claim timing", function () {
     );
   });
 
+  it("reverts when compounding too early", async function () {
+    const stakeAmt = await goat.balanceOf(user.address);
+    await goat.connect(user).stake(stakeAmt);
+    await expect(goat.connect(user).compoundReward()).to.be.revertedWith(
+      "Claim not allowed yet"
+    );
+  });
+
   it("allows claiming after the interval", async function () {
     const stakeAmt = await goat.balanceOf(user.address);
     await goat.connect(user).stake(stakeAmt);
@@ -32,5 +40,17 @@ describe("GOAT claim timing", function () {
     await expect(goat.connect(user).claimReward()).to.not.be.reverted;
     const after = await goat.lastStakedTime(user.address);
     expect(after).to.be.gt(before);
+  });
+
+  it("allows compounding after the interval", async function () {
+    const stakeAmt = await goat.balanceOf(user.address);
+    await goat.connect(user).stake(stakeAmt);
+
+    await ethers.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(goat.connect(user).compoundReward()).to.not.be.reverted;
+    const stakedAfter = await goat.stakingBalance(user.address);
+    expect(stakedAfter).to.be.gt(stakeAmt);
   });
 });


### PR DESCRIPTION
## Summary
- validate claim interval in `compoundReward`
- extend claim tests for compound reward timing

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68406bf6a1288325aa9f14f4d9b3c322