### PR TITLE
Add non-owner revert tests

### DIFF
--- a/test/addressSetter.test.js
+++ b/test/addressSetter.test.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("Setter address validation", function () {
-  let owner, goat, meat;
+  let owner, nonOwner, goat, meat;
 
   beforeEach(async function () {
-    [owner] = await ethers.getSigners();
+    [owner, nonOwner] = await ethers.getSigners();
     const GOAT = await ethers.getContractFactory("GOAT");
     goat = await GOAT.deploy(owner.address);
     await goat.waitForDeployment();
@@ -31,5 +31,23 @@ describe("Setter address validation", function () {
     await expect(meat.setGOATAddress(ethers.ZeroAddress)).to.be.revertedWith(
       "Invalid address"
     );
+  });
+
+  it("reverts when non-owner calls setMEATAddress", async function () {
+    await expect(
+      goat.connect(nonOwner).setMEATAddress(nonOwner.address)
+    ).to.be.revertedWith("Not the owner");
+  });
+
+  it("reverts when non-owner calls setNFTAddress", async function () {
+    await expect(
+      goat.connect(nonOwner).setNFTAddress(nonOwner.address)
+    ).to.be.revertedWith("Not the owner");
+  });
+
+  it("reverts when non-owner calls setGOATAddress", async function () {
+    await expect(
+      meat.connect(nonOwner).setGOATAddress(goat.target)
+    ).to.be.revertedWith("Not the owner");
   });
 });


### PR DESCRIPTION
## Summary
- extend the address setter suite with access-control tests

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68420f9baa8c83258336a06de8aeb052