### PR TITLE
Update docs for wasm target installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ This repository maintains both EVM and CosmWasm contract builds under the `artif
    ```
    Copy the ABI JSONs from `artifacts/contracts/` into `backend/abi/` if you change the contracts.
 2. **CosmWasm** – build the Rust packages:
+   Install the build target if needed:
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
+   Then run:
    ```bash
    ./wasm-contracts/build.sh
    ```
@@ -210,6 +215,7 @@ Cakupan unit test meliputi:
 Untuk kontrak CosmWasm, jalankan skrip build berikut terlebih dahulu:
 
 ```bash
+rustup target add wasm32-unknown-unknown
 ./wasm-contracts/build.sh
 ```
 

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -8,6 +8,14 @@ This project includes CosmWasm implementations for all core contracts under `was
 
 ## Building
 
+Install the WASM target if you have not already:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+Then run the build script:
+
 ```bash
 ./wasm-contracts/build.sh
 ```

--- a/wasm-contracts/build.sh
+++ b/wasm-contracts/build.sh
@@ -3,6 +3,12 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR"
 
+# Ensure the wasm target is installed
+if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
+  echo "Installing wasm32-unknown-unknown target"
+  rustup target add wasm32-unknown-unknown
+fi
+
 for pkg in starter meat goatnft; do
   cd "$DIR/$pkg"
   cargo build --release --target wasm32-unknown-unknown


### PR DESCRIPTION
## Summary
- mention installing the `wasm32-unknown-unknown` target before running the build script
- automate target installation inside `wasm-contracts/build.sh`

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841e5a2f0f083258c49d060bae5929a