### PR TITLE
codex/add-wasm-contract-readme

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -8,6 +8,9 @@ This project includes CosmWasm implementations for all core contracts under `was
 
 ## Building
 
+For toolchain setup and additional details see
+[../wasm-contracts/README.md](../wasm-contracts/README.md).
+
 Install the WASM target if you have not already:
 
 ```bash

--- a/wasm-contracts/README.md
+++ b/wasm-contracts/README.md
@@ -1,0 +1,19 @@
+# Building the CosmWasm contracts
+
+This folder contains the Rust implementations of the GOAT, MEAT and GoatNFT contracts. To compile them you need the standard Rust toolchain and the WebAssembly target.
+
+## Prerequisites
+
+1. Install [rustup](https://rustup.rs/) if you do not already have it.
+2. Add the `wasm32-unknown-unknown` build target:
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
+
+## Building
+
+Run the build script from the repository root:
+```bash
+./wasm-contracts/build.sh
+```
+The script compiles all packages in this directory. The resulting `.wasm` files are placed in the top‑level `artifacts/` folder while JSON schemas are written to each package's `schema/` directory.


### PR DESCRIPTION
## Summary
- add detailed build instructions for the CosmWasm contracts
- reference the new documentation from `wasm-deploy.md`

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6842459723708325941e892e2cfa18b3