### PR TITLE
Add test for GoatNFT owner restriction

### DIFF
--- a/test/nftOwner.test.js
+++ b/test/nftOwner.test.js
@@ -1,0 +1,21 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("GoatNFT owner restrictions", function () {
+  let owner, nonOwner, nft;
+
+  beforeEach(async function () {
+    [owner, nonOwner] = await ethers.getSigners();
+    const GoatNFT = await ethers.getContractFactory("GoatNFT");
+    nft = await GoatNFT.deploy();
+    await nft.waitForDeployment();
+  });
+
+  it("reverts when a non-owner calls mint", async function () {
+    await expect(
+      nft
+        .connect(nonOwner)
+        .mint(nonOwner.address, 1, "nfc", "breed", 2020, 50)
+    ).to.be.revertedWith("Not the owner");
+  });
+});


### PR DESCRIPTION
## Summary
- add nftOwner.test.js to ensure only the owner can mint GoatNFTs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68423a81e36c83258ee2d3d14d834583