### PR TITLE
codex/address-validation

### DIFF
--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -42,11 +42,13 @@ modifier onlyOwner() {
 /// @notice Sets the MEAT contract address
 /// @param meatAddress Address of the MEAT contract
 function setMEATAddress(address meatAddress) external onlyOwner {
+    require(meatAddress != address(0), "Invalid address");
     meatContract = meatAddress;
 }
 /// @notice Sets the Goat NFT contract address
 /// @param nftAddress Address of the GoatNFT contract
 function setNFTAddress(address nftAddress) external onlyOwner {
+    require(nftAddress != address(0), "Invalid address");
     nftContract = nftAddress;
 }
 /// @notice Allows the MEAT contract to mint GOAT tokens to any address

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -114,6 +114,7 @@ contract MEAT is ERC20 {
     }
 
     function setGOATAddress(address goatAddress) external onlyOwner {
+        require(goatAddress != address(0), "Invalid address");
         GOAT = IGOAT(goatAddress);
     }
 

--- a/test/addressSetter.test.js
+++ b/test/addressSetter.test.js
@@ -1,0 +1,35 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Setter address validation", function () {
+  let owner, goat, meat;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    meat = await MEAT.deploy(goat.target);
+    await meat.waitForDeployment();
+  });
+
+  it("reverts when setting MEAT address to zero", async function () {
+    await expect(goat.setMEATAddress(ethers.ZeroAddress)).to.be.revertedWith(
+      "Invalid address"
+    );
+  });
+
+  it("reverts when setting NFT address to zero", async function () {
+    await expect(goat.setNFTAddress(ethers.ZeroAddress)).to.be.revertedWith(
+      "Invalid address"
+    );
+  });
+
+  it("reverts when setting GOAT address to zero", async function () {
+    await expect(meat.setGOATAddress(ethers.ZeroAddress)).to.be.revertedWith(
+      "Invalid address"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- require non-zero addresses in GOAT and MEAT setters
- test address setter validations

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68417de4385c8325997cebd09c3d6856