### PR TITLE
Update GoatNFT metadata types

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ Struktur dan hubungan antar kontrak:
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint, memungkinkan penukaran MEAT ↔ GOAT, dan mengontrol fitur swap.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
-  Metadata tiap token dikemas dalam struct `GoatData` dan disimpan pada mapping
-  `goatMetadata`. Fungsi `mint` menerima `nfcId`, `breed`, `birthYear`, dan
-  `weight`; data dapat dibaca ulang melalui `getGoatData` dan dihapus saat
+  Metadata tiap token dikemas dalam struct `GoatData` (menyimpan `nfcId` bertipe
+  `string`, `breed`, `birthYear`, `weight`, dan `mintedAt`) dan disimpan pada
+  mapping `goatMetadata`. Fungsi `mint` menerima kelima data tersebut; data dapat
+  dibaca ulang melalui `getGoatData` dan dihapus saat
   `burn`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
   untuk dipanggil MEAT saat membutuhkan GOAT baru.

--- a/contract-map.md
+++ b/contract-map.md
@@ -20,5 +20,5 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 |---------|-------------|---------------|
 | GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
-| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored in `goatMetadata` mapping of `GoatData`. | `mint`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). | `mint`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -10,10 +10,10 @@ contract GoatNFT is ERC721Burnable {
     uint256 public nextId;
     mapping(uint256 => uint256) public goatValue;
     struct GoatData {
-        uint256 nfcId;
+        string nfcId;
         string breed;
-        uint16 birthYear;
-        uint16 weight;
+        uint256 birthYear;
+        uint256 weight;
         uint256 mintedAt;
     }
     mapping(uint256 => GoatData) public goatMetadata;
@@ -31,10 +31,10 @@ contract GoatNFT is ERC721Burnable {
     function mint(
         address to,
         uint256 value,
-        uint256 nfcId,
-        string calldata breed,
-        uint16 birthYear,
-        uint16 weight
+        string memory nfcId,
+        string memory breed,
+        uint256 birthYear,
+        uint256 weight
     ) external onlyOwner returns (uint256) {
         require(value > 0, "Value must be > 0");
         uint256 tokenId = ++nextId;

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -20,7 +20,7 @@ describe("GoatNFT burn and GOAT mint", function () {
 
   it("burns NFT and mints GOAT", async function () {
     const value = ethers.parseEther("5");
-    const nfcId = 1234;
+    const nfcId = "1234";
     const breed = "Boer";
     const birthYear = 2021;
     const weight = 70;
@@ -39,7 +39,7 @@ describe("GoatNFT burn and GOAT mint", function () {
     await expect(goat.connect(user).burnAndMint(tokenId)).to.not.be.reverted;
 
     const afterBurn = await nft.getGoatData(tokenId);
-    expect(afterBurn.nfcId).to.equal(0);
+    expect(afterBurn.nfcId).to.equal("");
   
     expect(await goat.balanceOf(user.address)).to.equal(value);
     await expect(nft.ownerOf(tokenId)).to.be.reverted;


### PR DESCRIPTION
## Summary
- store goat metadata as strings and uint256 values
- update tests for new metadata schema
- document GoatNFT struct changes

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68421b63c4408325b413367c22125624