### PR TITLE
codex/remove-mut-warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 artifacts/
 cache/
 
-wasm-contracts/starter/target/
+wasm-contracts/*/target/

--- a/wasm-contracts/goatnft/src/lib.rs
+++ b/wasm-contracts/goatnft/src/lib.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
-use base64;
+use base64::{engine::general_purpose, Engine as _};
 use serde_json_wasm;
 use cw2::set_contract_version;
 
@@ -42,14 +42,14 @@ fn execute_mint(mut deps: DepsMut, info: MessageInfo, to: String, value: Uint128
     only_owner(deps.branch(), &info)?;
     if value.is_zero() { return Err(StdError::generic_err("Value must be > 0")); }
     let to_addr = deps.api.addr_validate(&to)?;
-    let mut id = NEXT_ID.load(deps.storage)? + 1;
+    let id = NEXT_ID.load(deps.storage)? + 1;
     NEXT_ID.save(deps.storage, &id)?;
     OWNER_OF.save(deps.storage, id, &to_addr)?;
     GOAT_VALUE.save(deps.storage, id, &value)?;
     Ok(Response::new().add_attribute("token_id", id.to_string()))
 }
 
-fn execute_burn(mut deps: DepsMut, info: MessageInfo, token_id: String) -> StdResult<Response> {
+fn execute_burn(deps: DepsMut, info: MessageInfo, token_id: String) -> StdResult<Response> {
     let id: u64 = token_id.parse().map_err(|_| StdError::generic_err("invalid id"))?;
     let owner = OWNER_OF.load(deps.storage, id)?;
     if owner != info.sender {
@@ -83,7 +83,7 @@ pub fn query(deps: Deps, _env: Env, msg: Binary) -> StdResult<Binary> {
         return handle_query(deps, q);
     }
     if let Ok(s) = std::str::from_utf8(&msg) {
-        if let Ok(decoded) = base64::decode(s) {
+        if let Ok(decoded) = general_purpose::STANDARD.decode(s) {
             if let Ok(q) = serde_json_wasm::from_slice::<QueryMsg>(&decoded) {
                 return handle_query(deps, q);
             }

--- a/wasm-contracts/goatnft/tests/burn.rs
+++ b/wasm-contracts/goatnft/tests/burn.rs
@@ -4,7 +4,7 @@ use cw_multi_test::{App, ContractWrapper, Executor};
 use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
 use goatnft::{execute, instantiate, query};
 use starter::msg as goat_msg;
-use goatnft::msg::{InstantiateMsg as NftInstantiate, ExecuteMsg as NftExecute, QueryMsg as NftQuery, GoatValueResponse};
+use goatnft::msg::{InstantiateMsg as NftInstantiate, ExecuteMsg as NftExecute, QueryMsg as NftQuery};
 
 fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
     Box::new(ContractWrapper::new(goat_execute, goat_instantiate, goat_query))

--- a/wasm-contracts/meat/src/lib.rs
+++ b/wasm-contracts/meat/src/lib.rs
@@ -60,20 +60,20 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
     }
 }
 
-fn execute_transfer(mut deps: DepsMut, info: MessageInfo, recipient: String, amount: Uint128) -> StdResult<Response> {
+fn execute_transfer(deps: DepsMut, info: MessageInfo, recipient: String, amount: Uint128) -> StdResult<Response> {
     let recipient = deps.api.addr_validate(&recipient)?;
     sub_balance(deps.storage, &info.sender, amount)?;
     add_balance(deps.storage, &recipient, amount)?;
     Ok(Response::new())
 }
 
-fn execute_approve(mut deps: DepsMut, info: MessageInfo, spender: String, amount: Uint128) -> StdResult<Response> {
+fn execute_approve(deps: DepsMut, info: MessageInfo, spender: String, amount: Uint128) -> StdResult<Response> {
     let spender = deps.api.addr_validate(&spender)?;
     ALLOWANCES.save(deps.storage, (&info.sender, &spender), &amount)?;
     Ok(Response::new())
 }
 
-fn execute_transfer_from(mut deps: DepsMut, info: MessageInfo, owner: String, recipient: String, amount: Uint128) -> StdResult<Response> {
+fn execute_transfer_from(deps: DepsMut, info: MessageInfo, owner: String, recipient: String, amount: Uint128) -> StdResult<Response> {
     let owner_addr = deps.api.addr_validate(&owner)?;
     let recipient = deps.api.addr_validate(&recipient)?;
     let mut allowance = ALLOWANCES.may_load(deps.storage, (&owner_addr, &info.sender))?.unwrap_or_default();
@@ -85,7 +85,7 @@ fn execute_transfer_from(mut deps: DepsMut, info: MessageInfo, owner: String, re
     Ok(Response::new())
 }
 
-fn execute_mint_with_native(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
+fn execute_mint_with_native(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
     let coin: &Coin = info.funds.first().ok_or_else(|| StdError::generic_err("No funds"))?;
     if coin.amount.is_zero() { return Err(StdError::generic_err("No funds")); }
     let rate = RATE.load(deps.storage)?.u128();
@@ -125,7 +125,7 @@ fn execute_change_rate(mut deps: DepsMut, info: MessageInfo, new_rate: Uint128) 
     Ok(Response::new())
 }
 
-fn execute_swap_goat_for_meat(mut deps: DepsMut, env: Env, info: MessageInfo, goat_amount: Uint128) -> StdResult<Response> {
+fn execute_swap_goat_for_meat(deps: DepsMut, env: Env, info: MessageInfo, goat_amount: Uint128) -> StdResult<Response> {
     if !SWAP_ENABLED.load(deps.storage)? { return Err(StdError::generic_err("Swap disabled")); }
     if goat_amount.is_zero() { return Err(StdError::generic_err("Amount must be > 0")); }
     let goat = GOAT_CONTRACT.load(deps.storage)?;
@@ -133,7 +133,7 @@ fn execute_swap_goat_for_meat(mut deps: DepsMut, env: Env, info: MessageInfo, go
     let meat_needed = Uint128::new(goat_amount.u128() * SWAP_RATE);
     let contract = env.contract.address;
     let bal = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
-    let mut resp = Response::new().add_message(transfer);
+    let resp = Response::new().add_message(transfer);
     if bal >= meat_needed {
         sub_balance(deps.storage, &contract, meat_needed)?;
         add_balance(deps.storage, &info.sender, meat_needed)?;
@@ -150,7 +150,7 @@ fn execute_swap_goat_for_meat(mut deps: DepsMut, env: Env, info: MessageInfo, go
     Ok(resp)
 }
 
-fn execute_swap_meat_for_goat(mut deps: DepsMut, env: Env, info: MessageInfo, meat_amount: Uint128) -> StdResult<Response> {
+fn execute_swap_meat_for_goat(deps: DepsMut, env: Env, info: MessageInfo, meat_amount: Uint128) -> StdResult<Response> {
     if !SWAP_ENABLED.load(deps.storage)? { return Err(StdError::generic_err("Swap disabled")); }
     if meat_amount.is_zero() { return Err(StdError::generic_err("Amount must be > 0")); }
     let goat = GOAT_CONTRACT.load(deps.storage)?;

--- a/wasm-contracts/starter/src/lib.rs
+++ b/wasm-contracts/starter/src/lib.rs
@@ -84,20 +84,20 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
     }
 }
 
-fn execute_transfer(mut deps: DepsMut, info: MessageInfo, recipient: String, amount: Uint128) -> StdResult<Response> {
+fn execute_transfer(deps: DepsMut, info: MessageInfo, recipient: String, amount: Uint128) -> StdResult<Response> {
     let recipient = deps.api.addr_validate(&recipient)?;
     sub_balance(deps.storage, &info.sender, amount)?;
     add_balance(deps.storage, &recipient, amount)?;
     Ok(Response::new())
 }
 
-fn execute_approve(mut deps: DepsMut, info: MessageInfo, spender: String, amount: Uint128) -> StdResult<Response> {
+fn execute_approve(deps: DepsMut, info: MessageInfo, spender: String, amount: Uint128) -> StdResult<Response> {
     let spender = deps.api.addr_validate(&spender)?;
     ALLOWANCES.save(deps.storage, (&info.sender, &spender), &amount)?;
     Ok(Response::new())
 }
 
-fn execute_transfer_from(mut deps: DepsMut, info: MessageInfo, owner: String, recipient: String, amount: Uint128) -> StdResult<Response> {
+fn execute_transfer_from(deps: DepsMut, info: MessageInfo, owner: String, recipient: String, amount: Uint128) -> StdResult<Response> {
     let owner_addr = deps.api.addr_validate(&owner)?;
     let recipient = deps.api.addr_validate(&recipient)?;
     let mut allowance = ALLOWANCES.may_load(deps.storage, (&owner_addr, &info.sender))?.unwrap_or_default();
@@ -120,7 +120,7 @@ fn execute_mint_to(mut deps: DepsMut, info: MessageInfo, to: String, amount: Uin
     Ok(Response::new())
 }
 
-fn execute_burn_and_mint(mut deps: DepsMut, info: MessageInfo, token_id: u64) -> StdResult<Response> {
+fn execute_burn_and_mint(deps: DepsMut, info: MessageInfo, token_id: u64) -> StdResult<Response> {
     let nft = NFT_CONTRACT.load(deps.storage)?.ok_or_else(|| StdError::generic_err("NFT not set"))?;
     let query = to_json_binary(&serde_json::json!({"goat_value": {"token_id": token_id}}))?;
     let resp: GoatValueResponse = deps.querier.query_wasm_smart(nft.clone(), &query)?;
@@ -166,7 +166,7 @@ fn calculate_reward(deps: Deps, env: &Env, addr: &Addr) -> StdResult<Uint128> {
     Ok(Uint128::new(reward))
 }
 
-fn execute_stake(mut deps: DepsMut, env: Env, info: MessageInfo, amount: Uint128) -> StdResult<Response> {
+fn execute_stake(deps: DepsMut, env: Env, info: MessageInfo, amount: Uint128) -> StdResult<Response> {
     if amount.is_zero() {
         return Err(StdError::generic_err("Amount must be > 0"));
     }
@@ -177,7 +177,7 @@ fn execute_stake(mut deps: DepsMut, env: Env, info: MessageInfo, amount: Uint128
     Ok(Response::new())
 }
 
-fn execute_emergency_unstake(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
+fn execute_emergency_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
     let staked = STAKING_BALANCE.may_load(deps.storage, &info.sender)?.unwrap_or_default();
     if staked.is_zero() {
         return Err(StdError::generic_err("Nothing to unstake"));
@@ -189,7 +189,7 @@ fn execute_emergency_unstake(mut deps: DepsMut, env: Env, info: MessageInfo) -> 
     Ok(Response::new())
 }
 
-fn execute_unstake(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
+fn execute_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
     let staked = STAKING_BALANCE.may_load(deps.storage, &info.sender)?.unwrap_or_default();
     if staked.is_zero() {
         return Err(StdError::generic_err("Nothing to unstake"));
@@ -210,7 +210,7 @@ fn execute_unstake(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<
     Ok(Response::new())
 }
 
-fn execute_claim_reward(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
+fn execute_claim_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
     let reward = calculate_reward(deps.as_ref(), &env, &info.sender)?;
     if reward.is_zero() {
         return Err(StdError::generic_err("No reward to claim"));
@@ -227,7 +227,7 @@ fn execute_claim_reward(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdRe
     Ok(Response::new())
 }
 
-fn execute_compound_reward(mut deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
+fn execute_compound_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
     let reward = calculate_reward(deps.as_ref(), &env, &info.sender)?;
     if reward.is_zero() {
         return Err(StdError::generic_err("No reward to compound"));


### PR DESCRIPTION
## Summary
- silence unused mut warnings in contracts
- clean up unused imports in tests
- ignore generated `target` folders

## Testing
- `cargo test --manifest-path wasm-contracts/goatnft/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/meat/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/starter/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6841cfe6e88c8325b940d85129ee9801