### PR TITLE
Add transfer operations to goatnft

### DIFF
--- a/wasm-contracts/goatnft/src/lib.rs
+++ b/wasm-contracts/goatnft/src/lib.rs
@@ -49,6 +49,8 @@ fn handle_execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -
         }
         ExecuteMsg::Burn { token_id } => execute_burn(deps, info, token_id),
         ExecuteMsg::Approve { spender, token_id } => execute_approve(deps, info, spender, token_id),
+        ExecuteMsg::Transfer { to, token_id } => execute_transfer(deps, info, to, token_id),
+        ExecuteMsg::TransferFrom { owner, to, token_id } => execute_transfer_from(deps, info, owner, to, token_id),
     }
 }
 
@@ -122,6 +124,52 @@ fn execute_approve(deps: DepsMut, info: MessageInfo, spender: String, token_id: 
     }
     let spender_addr = deps.api.addr_validate(&spender)?;
     APPROVALS.save(deps.storage, id, &spender_addr)?;
+    Ok(Response::new())
+}
+
+fn execute_transfer(deps: DepsMut, info: MessageInfo, to: String, token_id: String) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        let approved = APPROVALS.may_load(deps.storage, id)?;
+        match approved {
+            Some(addr) if addr == info.sender => {},
+            _ => return Err(StdError::generic_err("Unauthorized")),
+        }
+    }
+    let to_addr = deps.api.addr_validate(&to)?;
+    OWNER_OF.save(deps.storage, id, &to_addr)?;
+    APPROVALS.remove(deps.storage, id);
+    Ok(Response::new())
+}
+
+fn execute_transfer_from(
+    deps: DepsMut,
+    info: MessageInfo,
+    owner: String,
+    to: String,
+    token_id: String,
+) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner_addr = deps.api.addr_validate(&owner)?;
+    let current_owner = OWNER_OF.load(deps.storage, id)?;
+    if current_owner != owner_addr {
+        return Err(StdError::generic_err("Owner mismatch"));
+    }
+    if owner_addr != info.sender {
+        let approved = APPROVALS.may_load(deps.storage, id)?;
+        match approved {
+            Some(addr) if addr == info.sender => {},
+            _ => return Err(StdError::generic_err("Unauthorized")),
+        }
+    }
+    let to_addr = deps.api.addr_validate(&to)?;
+    OWNER_OF.save(deps.storage, id, &to_addr)?;
+    APPROVALS.remove(deps.storage, id);
     Ok(Response::new())
 }
 

--- a/wasm-contracts/goatnft/src/msg.rs
+++ b/wasm-contracts/goatnft/src/msg.rs
@@ -18,6 +18,8 @@ pub enum ExecuteMsg {
     },
     Burn { token_id: String },
     Approve { spender: String, token_id: String },
+    Transfer { to: String, token_id: String },
+    TransferFrom { owner: String, to: String, token_id: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/wasm-contracts/goatnft/tests/transfer.rs
+++ b/wasm-contracts/goatnft/tests/transfer.rs
@@ -1,0 +1,172 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use goatnft::msg::{ExecuteMsg as NftExecute, InstantiateMsg as NftInstantiate, QueryMsg as NftQuery};
+use goatnft::{execute, instantiate, query};
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+fn mint_sample(app: &mut App, nft_addr: Addr) -> u64 {
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user1".into(),
+                value: Uint128::new(10),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 5,
+            },
+            &[],
+        )
+        .unwrap();
+    resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap()
+}
+
+#[test]
+fn transfer_changes_owner_and_clears_approval() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &NftInstantiate {}, &[], "nft", None)
+        .unwrap();
+
+    let token_id = mint_sample(&mut app, nft_addr.clone());
+
+    app.execute_contract(
+        Addr::unchecked("user1"),
+        nft_addr.clone(),
+        &NftExecute::Approve {
+            spender: "spender".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user1"),
+        nft_addr.clone(),
+        &NftExecute::Transfer {
+            to: "user2".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("spender"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user1"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    app.execute_contract(
+        Addr::unchecked("user2"),
+        nft_addr.clone(),
+        &NftExecute::Burn {
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res: Result<String, _> = app
+        .wrap()
+        .query_wasm_smart(nft_addr.clone(), &NftQuery::Owner { token_id });
+    assert!(res.is_err());
+}
+
+#[test]
+fn transfer_from_by_approved() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &NftInstantiate {}, &[], "nft", None)
+        .unwrap();
+
+    let token_id = mint_sample(&mut app, nft_addr.clone());
+
+    app.execute_contract(
+        Addr::unchecked("user1"),
+        nft_addr.clone(),
+        &NftExecute::Approve {
+            spender: "spender".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("spender"),
+        nft_addr.clone(),
+        &NftExecute::TransferFrom {
+            owner: "user1".into(),
+            to: "user2".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user1"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    app.execute_contract(
+        Addr::unchecked("user2"),
+        nft_addr.clone(),
+        &NftExecute::Burn {
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res: Result<String, _> = app
+        .wrap()
+        .query_wasm_smart(nft_addr, &NftQuery::Owner { token_id });
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## Summary
- extend goatnft ExecuteMsg with `Transfer` and `TransferFrom`
- handle new transfer messages in contract logic
- ensure approvals are cleared on transfer
- add tests covering the transfer behaviour

## Testing
- `cargo test --quiet` *(passes)*
- `yes | npx hardhat test` *(fails: Hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68426ceb30dc8325bf324df72907a355