### PR TITLE
Add GoatNFT stage to lifecycle doc

### DIFF
--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -6,12 +6,15 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * Users send native currency to the MEAT contract. Its `receive()` function mints MEAT to the sender using the `DepositRate`, scaled per 1000 units (default `100`, i.e. 100 MEAT per 1000 native).
 2. **Swapping**
    * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The fixed conversion constant `SwapRate` maintains proportional supply.
-3. **Staking GOAT**
+3. **GoatNFTs**
+   * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its value in `goatValue`.
+   * By calling `burnAndMint` on `GOAT.sol`, the NFT is burned and the same amount of GOAT is minted to the owner.
+4. **Staking GOAT**
    * GOAT holders stake tokens in `GOAT.sol` which records staking balances and timestamps. Rewards accrue linearly according to `rewardRate` and `rewardInterval`.
    *Calling `stake()` again resets `lastStakedTime` and discards any pending reward. Claim your reward first if you plan to restake.*
-4. **Claiming Rewards**
+5. **Claiming Rewards**
    * After `minClaimInterval` stakers may claim rewards or compound them back into the stake. If they choose to exit entirely they call `unstake` to receive the principal plus reward.
-5. **Returning to MEAT**
+6. **Returning to MEAT**
    * Unstaked GOAT can be swapped back for MEAT which may then be withdrawn from the ecosystem or used again for future interactions.
 
 This lifecycle ensures that every stage of participation is backed by explicit contract functions and transparent token flows.


### PR DESCRIPTION
## Summary
- describe the GoatNFT stage within the token lifecycle doc
- mention the `burnAndMint` flow and link to `contracts/GoatNFT.sol`

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841f010e77c8325bca9463c86c9fa42