### PR TITLE
Fix Goats staking payout with minting shortfall

### DIFF
--- a/wasm-contracts/starter/src/lib.rs
+++ b/wasm-contracts/starter/src/lib.rs
@@ -184,8 +184,22 @@ fn execute_emergency_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdR
     }
     STAKING_BALANCE.remove(deps.storage, &info.sender);
     LAST_STAKED_TIME.remove(deps.storage, &info.sender);
-    sub_balance(deps.storage, &env.contract.address, staked)?;
-    add_balance(deps.storage, &info.sender, staked)?;
+
+    let contract = env.contract.address;
+    let available = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
+    if available >= staked {
+        sub_balance(deps.storage, &contract, staked)?;
+        add_balance(deps.storage, &info.sender, staked)?;
+    } else {
+        if !available.is_zero() {
+            sub_balance(deps.storage, &contract, available)?;
+            add_balance(deps.storage, &info.sender, available)?;
+        }
+        let diff = staked.checked_sub(available)?;
+        add_balance(deps.storage, &info.sender, diff)?;
+        let supply = TOTAL_SUPPLY.load(deps.storage)? + diff;
+        TOTAL_SUPPLY.save(deps.storage, &supply)?;
+    }
     Ok(Response::new())
 }
 
@@ -203,10 +217,21 @@ fn execute_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Resp
     STAKING_BALANCE.remove(deps.storage, &info.sender);
     LAST_STAKED_TIME.remove(deps.storage, &info.sender);
     let total = staked + reward;
-    sub_balance(deps.storage, &env.contract.address, staked)?;
-    add_balance(deps.storage, &info.sender, total)?;
-    let supply = TOTAL_SUPPLY.load(deps.storage)? + reward;
-    TOTAL_SUPPLY.save(deps.storage, &supply)?;
+    let contract = env.contract.address;
+    let available = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
+    if available >= total {
+        sub_balance(deps.storage, &contract, total)?;
+        add_balance(deps.storage, &info.sender, total)?;
+    } else {
+        if !available.is_zero() {
+            sub_balance(deps.storage, &contract, available)?;
+            add_balance(deps.storage, &info.sender, available)?;
+        }
+        let diff = total.checked_sub(available)?;
+        add_balance(deps.storage, &info.sender, diff)?;
+        let supply = TOTAL_SUPPLY.load(deps.storage)? + diff;
+        TOTAL_SUPPLY.save(deps.storage, &supply)?;
+    }
     Ok(Response::new())
 }
 
@@ -220,10 +245,22 @@ fn execute_claim_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult
     if env.block.time.seconds().saturating_sub(last) < min {
         return Err(StdError::generic_err("Claim not allowed yet"));
     }
+    let contract = env.contract.address;
+    let available = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
+    if available >= reward {
+        sub_balance(deps.storage, &contract, reward)?;
+        add_balance(deps.storage, &info.sender, reward)?;
+    } else {
+        if !available.is_zero() {
+            sub_balance(deps.storage, &contract, available)?;
+            add_balance(deps.storage, &info.sender, available)?;
+        }
+        let diff = reward.checked_sub(available)?;
+        add_balance(deps.storage, &info.sender, diff)?;
+        let supply = TOTAL_SUPPLY.load(deps.storage)? + diff;
+        TOTAL_SUPPLY.save(deps.storage, &supply)?;
+    }
     LAST_STAKED_TIME.save(deps.storage, &info.sender, &env.block.time.seconds())?;
-    add_balance(deps.storage, &info.sender, reward)?;
-    let supply = TOTAL_SUPPLY.load(deps.storage)? + reward;
-    TOTAL_SUPPLY.save(deps.storage, &supply)?;
     Ok(Response::new())
 }
 
@@ -237,10 +274,16 @@ fn execute_compound_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdRes
     if env.block.time.seconds().saturating_sub(last) < min {
         return Err(StdError::generic_err("Claim not allowed yet"));
     }
+    let contract = env.contract.address;
+    let available = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
+    if available < reward {
+        let diff = reward.checked_sub(available)?;
+        add_balance(deps.storage, &contract, diff)?;
+        let supply = TOTAL_SUPPLY.load(deps.storage)? + diff;
+        TOTAL_SUPPLY.save(deps.storage, &supply)?;
+    }
     STAKING_BALANCE.update(deps.storage, &info.sender, |b| -> StdResult<_> { Ok(b.unwrap_or_default() + reward) })?;
     LAST_STAKED_TIME.save(deps.storage, &info.sender, &env.block.time.seconds())?;
-    let supply = TOTAL_SUPPLY.load(deps.storage)? + reward;
-    TOTAL_SUPPLY.save(deps.storage, &supply)?;
     Ok(Response::new())
 }
 

--- a/wasm-contracts/starter/tests/goat.rs
+++ b/wasm-contracts/starter/tests/goat.rs
@@ -202,3 +202,62 @@ fn claim_without_stake_fails() {
     ).unwrap_err();
     assert!(!err.to_string().is_empty());
 }
+
+#[test]
+fn emergency_unstake_mints_shortfall() {
+    let (mut app, addr) = init_app();
+    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "user".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
+    // drain contract balance
+    app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(30) }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::EmergencyUnstake {}, &[]).unwrap();
+    let bal: BalanceResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::Balance { address: "user".into() }).unwrap();
+    assert_eq!(bal.balance, Uint128::new(50));
+    let info: TokenInfoResponse = app.wrap().query_wasm_smart(addr, &QueryMsg::TokenInfo {}).unwrap();
+    assert_eq!(info.total_supply, Uint128::new(80));
+}
+
+#[test]
+fn unstake_mints_shortfall() {
+    let (mut app, addr) = init_app();
+    app.execute_contract(Addr::unchecked("owner"), addr.clone(), &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "user".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(30) }, &[]).unwrap();
+    app.update_block(|b| b.time = b.time.plus_seconds(1));
+    app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::Unstake {}, &[]).unwrap();
+    let bal: BalanceResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::Balance { address: "user".into() }).unwrap();
+    assert_eq!(bal.balance, Uint128::new(100));
+    let info: TokenInfoResponse = app.wrap().query_wasm_smart(addr, &QueryMsg::TokenInfo {}).unwrap();
+    assert_eq!(info.total_supply, Uint128::new(130));
+}
+
+#[test]
+fn claim_reward_mints_shortfall() {
+    let (mut app, addr) = init_app();
+    app.execute_contract(Addr::unchecked("owner"), addr.clone(), &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(40) }, &[]).unwrap();
+    app.update_block(|b| b.time = b.time.plus_seconds(1));
+    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::ClaimReward {}, &[]).unwrap();
+    let bal: BalanceResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::Balance { address: "staker".into() }).unwrap();
+    assert_eq!(bal.balance, Uint128::new(50));
+    let info: TokenInfoResponse = app.wrap().query_wasm_smart(addr, &QueryMsg::TokenInfo {}).unwrap();
+    assert_eq!(info.total_supply, Uint128::new(90));
+}
+
+#[test]
+fn compound_reward_mints_shortfall() {
+    let (mut app, addr) = init_app();
+    app.execute_contract(Addr::unchecked("owner"), addr.clone(), &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
+    app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(30) }, &[]).unwrap();
+    app.update_block(|b| b.time = b.time.plus_seconds(1));
+    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::CompoundReward {}, &[]).unwrap();
+    let stake: StakingInfoResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::StakingBalance { address: "staker".into() }).unwrap();
+    assert_eq!(stake.balance, Uint128::new(100));
+    let info: TokenInfoResponse = app.wrap().query_wasm_smart(addr, &QueryMsg::TokenInfo {}).unwrap();
+    assert_eq!(info.total_supply, Uint128::new(80));
+}


### PR DESCRIPTION
## Summary
- handle contract balance shortfalls when unstaking or claiming rewards in starter contract
- update reward payout logic to mint missing GOAT tokens and adjust total supply
- add unit tests for shortfall scenarios

## Testing
- `cargo test` in `wasm-contracts/starter`
- `cargo test` in `wasm-contracts/meat`

------
https://chatgpt.com/codex/tasks/task_e_6841dc8aef2c8325845a9e651a3ff913