### PR TITLE
codex: replace to_binary with to_json_binary

### DIFF
--- a/wasm-contracts/goatnft/src/lib.rs
+++ b/wasm-contracts/goatnft/src/lib.rs
@@ -1,6 +1,5 @@
-use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
+use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
 use base64;
-use cw721;
 use serde_json_wasm;
 use cw2::set_contract_version;
 
@@ -65,15 +64,15 @@ fn handle_query(deps: Deps, q: QueryMsg) -> StdResult<Binary> {
     match q {
         QueryMsg::GoatValue { token_id } => {
             let value = GOAT_VALUE.load(deps.storage, token_id)?;
-            to_binary(&GoatValueResponse { value })
+            to_json_binary(&GoatValueResponse { value })
         }
         QueryMsg::Owner { token_id } => {
             let owner = OWNER_OF.load(deps.storage, token_id)?;
-            to_binary(&owner.into_string())
+            to_json_binary(&owner.into_string())
         }
         QueryMsg::OwnerAddress {} => {
             let owner = OWNER.load(deps.storage)?;
-            to_binary(&owner.into_string())
+            to_json_binary(&owner.into_string())
         }
     }
 }

--- a/wasm-contracts/meat/src/lib.rs
+++ b/wasm-contracts/meat/src/lib.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg, BankMsg};
+use cosmwasm_std::{entry_point, to_json_binary, Addr, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg, BankMsg};
 use cw2::set_contract_version;
 
 use starter::msg as goat_msg;
@@ -129,7 +129,7 @@ fn execute_swap_goat_for_meat(mut deps: DepsMut, env: Env, info: MessageInfo, go
     if !SWAP_ENABLED.load(deps.storage)? { return Err(StdError::generic_err("Swap disabled")); }
     if goat_amount.is_zero() { return Err(StdError::generic_err("Amount must be > 0")); }
     let goat = GOAT_CONTRACT.load(deps.storage)?;
-    let transfer = WasmMsg::Execute { contract_addr: goat.to_string(), msg: to_binary(&goat_msg::ExecuteMsg::TransferFrom { owner: info.sender.to_string(), recipient: env.contract.address.to_string(), amount: goat_amount })?, funds: vec![] };
+    let transfer = WasmMsg::Execute { contract_addr: goat.to_string(), msg: to_json_binary(&goat_msg::ExecuteMsg::TransferFrom { owner: info.sender.to_string(), recipient: env.contract.address.to_string(), amount: goat_amount })?, funds: vec![] };
     let meat_needed = Uint128::new(goat_amount.u128() * SWAP_RATE);
     let contract = env.contract.address;
     let bal = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
@@ -164,13 +164,13 @@ fn execute_swap_meat_for_goat(mut deps: DepsMut, env: Env, info: MessageInfo, me
         let diff = goat_amount.checked_sub(goat_bal.balance)?;
         resp = resp.add_message(WasmMsg::Execute {
             contract_addr: goat.to_string(),
-            msg: to_binary(&goat_msg::ExecuteMsg::MintTo { to: env.contract.address.to_string(), amount: diff })?,
+            msg: to_json_binary(&goat_msg::ExecuteMsg::MintTo { to: env.contract.address.to_string(), amount: diff })?,
             funds: vec![],
         });
     }
     resp = resp.add_message(WasmMsg::Execute {
         contract_addr: goat.to_string(),
-        msg: to_binary(&goat_msg::ExecuteMsg::Transfer { recipient: info.sender.to_string(), amount: goat_amount })?,
+        msg: to_json_binary(&goat_msg::ExecuteMsg::Transfer { recipient: info.sender.to_string(), amount: goat_amount })?,
         funds: vec![],
     });
     Ok(resp)
@@ -195,37 +195,37 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Balance { address } => {
             let addr = deps.api.addr_validate(&address)?;
             let balance = BALANCES.may_load(deps.storage, &addr)?.unwrap_or_default();
-            to_binary(&BalanceResponse { balance })
+            to_json_binary(&BalanceResponse { balance })
         }
         QueryMsg::Allowance { owner, spender } => {
             let owner = deps.api.addr_validate(&owner)?;
             let spender = deps.api.addr_validate(&spender)?;
             let allowance = ALLOWANCES.may_load(deps.storage, (&owner, &spender))?.unwrap_or_default();
-            to_binary(&AllowanceResponse { allowance })
+            to_json_binary(&AllowanceResponse { allowance })
         }
         QueryMsg::TokenInfo {} => {
             let total_supply = TOTAL_SUPPLY.load(deps.storage)?;
-            to_binary(&TokenInfoResponse { name: NAME.to_string(), symbol: SYMBOL.to_string(), decimals: DECIMALS, total_supply })
+            to_json_binary(&TokenInfoResponse { name: NAME.to_string(), symbol: SYMBOL.to_string(), decimals: DECIMALS, total_supply })
         }
         QueryMsg::DepositRate {} => {
             let rate = RATE.load(deps.storage)?;
-            to_binary(&RateResponse { rate })
+            to_json_binary(&RateResponse { rate })
         }
         QueryMsg::SwapEnabled {} => {
             let enabled = SWAP_ENABLED.load(deps.storage)?;
-            to_binary(&EnabledResponse { enabled })
+            to_json_binary(&EnabledResponse { enabled })
         }
         QueryMsg::Owner {} => {
             let owner = OWNER.load(deps.storage)?;
-            to_binary(&owner.into_string())
+            to_json_binary(&owner.into_string())
         }
         QueryMsg::EquivalentMeat { goat_amount } => {
             let amount = Uint128::new(goat_amount.u128() * SWAP_RATE);
-            to_binary(&EquivalentResponse { amount })
+            to_json_binary(&EquivalentResponse { amount })
         }
         QueryMsg::EquivalentGoat { meat_amount } => {
             let amount = Uint128::new(meat_amount.u128() / SWAP_RATE);
-            to_binary(&EquivalentResponse { amount })
+            to_json_binary(&EquivalentResponse { amount })
         }
     }
 }

--- a/wasm-contracts/starter/src/lib.rs
+++ b/wasm-contracts/starter/src/lib.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg};
+use cosmwasm_std::{entry_point, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg};
 use cw2::set_contract_version;
 use cw721::Cw721ExecuteMsg;
 use crate::msg::{
@@ -122,9 +122,9 @@ fn execute_mint_to(mut deps: DepsMut, info: MessageInfo, to: String, amount: Uin
 
 fn execute_burn_and_mint(mut deps: DepsMut, info: MessageInfo, token_id: u64) -> StdResult<Response> {
     let nft = NFT_CONTRACT.load(deps.storage)?.ok_or_else(|| StdError::generic_err("NFT not set"))?;
-    let query = to_binary(&serde_json::json!({"goat_value": {"token_id": token_id}}))?;
+    let query = to_json_binary(&serde_json::json!({"goat_value": {"token_id": token_id}}))?;
     let resp: GoatValueResponse = deps.querier.query_wasm_smart(nft.clone(), &query)?;
-    let burn = WasmMsg::Execute { contract_addr: nft.to_string(), msg: to_binary(&Cw721ExecuteMsg::Burn { token_id: token_id.to_string() })?, funds: vec![] };
+    let burn = WasmMsg::Execute { contract_addr: nft.to_string(), msg: to_json_binary(&Cw721ExecuteMsg::Burn { token_id: token_id.to_string() })?, funds: vec![] };
     add_balance(deps.storage, &info.sender, resp.value)?;
     let supply = TOTAL_SUPPLY.load(deps.storage)? + resp.value;
     TOTAL_SUPPLY.save(deps.storage, &supply)?;
@@ -250,41 +250,41 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Balance { address } => {
             let addr = deps.api.addr_validate(&address)?;
             let balance = BALANCES.may_load(deps.storage, &addr)?.unwrap_or_default();
-            to_binary(&BalanceResponse { balance })
+            to_json_binary(&BalanceResponse { balance })
         }
         QueryMsg::Allowance { owner, spender } => {
             let owner = deps.api.addr_validate(&owner)?;
             let spender = deps.api.addr_validate(&spender)?;
             let allowance = ALLOWANCES.may_load(deps.storage, (&owner, &spender))?.unwrap_or_default();
-            to_binary(&AllowanceResponse { allowance })
+            to_json_binary(&AllowanceResponse { allowance })
         }
         QueryMsg::TokenInfo {} => {
             let total_supply = TOTAL_SUPPLY.load(deps.storage)?;
-            to_binary(&TokenInfoResponse { name: NAME.to_string(), symbol: SYMBOL.to_string(), decimals: DECIMALS, total_supply })
+            to_json_binary(&TokenInfoResponse { name: NAME.to_string(), symbol: SYMBOL.to_string(), decimals: DECIMALS, total_supply })
         }
         QueryMsg::StakingBalance { address } => {
             let addr = deps.api.addr_validate(&address)?;
             let balance = STAKING_BALANCE.may_load(deps.storage, &addr)?.unwrap_or_default();
             let last = LAST_STAKED_TIME.may_load(deps.storage, &addr)?.unwrap_or_default();
-            to_binary(&StakingInfoResponse { balance, last_staked: last })
+            to_json_binary(&StakingInfoResponse { balance, last_staked: last })
         }
         QueryMsg::PendingReward { address } => {
             let addr = deps.api.addr_validate(&address)?;
             let reward = calculate_reward(deps, &env, &addr)?;
-            to_binary(&PendingRewardResponse { reward })
+            to_json_binary(&PendingRewardResponse { reward })
         }
         QueryMsg::NextClaimTime { address } => {
             let addr = deps.api.addr_validate(&address)?;
             let last = LAST_STAKED_TIME.may_load(deps.storage, &addr)?.unwrap_or_default();
             if last == 0 {
-                return to_binary(&NextClaimResponse { timestamp: 0 });
+                return to_json_binary(&NextClaimResponse { timestamp: 0 });
             }
             let min = MIN_CLAIM_INTERVAL.load(deps.storage)?;
-            to_binary(&NextClaimResponse { timestamp: last + min })
+            to_json_binary(&NextClaimResponse { timestamp: last + min })
         }
         QueryMsg::Owner {} => {
             let owner = OWNER.load(deps.storage)?;
-            to_binary(&owner.into_string())
+            to_json_binary(&owner.into_string())
         }
     }
 }


### PR DESCRIPTION
## Summary
- update wasm contracts to use `to_json_binary`
- keep query and execute helpers consistent with CW standards

## Testing
- `cargo test --quiet` in `wasm-contracts/goatnft`
- `cargo test --quiet` in `wasm-contracts/meat`
- `cargo test --quiet` in `wasm-contracts/starter`


------
https://chatgpt.com/codex/tasks/task_e_6841cdc369bc8325bbf3bcff5368c008