### PR TITLE
Update GoatNFT docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ Struktur dan hubungan antar kontrak:
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint, memungkinkan penukaran MEAT ↔ GOAT, dan mengontrol fitur swap.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
-  Fungsi `mint` menerima metadata seperti `nfcId`, `breed`, `birthYear`, dan
-  `weight` lalu mencatat waktu pencetakan pada `goatMetadata`. Data dihapus saat
+  Metadata tiap token dikemas dalam struct `GoatData` dan disimpan pada mapping
+  `goatMetadata`. Fungsi `mint` menerima `nfcId`, `breed`, `birthYear`, dan
+  `weight`; data dapat dibaca ulang melalui `getGoatData` dan dihapus saat
   `burn`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
   untuk dipanggil MEAT saat membutuhkan GOAT baru.

--- a/contract-map.md
+++ b/contract-map.md
@@ -20,5 +20,5 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 |---------|-------------|---------------|
 | GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
-| GoatNFT | ERC721 goat identifier redeemable for GOAT with on-chain metadata. | `mint`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored in `goatMetadata` mapping of `GoatData`. | `mint`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |


### PR DESCRIPTION
## Summary
- clarify GoatNFT metadata storage in contract-map
- mention new `GoatData` struct and mapping with getter in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841e165f2008325871227b8b7eaa1fc