### PR TITLE
codex/reset-last-staked-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Simulasi tahapan staking hingga unstake:
 3. Ketika keluar, panggil `unstake` sehingga pokok dan reward terkirim dan data
    staking dihapus.
 
-4. Dalam keadaan darurat, `emergencyUnstake` dapat digunakan kapan saja untuk menarik pokok tanpa reward.
+4. Dalam keadaan darurat, `emergencyUnstake` dapat digunakan kapan saja untuk menarik pokok tanpa reward. Fungsi ini juga menghapus `lastStakedTime` sehingga status staking benar-benar bersih.
 
 Reward dihitung berbasis waktu (detik) sehingga tidak bergantung pada jumlah
 blok. Perubahan state utama terjadi pada `stakingBalance`, `lastStakedTime`, dan

--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -84,6 +84,7 @@ function emergencyUnstake() external {
     uint256 staked = stakingBalance[msg.sender];
     require(staked > 0, "Nothing to unstake");
     stakingBalance[msg.sender] = 0;
+    lastStakedTime[msg.sender] = 0;
     uint256 available = balanceOf(address(this));
     if (available >= staked) {
         _transfer(address(this), msg.sender, staked);

--- a/test/fullFlow.test.js
+++ b/test/fullFlow.test.js
@@ -156,6 +156,7 @@ describe("Full flow integration", function () {
       .withArgs(user3.address, goatOut3, 0);
 
     expect(await goat.balanceOf(user3.address)).to.equal(goatOut3);
+    expect(await goat.lastStakedTime(user3.address)).to.equal(0n);
     const finalMeat3 = ethers.parseEther("100") - amountSwap3;
     expect(await meat.balanceOf(user3.address)).to.equal(finalMeat3);
   });


### PR DESCRIPTION
## Summary
- update `emergencyUnstake` to clear `lastStakedTime`
- clarify README on emergency unstake
- assert that emergency unstake clears last staked time

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6842171cfa3083259d6f0263b3a04e87