### PR TITLE
codex: enforce NFT burn authorization

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -36,6 +36,14 @@ wasmd tx wasm instantiate <code_id> '{"meat_contract":"cosmos1..."}' \
 Instantiate `meat` and `goatnft` with similar commands by providing the desired
 `goat_contract` or no parameters for the NFT.
 
+After deploying `goatnft`, authorize the GOAT contract to burn NFTs:
+
+```bash
+wasmd tx wasm execute <nft_address> '{"set_allowed_contract":{"contract":"<goat_addr>"}}' \
+  --from wallet --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+```
+
 ## Query Examples
 
 ```bash

--- a/wasm-contracts/goatnft/src/lib.rs
+++ b/wasm-contracts/goatnft/src/lib.rs
@@ -1,9 +1,12 @@
-use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
 use base64::{engine::general_purpose, Engine as _};
-use serde_json_wasm;
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult, Uint128,
+};
 use cw2::set_contract_version;
+use serde_json_wasm;
 
-use crate::msg::{InstantiateMsg, ExecuteMsg, QueryMsg, GoatValueResponse};
+use crate::msg::{ExecuteMsg, GoatValueResponse, InstantiateMsg, QueryMsg};
 use crate::state::*;
 
 pub mod msg;
@@ -13,16 +16,24 @@ const CONTRACT_NAME: &str = "goatnft";
 const CONTRACT_VERSION: &str = "0.1.0";
 
 #[entry_point]
-pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, _msg: InstantiateMsg) -> StdResult<Response> {
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> StdResult<Response> {
     OWNER.save(deps.storage, &info.sender)?;
     NEXT_ID.save(deps.storage, &0u64)?;
+    ALLOWED_CONTRACT.save(deps.storage, &None)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
 
 fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
     let owner = OWNER.load(deps.storage)?;
-    if info.sender != owner { return Err(StdError::generic_err("Not the owner")); }
+    if info.sender != owner {
+        return Err(StdError::generic_err("Not the owner"));
+    }
     Ok(())
 }
 
@@ -30,17 +41,32 @@ fn handle_execute(deps: DepsMut, info: MessageInfo, msg: ExecuteMsg) -> StdResul
     match msg {
         ExecuteMsg::Mint { to, value } => execute_mint(deps, info, to, value),
         ExecuteMsg::Burn { token_id } => execute_burn(deps, info, token_id),
+        ExecuteMsg::SetAllowedContract { contract } => {
+            execute_set_allowed_contract(deps, info, contract)
+        }
     }
 }
 
 #[entry_point]
-pub fn execute(deps: DepsMut, _env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
     handle_execute(deps, info, msg)
 }
 
-fn execute_mint(mut deps: DepsMut, info: MessageInfo, to: String, value: Uint128) -> StdResult<Response> {
+fn execute_mint(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    to: String,
+    value: Uint128,
+) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;
-    if value.is_zero() { return Err(StdError::generic_err("Value must be > 0")); }
+    if value.is_zero() {
+        return Err(StdError::generic_err("Value must be > 0"));
+    }
     let to_addr = deps.api.addr_validate(&to)?;
     let id = NEXT_ID.load(deps.storage)? + 1;
     NEXT_ID.save(deps.storage, &id)?;
@@ -50,13 +76,29 @@ fn execute_mint(mut deps: DepsMut, info: MessageInfo, to: String, value: Uint128
 }
 
 fn execute_burn(deps: DepsMut, info: MessageInfo, token_id: String) -> StdResult<Response> {
-    let id: u64 = token_id.parse().map_err(|_| StdError::generic_err("invalid id"))?;
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
     let owner = OWNER_OF.load(deps.storage, id)?;
     if owner != info.sender {
-        // allow burning by contracts like GOAT without explicit approval
+        match ALLOWED_CONTRACT.load(deps.storage)? {
+            Some(addr) if addr == info.sender => {}
+            _ => return Err(StdError::generic_err("Unauthorized")),
+        }
     }
     OWNER_OF.remove(deps.storage, id);
     GOAT_VALUE.remove(deps.storage, id);
+    Ok(Response::new())
+}
+
+fn execute_set_allowed_contract(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    contract: String,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&contract)?;
+    ALLOWED_CONTRACT.save(deps.storage, &Some(addr))?;
     Ok(Response::new())
 }
 

--- a/wasm-contracts/goatnft/src/msg.rs
+++ b/wasm-contracts/goatnft/src/msg.rs
@@ -10,6 +10,7 @@ pub struct InstantiateMsg {}
 pub enum ExecuteMsg {
     Mint { to: String, value: Uint128 },
     Burn { token_id: String },
+    SetAllowedContract { contract: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/wasm-contracts/goatnft/src/state.rs
+++ b/wasm-contracts/goatnft/src/state.rs
@@ -5,3 +5,4 @@ pub const OWNER: Item<Addr> = Item::new("owner");
 pub const NEXT_ID: Item<u64> = Item::new("next_id");
 pub const OWNER_OF: Map<u64, Addr> = Map::new("owner_of");
 pub const GOAT_VALUE: Map<u64, Uint128> = Map::new("goat_value");
+pub const ALLOWED_CONTRACT: Item<Option<Addr>> = Item::new("allowed_contract");

--- a/wasm-contracts/goatnft/tests/burn.rs
+++ b/wasm-contracts/goatnft/tests/burn.rs
@@ -1,13 +1,19 @@
 use cosmwasm_std::{Addr, Empty, Uint128};
 use cw_multi_test::{App, ContractWrapper, Executor};
 
-use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
+use goatnft::msg::{
+    ExecuteMsg as NftExecute, InstantiateMsg as NftInstantiate, QueryMsg as NftQuery,
+};
 use goatnft::{execute, instantiate, query};
 use starter::msg as goat_msg;
-use goatnft::msg::{InstantiateMsg as NftInstantiate, ExecuteMsg as NftExecute, QueryMsg as NftQuery};
+use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
 
 fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
-    Box::new(ContractWrapper::new(goat_execute, goat_instantiate, goat_query))
+    Box::new(ContractWrapper::new(
+        goat_execute,
+        goat_instantiate,
+        goat_query,
+    ))
 }
 
 fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
@@ -20,18 +26,170 @@ fn burn_nft_for_goat() {
     let goat_id = app.store_code(contract_goat());
     let nft_id = app.store_code(contract_nft());
 
-    let goat_addr = app.instantiate_contract(goat_id, Addr::unchecked("owner"), &starter::msg::InstantiateMsg { meat_contract: "meat".into() }, &[], "goat", None).unwrap();
-    let nft_addr = app.instantiate_contract(nft_id, Addr::unchecked("owner"), &NftInstantiate {}, &[], "nft", None).unwrap();
+    let goat_addr = app
+        .instantiate_contract(
+            goat_id,
+            Addr::unchecked("owner"),
+            &starter::msg::InstantiateMsg {
+                meat_contract: "meat".into(),
+            },
+            &[],
+            "goat",
+            None,
+        )
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &NftInstantiate {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
 
-    app.execute_contract(Addr::unchecked("owner"), goat_addr.clone(), &goat_msg::ExecuteMsg::SetNftAddress { nft_address: nft_addr.to_string() }, &[]).unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        goat_addr.clone(),
+        &goat_msg::ExecuteMsg::SetNftAddress {
+            nft_address: nft_addr.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        nft_addr.clone(),
+        &NftExecute::SetAllowedContract {
+            contract: goat_addr.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
 
-    let resp = app.execute_contract(Addr::unchecked("owner"), nft_addr.clone(), &NftExecute::Mint { to: "user".into(), value: Uint128::new(50) }, &[]).unwrap();
-    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap().attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user".into(),
+                value: Uint128::new(50),
+            },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap();
 
-    app.execute_contract(Addr::unchecked("user"), goat_addr.clone(), &goat_msg::ExecuteMsg::BurnAndMint { token_id }, &[]).unwrap();
+    app.execute_contract(
+        Addr::unchecked("user"),
+        goat_addr.clone(),
+        &goat_msg::ExecuteMsg::BurnAndMint { token_id },
+        &[],
+    )
+    .unwrap();
 
-    let goat_bal: goat_msg::BalanceResponse = app.wrap().query_wasm_smart(goat_addr, &goat_msg::QueryMsg::Balance { address: "user".into() }).unwrap();
+    let goat_bal: goat_msg::BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            goat_addr,
+            &goat_msg::QueryMsg::Balance {
+                address: "user".into(),
+            },
+        )
+        .unwrap();
     assert_eq!(goat_bal.balance, Uint128::new(50));
-    let owner_res: Result<String, _> = app.wrap().query_wasm_smart(nft_addr, &NftQuery::Owner { token_id });
+    let owner_res: Result<String, _> = app
+        .wrap()
+        .query_wasm_smart(nft_addr, &NftQuery::Owner { token_id });
     assert!(owner_res.is_err());
+}
+
+#[test]
+fn burn_nft_unauthorized() {
+    let mut app = App::default();
+    let goat_id = app.store_code(contract_goat());
+    let nft_id = app.store_code(contract_nft());
+
+    let goat_addr = app
+        .instantiate_contract(
+            goat_id,
+            Addr::unchecked("owner"),
+            &starter::msg::InstantiateMsg {
+                meat_contract: "meat".into(),
+            },
+            &[],
+            "goat",
+            None,
+        )
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &NftInstantiate {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        nft_addr.clone(),
+        &NftExecute::SetAllowedContract {
+            contract: goat_addr.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user".into(),
+                value: Uint128::new(50),
+            },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("intruder"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    // ensure burn was rejected and state left unchanged
 }

--- a/wasm-contracts/starter/tests/goat.rs
+++ b/wasm-contracts/starter/tests/goat.rs
@@ -124,6 +124,13 @@ fn burn_and_mint_emits_burn() {
         &[]
     ).unwrap();
 
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::SetAllowedContract { contract: goat_addr.to_string() },
+        &[]
+    ).unwrap();
+
     let resp = app.execute_contract(
         Addr::unchecked("owner"),
         nft_addr.clone(),


### PR DESCRIPTION
## Summary
- add allowed contract config for goatnft burn
- validate sender matches owner or allowed contract
- test burn failure for unauthorized sender
- document how to set allowed contract

## Testing
- `cargo test --quiet --manifest-path wasm-contracts/goatnft/Cargo.toml`
- `cargo test --quiet --manifest-path wasm-contracts/starter/Cargo.toml`
- `cargo test --quiet --manifest-path wasm-contracts/meat/Cargo.toml`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841e58564188325956c8f4894190976