### PR TITLE
Document cargo schema and adjust ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ artifacts/
 cache/
 
 wasm-contracts/starter/target/
-wasm-contracts/starter/schema/

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Untuk kontrak CosmWasm, jalankan skrip build berikut terlebih dahulu:
 ```
 
 Skrip ini akan membangun `starter`, `meat`, dan `goatnft`, menyalin semua file `.wasm` ke folder `artifacts` dan menulis schema di masing-masing paket.
+Jika perintah `cargo schema` belum tersedia, jalankan `cargo install cargo-run-script` terlebih dahulu.
 
 Unit test Rust di setiap paket dapat dijalankan dengan:
 

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -13,6 +13,7 @@ This project includes CosmWasm implementations for all core contracts under `was
 ```
 
 The script compiles all packages and places their `.wasm` files under `artifacts/`. JSON schemas are exported under each package's `schema` folder.
+If `cargo schema` is not available, install it via `cargo install cargo-run-script` before running the build script.
 
 ## Upload & Instantiate
 


### PR DESCRIPTION
## Summary
- stop ignoring `wasm-contracts/starter/schema`
- document how to install `cargo schema`

## Testing
- `npx hardhat test` *(fails: needs hardhat installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2729c808325a04f33ecf1af1c5b