### PR TITLE
codex/docs-update-emergency-unstake

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Struktur dan hubungan antar kontrak:
 - `burnAndMint` pada GOAT memungkinkan pemilik `GoatNFT` menukar NFT mereka
   menjadi token GOAT setara nilai `goatValue`. Fungsi ini memanggil `burn`
   di `GoatNFT` lalu mencetak jumlah GOAT yang sama ke alamat pemilik.
+- `emergencyUnstake` memungkinkan penarikan token yang di-stake tanpa reward kapan saja.
 
 ### Contoh Penggunaan
 

--- a/contract-map.md
+++ b/contract-map.md
@@ -12,6 +12,7 @@
 
 * **MEAT** acts as the gateway: it accepts native coins, mints MEAT, and handles swaps in both directions. The owner may withdraw accumulated native balance.
 * **GOAT** receives minted supply from MEAT and provides staking functionality. Rewards and configuration parameters are adjustable by the owner.
+  - `emergencyUnstake` allows stakers to withdraw tokens without rewards at any time.
 * **FailingGOAT** is only for testing; it implements the same interface but allows simulated transfer failures.
 * **IGOAT** defines the `mintTo` function which enables MEAT to mint GOAT when necessary.
 


### PR DESCRIPTION
## Summary
- document the emergencyUnstake function in README and contract-map

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6842436a15548325b067b8e8114489ae