### PR TITLE
codex/fix-unstake-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ Simulasi tahapan staking hingga unstake:
    - `claimReward` untuk mengambil hasil tanpa menarik pokok;
    - `compoundReward` agar hasil otomatis ditambahkan ke saldo staking.
 3. Ketika keluar, panggil `unstake` sehingga pokok dan reward terkirim dan data
-   staking dihapus.
+   staking dihapus. Fungsi ini juga mengatur `lastStakedTime` kembali ke `0`
+   agar status staking pengguna bersih.
 
 4. Dalam keadaan darurat, `emergencyUnstake` dapat digunakan kapan saja untuk menarik pokok tanpa reward. Fungsi ini juga menghapus `lastStakedTime` sehingga status staking benar-benar bersih.
 

--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -108,7 +108,8 @@ function unstake() external {
     require(block.timestamp - lastTime >= minClaimInterval, "Claim not allowed yet");
     uint256 reward = calculateReward(msg.sender, lastTime);
     uint256 total = staked + reward;
-    stakingBalance[msg.sender] = 0;    
+    stakingBalance[msg.sender] = 0;
+    lastStakedTime[msg.sender] = 0;
     uint256 available = balanceOf(address(this));
     if (available >= total) {
         _transfer(address(this), msg.sender, total);

--- a/test/fullFlow.test.js
+++ b/test/fullFlow.test.js
@@ -103,6 +103,7 @@ describe("Full flow integration", function () {
     await expect(goat.connect(user1).unstake())
       .to.emit(goat, "Unstaked")
       .withArgs(user1.address, stakeAfterCompound, anyValue);
+    expect(await goat.lastStakedTime(user1.address)).to.equal(0n);
     const goatReturn = await goat.balanceOf(user1.address);
     expect(goatReturn).to.be.gt(stakeAfterCompound);
 
@@ -140,6 +141,7 @@ describe("Full flow integration", function () {
     await expect(goat.connect(user2).unstake())
       .to.emit(goat, "Unstaked")
       .withArgs(user2.address, goatOut2, anyValue);
+    expect(await goat.lastStakedTime(user2.address)).to.equal(0n);
 
     const finalGoat2 = await goat.balanceOf(user2.address);
     expect(finalGoat2).to.be.gt(goatOut2);


### PR DESCRIPTION
## Summary
- zero out `lastStakedTime` in `unstake`
- check the timestamp reset in integration tests
- note unstake clearing timestamp in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68424a72f6348325aba2122bc5124cf5