### PR TITLE
codex/docs-burnAndMint

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ Struktur dan hubungan antar kontrak:
   untuk dipanggil MEAT saat membutuhkan GOAT baru.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test
   guna mensimulasikan kegagalan `transfer`.
+- `burnAndMint` pada GOAT memungkinkan pemilik `GoatNFT` menukar NFT mereka
+  menjadi token GOAT setara nilai `goatValue`. Fungsi ini memanggil `burn`
+  di `GoatNFT` lalu mencetak jumlah GOAT yang sama ke alamat pemilik.
+
+### Contoh Penggunaan
+
+```solidity
+// asumsikan "nft" dan "goat" sudah terdeploy
+nft.approve(goatAddress, tokenId);
+goat.burnAndMint(tokenId);
+```
 
 Alur panggilan eksternal–internal secara ringkas:
 1. `swapMEATForGOAT` memanggil `transferFrom` MEAT dan `mintTo` GOAT jika saldo


### PR DESCRIPTION
## Summary
- document how `burnAndMint` converts a GoatNFT into GOAT
- show a minimal example of calling `burnAndMint`

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6841f22aad548325ac177178e4ea4380