### PR TITLE
Fix build.sh path resolution

### DIFF
--- a/wasm-contracts/build.sh
+++ b/wasm-contracts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-DIR="$(dirname "$0")"
+DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR"
 
 for pkg in starter meat goatnft; do


### PR DESCRIPTION
## Summary
- ensure build.sh resolves absolute directory before iterating packages

## Testing
- `./wasm-contracts/build.sh` *(fails: `cargo schema` not found)*
- `npx hardhat test` *(fails: Hardhat not installed locally)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9b7f8dc83259c0b8520512fa32b