### PR TITLE
codex/goat-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Struktur dan hubungan antar kontrak:
   yang dapat mencetak GOAT melalui `mintTo`.
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint, memungkinkan penukaran MEAT ↔ GOAT, dan mengontrol fitur swap.
+- `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
+  Fungsi `mint` menerima metadata seperti `nfcId`, `breed`, `birthYear`, dan
+  `weight` lalu mencatat waktu pencetakan pada `goatMetadata`. Data dihapus saat
+  `burn`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
   untuk dipanggil MEAT saat membutuhkan GOAT baru.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test

--- a/contract-map.md
+++ b/contract-map.md
@@ -20,5 +20,5 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 |---------|-------------|---------------|
 | GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
-| GoatNFT | ERC721 goat identifier redeemable for GOAT. | `mint`, `burn`, `goatValue` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT with on-chain metadata. | `mint`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -9,6 +9,14 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 contract GoatNFT is ERC721Burnable {
     uint256 public nextId;
     mapping(uint256 => uint256) public goatValue;
+    struct GoatData {
+        uint256 nfcId;
+        string breed;
+        uint16 birthYear;
+        uint16 weight;
+        uint256 mintedAt;
+    }
+    mapping(uint256 => GoatData) public goatMetadata;
     address private immutable _owner;
 
     constructor() ERC721("Goat Identifier", "GOATNFT") {
@@ -20,10 +28,18 @@ contract GoatNFT is ERC721Burnable {
         _;
     }
 
-    function mint(address to, uint256 value) external onlyOwner returns (uint256) {
+    function mint(
+        address to,
+        uint256 value,
+        uint256 nfcId,
+        string calldata breed,
+        uint16 birthYear,
+        uint16 weight
+    ) external onlyOwner returns (uint256) {
         require(value > 0, "Value must be > 0");
         uint256 tokenId = ++nextId;
         goatValue[tokenId] = value;
+        goatMetadata[tokenId] = GoatData(nfcId, breed, birthYear, weight, block.timestamp);
         _mint(to, tokenId);
         return tokenId;
     }
@@ -33,6 +49,11 @@ contract GoatNFT is ERC721Burnable {
         require(_isAuthorized(tokenOwner, msg.sender, tokenId), "Not owner");
         super.burn(tokenId);
         delete goatValue[tokenId];
+        delete goatMetadata[tokenId];
+    }
+
+    function getGoatData(uint256 tokenId) external view returns (GoatData memory) {
+        return goatMetadata[tokenId];
     }
 
     function owner() external view returns (address) {

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -20,13 +20,27 @@ describe("GoatNFT burn and GOAT mint", function () {
 
   it("burns NFT and mints GOAT", async function () {
     const value = ethers.parseEther("5");
-    const tx = await nft.mint(user.address, value);
+    const nfcId = 1234;
+    const breed = "Boer";
+    const birthYear = 2021;
+    const weight = 70;
+    const tx = await nft.mint(user.address, value, nfcId, breed, birthYear, weight);
     const receipt = await tx.wait();
     const tokenId = receipt.logs[0].args[2]; // Transfer event
+
+    const stored = await nft.getGoatData(tokenId);
+    expect(stored.nfcId).to.equal(nfcId);
+    expect(stored.breed).to.equal(breed);
+    expect(stored.birthYear).to.equal(birthYear);
+    expect(stored.weight).to.equal(weight);
+    expect(stored.mintedAt).to.be.gt(0);
 
     await nft.connect(user).approve(goat.target, tokenId);
     await expect(goat.connect(user).burnAndMint(tokenId)).to.not.be.reverted;
 
+    const afterBurn = await nft.getGoatData(tokenId);
+    expect(afterBurn.nfcId).to.equal(0);
+  
     expect(await goat.balanceOf(user.address)).to.equal(value);
     await expect(nft.ownerOf(tokenId)).to.be.reverted;
   });


### PR DESCRIPTION
## Summary
- expand `GoatNFT` to store goat metadata
- save/delete metadata on mint/burn
- expose `getGoatData`
- test metadata persistence
- document new metadata behavior

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841df4c9b688325a7c925867b6e9345