### PR TITLE
Fix Native Token Withdrawal

### DIFF
--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -60,7 +60,8 @@ contract MEAT is ERC20 {
     function withdrawNative() external onlyOwner {
         uint256 balance = address(this).balance;
         require(balance > 0, "No Native Token to withdraw");
-        payable(_owner).transfer(balance);
+        (bool sent, ) = payable(_owner).call{value: balance}("");
+        require(sent, "Native transfer failed");
         emit NativeWithdrawn(_owner, balance);
     }
 


### PR DESCRIPTION
## Summary
- use `call` for Native withdrawals to handle failures

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841ee039404832598f5ae10594bf136