### PR TITLE
Add goat metadata and approval flow

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -47,10 +47,10 @@ wasmd tx wasm instantiate <code_id> '{"meat_contract":"cosmos1..."}' \
 Instantiate `meat` and `goatnft` with similar commands by providing the desired
 `goat_contract` or no parameters for the NFT.
 
-After deploying `goatnft`, authorize the GOAT contract to burn NFTs:
+After deploying `goatnft`, each NFT owner must approve the GOAT contract before it can burn tokens. Example approval:
 
 ```bash
-wasmd tx wasm execute <nft_address> '{"set_allowed_contract":{"contract":"<goat_addr>"}}' \
+wasmd tx wasm execute <nft_address> '{"approve":{"spender":"<goat_addr>","token_id":"1"}}' \
   --from wallet --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```

--- a/wasm-contracts/goatnft/src/lib.rs
+++ b/wasm-contracts/goatnft/src/lib.rs
@@ -6,7 +6,13 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use serde_json_wasm;
 
-use crate::msg::{ExecuteMsg, GoatValueResponse, InstantiateMsg, QueryMsg};
+use crate::msg::{
+    ExecuteMsg,
+    GoatValueResponse,
+    GoatDataResponse,
+    InstantiateMsg,
+    QueryMsg,
+};
 use crate::state::*;
 
 pub mod msg;
@@ -24,7 +30,6 @@ pub fn instantiate(
 ) -> StdResult<Response> {
     OWNER.save(deps.storage, &info.sender)?;
     NEXT_ID.save(deps.storage, &0u64)?;
-    ALLOWED_CONTRACT.save(deps.storage, &None)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
@@ -37,31 +42,36 @@ fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
     Ok(())
 }
 
-fn handle_execute(deps: DepsMut, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+fn handle_execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     match msg {
-        ExecuteMsg::Mint { to, value } => execute_mint(deps, info, to, value),
-        ExecuteMsg::Burn { token_id } => execute_burn(deps, info, token_id),
-        ExecuteMsg::SetAllowedContract { contract } => {
-            execute_set_allowed_contract(deps, info, contract)
+        ExecuteMsg::Mint { to, value, nfc_id, breed, birth_year, weight } => {
+            execute_mint(deps, env, info, to, value, nfc_id, breed, birth_year, weight)
         }
+        ExecuteMsg::Burn { token_id } => execute_burn(deps, info, token_id),
+        ExecuteMsg::Approve { spender, token_id } => execute_approve(deps, info, spender, token_id),
     }
 }
 
 #[entry_point]
 pub fn execute(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> StdResult<Response> {
-    handle_execute(deps, info, msg)
+    handle_execute(deps, env, info, msg)
 }
 
 fn execute_mint(
     mut deps: DepsMut,
+    env: Env,
     info: MessageInfo,
     to: String,
     value: Uint128,
+    nfc_id: String,
+    breed: String,
+    birth_year: u64,
+    weight: u64,
 ) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;
     if value.is_zero() {
@@ -72,6 +82,14 @@ fn execute_mint(
     NEXT_ID.save(deps.storage, &id)?;
     OWNER_OF.save(deps.storage, id, &to_addr)?;
     GOAT_VALUE.save(deps.storage, id, &value)?;
+    let data = GoatData {
+        nfc_id,
+        breed,
+        birth_year,
+        weight,
+        minted_at: env.block.time.seconds(),
+    };
+    GOAT_METADATA.save(deps.storage, id, &data)?;
     Ok(Response::new().add_attribute("token_id", id.to_string()))
 }
 
@@ -81,24 +99,29 @@ fn execute_burn(deps: DepsMut, info: MessageInfo, token_id: String) -> StdResult
         .map_err(|_| StdError::generic_err("invalid id"))?;
     let owner = OWNER_OF.load(deps.storage, id)?;
     if owner != info.sender {
-        match ALLOWED_CONTRACT.load(deps.storage)? {
-            Some(addr) if addr == info.sender => {}
+        let approved = APPROVALS.may_load(deps.storage, id)?;
+        match approved {
+            Some(addr) if addr == info.sender => {},
             _ => return Err(StdError::generic_err("Unauthorized")),
         }
     }
     OWNER_OF.remove(deps.storage, id);
     GOAT_VALUE.remove(deps.storage, id);
+    GOAT_METADATA.remove(deps.storage, id);
+    APPROVALS.remove(deps.storage, id);
     Ok(Response::new())
 }
 
-fn execute_set_allowed_contract(
-    mut deps: DepsMut,
-    info: MessageInfo,
-    contract: String,
-) -> StdResult<Response> {
-    only_owner(deps.branch(), &info)?;
-    let addr = deps.api.addr_validate(&contract)?;
-    ALLOWED_CONTRACT.save(deps.storage, &Some(addr))?;
+fn execute_approve(deps: DepsMut, info: MessageInfo, spender: String, token_id: String) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        return Err(StdError::generic_err("Unauthorized"));
+    }
+    let spender_addr = deps.api.addr_validate(&spender)?;
+    APPROVALS.save(deps.storage, id, &spender_addr)?;
     Ok(Response::new())
 }
 
@@ -107,6 +130,16 @@ fn handle_query(deps: Deps, q: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GoatValue { token_id } => {
             let value = GOAT_VALUE.load(deps.storage, token_id)?;
             to_json_binary(&GoatValueResponse { value })
+        }
+        QueryMsg::GoatData { token_id } => {
+            let data = GOAT_METADATA.load(deps.storage, token_id)?;
+            to_json_binary(&GoatDataResponse {
+                nfc_id: data.nfc_id,
+                breed: data.breed,
+                birth_year: data.birth_year,
+                weight: data.weight,
+                minted_at: data.minted_at,
+            })
         }
         QueryMsg::Owner { token_id } => {
             let owner = OWNER_OF.load(deps.storage, token_id)?;

--- a/wasm-contracts/goatnft/src/msg.rs
+++ b/wasm-contracts/goatnft/src/msg.rs
@@ -8,15 +8,23 @@ pub struct InstantiateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    Mint { to: String, value: Uint128 },
+    Mint {
+        to: String,
+        value: Uint128,
+        nfc_id: String,
+        breed: String,
+        birth_year: u64,
+        weight: u64,
+    },
     Burn { token_id: String },
-    SetAllowedContract { contract: String },
+    Approve { spender: String, token_id: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     GoatValue { token_id: u64 },
+    GoatData { token_id: u64 },
     Owner { token_id: u64 },
     OwnerAddress {},
 }
@@ -24,4 +32,13 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GoatValueResponse {
     pub value: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct GoatDataResponse {
+    pub nfc_id: String,
+    pub breed: String,
+    pub birth_year: u64,
+    pub weight: u64,
+    pub minted_at: u64,
 }

--- a/wasm-contracts/goatnft/src/state.rs
+++ b/wasm-contracts/goatnft/src/state.rs
@@ -1,8 +1,19 @@
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
 
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct GoatData {
+    pub nfc_id: String,
+    pub breed: String,
+    pub birth_year: u64,
+    pub weight: u64,
+    pub minted_at: u64,
+}
+
 pub const OWNER: Item<Addr> = Item::new("owner");
 pub const NEXT_ID: Item<u64> = Item::new("next_id");
 pub const OWNER_OF: Map<u64, Addr> = Map::new("owner_of");
 pub const GOAT_VALUE: Map<u64, Uint128> = Map::new("goat_value");
-pub const ALLOWED_CONTRACT: Item<Option<Addr>> = Item::new("allowed_contract");
+pub const GOAT_METADATA: Map<u64, GoatData> = Map::new("goat_metadata");
+pub const APPROVALS: Map<u64, Addr> = Map::new("approvals");
+

--- a/wasm-contracts/goatnft/tests/burn.rs
+++ b/wasm-contracts/goatnft/tests/burn.rs
@@ -58,15 +58,6 @@ fn burn_nft_for_goat() {
         &[],
     )
     .unwrap();
-    app.execute_contract(
-        Addr::unchecked("owner"),
-        nft_addr.clone(),
-        &NftExecute::SetAllowedContract {
-            contract: goat_addr.to_string(),
-        },
-        &[],
-    )
-    .unwrap();
 
     let resp = app
         .execute_contract(
@@ -75,6 +66,10 @@ fn burn_nft_for_goat() {
             &NftExecute::Mint {
                 to: "user".into(),
                 value: Uint128::new(50),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 10,
             },
             &[],
         )
@@ -91,6 +86,17 @@ fn burn_nft_for_goat() {
         .value
         .parse()
         .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &NftExecute::Approve {
+            spender: goat_addr.to_string(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
 
     app.execute_contract(
         Addr::unchecked("user"),
@@ -145,15 +151,6 @@ fn burn_nft_unauthorized() {
         )
         .unwrap();
 
-    app.execute_contract(
-        Addr::unchecked("owner"),
-        nft_addr.clone(),
-        &NftExecute::SetAllowedContract {
-            contract: goat_addr.to_string(),
-        },
-        &[],
-    )
-    .unwrap();
 
     let resp = app
         .execute_contract(
@@ -162,6 +159,10 @@ fn burn_nft_unauthorized() {
             &NftExecute::Mint {
                 to: "user".into(),
                 value: Uint128::new(50),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 10,
             },
             &[],
         )
@@ -191,5 +192,5 @@ fn burn_nft_unauthorized() {
         .unwrap_err();
     assert!(!err.to_string().is_empty());
 
-    // ensure burn was rejected and state left unchanged
+    // ensure burn was rejected
 }

--- a/wasm-contracts/starter/tests/goat.rs
+++ b/wasm-contracts/starter/tests/goat.rs
@@ -124,21 +124,32 @@ fn burn_and_mint_emits_burn() {
         &[]
     ).unwrap();
 
-    app.execute_contract(
-        Addr::unchecked("owner"),
-        nft_addr.clone(),
-        &nft_msg::ExecuteMsg::SetAllowedContract { contract: goat_addr.to_string() },
-        &[]
-    ).unwrap();
 
     let resp = app.execute_contract(
         Addr::unchecked("owner"),
         nft_addr.clone(),
-        &nft_msg::ExecuteMsg::Mint { to: "user".into(), value: Uint128::new(50) },
+        &nft_msg::ExecuteMsg::Mint {
+            to: "user".into(),
+            value: Uint128::new(50),
+            nfc_id: "nfc".into(),
+            breed: "breed".into(),
+            birth_year: 2024,
+            weight: 10,
+        },
         &[]
     ).unwrap();
     let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap()
         .attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::Approve {
+            spender: goat_addr.to_string(),
+            token_id: token_id.to_string(),
+        },
+        &[]
+    ).unwrap();
 
     let res = app.execute_contract(
         Addr::unchecked("user"),


### PR DESCRIPTION
## Summary
- store goat metadata and approval mapping for NFT contract
- include metadata fields in execute messages and queries
- implement approval-based burn permissions
- update tests for new mint parameters and approval flow
- adjust deployment docs for new approve command

## Testing
- `cargo test` in `wasm-contracts/goatnft`
- `cargo test` in `wasm-contracts/starter`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684258b5f0c4832597c4c41a65f14912