### PR TITLE
Add GoatNFT burn-and-mint integration

### DIFF
--- a/contract-map.md
+++ b/contract-map.md
@@ -1,0 +1,8 @@
+# Contract Map
+
+| Contract | Description | Key Functions |
+|---------|-------------|---------------|
+| GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
+| MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT. | `mint`, `burn`, `goatValue` |
+| IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |

--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IGoatNFT } from "./interfaces/IGoatNFT.sol";
 
 /// @title GOAT Token - Guardian of Organic Agriculture Trust
 /// @notice A smart contract enabling staking, compounding, and minting by MEAT contract
@@ -27,6 +28,7 @@ uint256 public rewardInterval = 365 days;
 uint256 public minClaimInterval = 7 days;
 uint256 private constant REWARD_PRECISION = 1e18;
 address public meatContract;
+address public nftContract;
 
 constructor(address meatAddress) ERC20("Guardian of Agricultural Trade", "GOAT") {
     _owner = msg.sender;
@@ -42,12 +44,27 @@ modifier onlyOwner() {
 function setMEATAddress(address meatAddress) external onlyOwner {
     meatContract = meatAddress;
 }
+/// @notice Sets the Goat NFT contract address
+/// @param nftAddress Address of the GoatNFT contract
+function setNFTAddress(address nftAddress) external onlyOwner {
+    nftContract = nftAddress;
+}
 /// @notice Allows the MEAT contract to mint GOAT tokens to any address
 /// @param to The recipient address
 /// @param amount The amount of GOAT to mint
 function mintTo(address to, uint256 amount) external {
     require(msg.sender == meatContract, "Unauthorized mint");
     _mint(to, amount);
+}
+/// @notice Burn a Goat NFT to receive GOAT tokens
+/// @param tokenId ID of the NFT to burn
+function burnAndMint(uint256 tokenId) external {
+    require(nftContract != address(0), "NFT not set");
+    IGoatNFT nft = IGoatNFT(nftContract);
+    require(nft.ownerOf(tokenId) == msg.sender, "Not token owner");
+    uint256 amount = nft.goatValue(tokenId);
+    nft.burn(tokenId);
+    _mint(msg.sender, amount);
 }
 /// @notice Stake GOAT tokens to earn rewards
 /// @param amount The amount of GOAT tokens to stake

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @title GoatNFT - tokenized goat identification
+/// @notice Each NFT holds a value redeemable for GOAT tokens
+contract GoatNFT is ERC721Burnable {
+    uint256 public nextId;
+    mapping(uint256 => uint256) public goatValue;
+    address private immutable _owner;
+
+    constructor() ERC721("Goat Identifier", "GOATNFT") {
+        _owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    function mint(address to, uint256 value) external onlyOwner returns (uint256) {
+        require(value > 0, "Value must be > 0");
+        uint256 tokenId = ++nextId;
+        goatValue[tokenId] = value;
+        _mint(to, tokenId);
+        return tokenId;
+    }
+
+    function burn(uint256 tokenId) public override {
+        address tokenOwner = ownerOf(tokenId);
+        require(_isAuthorized(tokenOwner, msg.sender, tokenId), "Not owner");
+        super.burn(tokenId);
+        delete goatValue[tokenId];
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}

--- a/contracts/interfaces/IGoatNFT.sol
+++ b/contracts/interfaces/IGoatNFT.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+interface IGoatNFT {
+    function goatValue(uint256 tokenId) external view returns (uint256);
+    function burn(uint256 tokenId) external;
+    function ownerOf(uint256 tokenId) external view returns (address);
+}

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -1,0 +1,33 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("GoatNFT burn and GOAT mint", function () {
+  let owner, user, goat, nft;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const GoatNFT = await ethers.getContractFactory("GoatNFT");
+    nft = await GoatNFT.deploy();
+    await nft.waitForDeployment();
+
+    await goat.setNFTAddress(nft.target);
+  });
+
+  it("burns NFT and mints GOAT", async function () {
+    const value = ethers.parseEther("5");
+    const tx = await nft.mint(user.address, value);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2]; // Transfer event
+
+    await nft.connect(user).approve(goat.target, tokenId);
+    await expect(goat.connect(user).burnAndMint(tokenId)).to.not.be.reverted;
+
+    expect(await goat.balanceOf(user.address)).to.equal(value);
+    await expect(nft.ownerOf(tokenId)).to.be.reverted;
+  });
+});


### PR DESCRIPTION
## Summary
- create `GoatNFT` ERC721 with burnable goats
- interface `IGoatNFT`
- hook NFT burning to mint GOAT through `burnAndMint`
- document contracts in `contract-map.md`
- add test for burning NFT to mint GOAT

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684134c794dc8325aa1a87ca001d29a7