### PR TITLE
Clarify NFT burn approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,10 @@ Struktur dan hubungan antar kontrak:
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test
   guna mensimulasikan kegagalan `transfer`.
 - `burnAndMint` pada GOAT memungkinkan pemilik `GoatNFT` menukar NFT mereka
-  menjadi token GOAT setara nilai `goatValue`. Fungsi ini memanggil `burn`
-  di `GoatNFT` lalu mencetak jumlah GOAT yang sama ke alamat pemilik.
+  menjadi token GOAT setara nilai `goatValue`. Sebelum memanggil fungsi ini
+  pemilik harus `approve` token tersebut ke kontrak GOAT. Fungsi kemudian
+  memanggil `burn` di `GoatNFT` dan mencetak jumlah GOAT yang sama ke alamat
+  pemilik.
 - `emergencyUnstake` memungkinkan penarikan token yang di-stake tanpa reward kapan saja.
 
 ### Contoh Penggunaan

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -70,6 +70,14 @@ wasmd tx wasm execute <nft_address> '{"approve":{"spender":"<goat_addr>","token_
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
 
+Once approved, redeem the NFT's value by calling `burn_and_mint` on the GOAT contract:
+
+```bash
+wasmd tx wasm execute <goat_address> '{"burn_and_mint":{"token_id":1}}' \
+  --from wallet --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+```
+
 ## Query Examples
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that `burnAndMint` requires prior approval in README
- show `burn_and_mint` usage after approval in WASM deployment guide

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684261e27fd08325b71d7d6ab854f904