### PR TITLE
Remove unused calcReward from tests

### DIFF
--- a/test/fullFlow.test.js
+++ b/test/fullFlow.test.js
@@ -2,10 +2,6 @@ const { expect } = require("chai");
 const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const { ethers } = require("hardhat");
 
-function calcReward(staked, duration, rate, interval) {
-  return (staked * BigInt(duration) * BigInt(rate)) / (BigInt(interval) * 10n ** 18n);
-}
-
 describe("Full flow integration", function () {
   let owner, user1, user2, user3;
   let goat, meat;


### PR DESCRIPTION
## Summary
- clean up fullFlow test by removing unused `calcReward`

## Testing
- `npm ci`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_684149b7e01c8325b7c635eb527c8a24