### PR TITLE
Add emergencyUnstake docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Simulasi tahapan staking hingga unstake:
 3. Ketika keluar, panggil `unstake` sehingga pokok dan reward terkirim dan data
    staking dihapus.
 
+4. Dalam keadaan darurat, `emergencyUnstake` dapat digunakan kapan saja untuk menarik pokok tanpa reward.
+
 Reward dihitung berbasis waktu (detik) sehingga tidak bergantung pada jumlah
 blok. Perubahan state utama terjadi pada `stakingBalance`, `lastStakedTime`, dan
 saldo token pengguna.

--- a/contract-map.md
+++ b/contract-map.md
@@ -18,7 +18,7 @@
 The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for GOAT. Both share the same owner who can manage rates and enable or disable swapping. The table below summarises the main contracts and their roles.
 | Contract | Description | Key Functions |
 |---------|-------------|---------------|
-| GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
+| GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
 | GoatNFT | ERC721 goat identifier redeemable for GOAT. | `mint`, `burn`, `goatValue` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |


### PR DESCRIPTION
## Summary
- explain `emergencyUnstake` staking escape hatch in README
- list `emergencyUnstake` in contract map

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68416a253b5483259907272b93180b14