### PR TITLE
codex/update-readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ Jalankan perintah berikut untuk melakukan deploy:
 npx hardhat run scripts/deploy.js --network sepolia
 ```
 
+## Build Artifacts
+
+This repository maintains both EVM and CosmWasm contract builds under the `artifacts/` folder.
+
+1. **EVM** – compile the Solidity contracts and generate ABI files:
+   ```bash
+   npx hardhat compile
+   ```
+   Copy the ABI JSONs from `artifacts/contracts/` into `backend/abi/` if you change the contracts.
+2. **CosmWasm** – build the Rust packages:
+   ```bash
+   ./wasm-contracts/build.sh
+   ```
+   The script outputs `.wasm` files to `artifacts/` and writes schema files under each package.
+
 ## Parameter Penting
 
 - **SwapRate** – konstanta di kontrak MEAT yang menentukan rasio penukaran antar
@@ -101,7 +116,11 @@ A small Express backend in `backend/` exposes cached contract analytics. Start i
 npm run start:server
 ```
 
-Copy `backend/.env.example` to `.env` and fill in `RPC_URL`, `GOAT_ADDRESS`, `MEAT_ADDRESS` and `PORT` so the server can read on-chain data after Hardhat compilation.
+Prepare the environment variables before starting the server:
+```bash
+cp backend/.env.example backend/.env
+```
+Edit `backend/.env` and set `RPC_URL`, `GOAT_ADDRESS`, `MEAT_ADDRESS` and `PORT` so the server can read on-chain data after Hardhat compilation.
 
 ### API Endpoints
 - `GET /health` – health check.
@@ -117,9 +136,12 @@ still resides in `frontend/` purely as a placeholder and to illustrate
 environment variable usage.
 
 Clone the dedicated UI repository (when available) and follow its README for
-installation and `npm run dev` instructions. Remember to copy `.env.example` to
-`.env.local` and set your deployed `NEXT_PUBLIC_GOAT_ADDRESS` and
-`NEXT_PUBLIC_MEAT_ADDRESS` values there.
+installation and `npm run dev` instructions. Prepare the environment variables:
+```bash
+cp frontend/.env.example frontend/.env.local
+```
+Then edit `frontend/.env.local` to set your deployed `NEXT_PUBLIC_GOAT_ADDRESS`
+and `NEXT_PUBLIC_MEAT_ADDRESS` values.
 
 ## 🧱 Struktur Kontrak
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,18 +2,26 @@
 
 This folder contains a small Express server that exposes cached stats for the GOAT and MEAT token contracts. The server reads on-chain data through an RPC provider and exposes JSON endpoints used by the frontend.
 
-## Environment Variables
+## Setup
 
-Copy `.env.example` to `.env` and fill the following values:
-
-- `RPC_URL` – RPC endpoint to access the blockchain
-- `GOAT_ADDRESS` – deployed GOAT contract address
-- `MEAT_ADDRESS` – deployed MEAT contract address
-- `PORT` – port the server should listen on
+1. Install dependencies at the repository root:
+   ```bash
+   npm install
+   ```
+2. Compile the contracts to generate ABI files used by the server:
+   ```bash
+   npx hardhat compile
+   ```
+   Copy updated ABI JSONs from `artifacts/contracts/` into `backend/abi/` when you modify the contracts.
+3. Copy the environment template and set the required variables:
+   ```bash
+   cp .env.example .env
+   ```
+   Configure `RPC_URL`, `GOAT_ADDRESS`, `MEAT_ADDRESS` and `PORT` in `backend/.env`.
 
 ## Running
 
-Install dependencies at the repository root and start the server with:
+Start the server with:
 
 ```bash
 npm run start:server


### PR DESCRIPTION
## Summary
- update root README with explicit env setup for backend and frontend
- document build procedures for EVM and CosmWasm artifacts
- expand backend README with step-by-step setup instructions

## Testing
- `npx hardhat test`
- `for d in wasm-contracts/*/; do (cd "$d" && cargo test --quiet); done`

------
https://chatgpt.com/codex/tasks/task_e_6841c94c71188325860a9d4a464451ce