### PR TITLE
Add restake warning to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Berikut gambaran umum alur penggunaan kedua token:
 1. **Mint MEAT** – Kirim native token (misalnya ETH/BNB) langsung ke kontrak `MEAT`. Kontrak akan otomatis mencetak MEAT melalui fungsi `receive()` menggunakan rasio `DepositRate` dan mengirimkannya ke pengirim.
 2. **Swap MEAT ⇄ GOAT** – Fitur swap aktif jika `swapEnabled` bernilai `true`. Rasio konversi ditentukan oleh konstanta `SwapRate` (default `85`). Fungsi `swapMEATForGOAT` menukar MEAT yang dimiliki pengguna menjadi GOAT, sedangkan `swapGOATForMEAT` melakukan sebaliknya.
 3. **Stake GOAT** – Pemegang GOAT dapat memanggil `stake(amount)` pada kontrak GOAT untuk mulai memperoleh reward. Besarnya reward dihitung linier berdasarkan `rewardRate` dengan periode akrual `rewardInterval`.
+   *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
 
 ## Deployment

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -8,6 +8,7 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The fixed conversion constant `SwapRate` maintains proportional supply.
 3. **Staking GOAT**
    * GOAT holders stake tokens in `GOAT.sol` which records staking balances and timestamps. Rewards accrue linearly according to `rewardRate` and `rewardInterval`.
+   *Calling `stake()` again resets `lastStakedTime` and discards any pending reward. Claim your reward first if you plan to restake.*
 4. **Claiming Rewards**
    * After `minClaimInterval` stakers may claim rewards or compound them back into the stake. If they choose to exit entirely they call `unstake` to receive the principal plus reward.
 5. **Returning to MEAT**


### PR DESCRIPTION
## Summary
- mention that restaking resets `lastStakedTime` in README
- repeat note in GOAT & MEAT lifecycle doc

## Testing
- `npx hardhat test` *(fails: Need to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_6841505461448325a1595a083d681ea2