### PR TITLE
docs: cleanup frontend setup and contract map

### DIFF
--- a/contract-map.md
+++ b/contract-map.md
@@ -15,8 +15,7 @@
 * **FailingGOAT** is only for testing; it implements the same interface but allows simulated transfer failures.
 * **IGOAT** defines the `mintTo` function which enables MEAT to mint GOAT when necessary.
 
-The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for GOAT. Both share the same owner who can manage rates and enable or disable swapping.
-=======
+The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for GOAT. Both share the same owner who can manage rates and enable or disable swapping. The table below summarises the main contracts and their roles.
 | Contract | Description | Key Functions |
 |---------|-------------|---------------|
 | GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,9 +10,10 @@ This directory contains the web interface used to interact with the GOAT and MEA
 
 ## Development
 
-Install dependencies and start a local dev server:
+Copy `.env.example` to `.env.local` and set `NEXT_PUBLIC_GOAT_ADDRESS` and `NEXT_PUBLIC_MEAT_ADDRESS` to the deployed contract addresses. Then install dependencies and start a local dev server:
 
 ```bash
+cp .env.example .env.local
 npm install
 npm run dev
 ```
@@ -26,17 +27,3 @@ npm run build
 ```
 
 For full contract information and backend instructions see the [root README](../README.md).
-=======
-# Frontend
-
-This folder holds the Next.js interface for interacting with the GOAT and MEAT contracts.
-
-## Local Setup
-
-1. Copy `.env.example` to `.env.local`:
-   ```bash
-   cp .env.example .env.local
-   ```
-2. Edit `.env.local` and set `NEXT_PUBLIC_GOAT_ADDRESS` and `NEXT_PUBLIC_MEAT_ADDRESS` to the deployed contract addresses.
-
-Run the development server with `npm run dev` after installing dependencies.


### PR DESCRIPTION
## Summary
- streamline contract table in `contract-map.md`
- combine duplicate setup sections in `frontend/README.md`

## Testing
- `npx hardhat test` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_684144502f888325801ee6509268fbef