### PR TITLE
codex/add-events

### DIFF
--- a/wasm-contracts/meat/src/lib.rs
+++ b/wasm-contracts/meat/src/lib.rs
@@ -105,10 +105,18 @@ fn execute_mint_with_native(deps: DepsMut, env: Env, info: MessageInfo) -> StdRe
         add_balance(deps.storage, &info.sender, to_mint)?;
         let total = TOTAL_SUPPLY.load(deps.storage)? + to_mint;
         TOTAL_SUPPLY.save(deps.storage, &total)?;
-        return Ok(Response::new());
+        return Ok(Response::new()
+            .add_attribute("action", "MintedWithNative")
+            .add_attribute("user", info.sender.clone())
+            .add_attribute("native", coin.amount)
+            .add_attribute("minted", to_mint));
     }
     add_balance(deps.storage, &info.sender, mint)?;
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "MintedWithNative")
+        .add_attribute("user", info.sender)
+        .add_attribute("native", coin.amount)
+        .add_attribute("minted", mint))
 }
 
 fn execute_withdraw_native(mut deps: DepsMut, env: Env, info: MessageInfo, to: Option<String>) -> StdResult<Response> {
@@ -116,13 +124,21 @@ fn execute_withdraw_native(mut deps: DepsMut, env: Env, info: MessageInfo, to: O
     let bal = deps.querier.query_all_balances(env.contract.address)?;
     if bal.is_empty() { return Err(StdError::generic_err("No funds")); }
     let to_addr = to.unwrap_or_else(|| info.sender.to_string());
-    Ok(Response::new().add_message(BankMsg::Send { to_address: to_addr, amount: bal }))
+    Ok(Response::new()
+        .add_message(BankMsg::Send { to_address: to_addr.clone(), amount: bal.clone() })
+        .add_attribute("action", "NativeWithdrawn")
+        .add_attribute("to", to_addr)
+        .add_attribute("amount", format!("{}", bal.iter().map(|c| c.amount).sum::<Uint128>())))
 }
 
 fn execute_change_rate(mut deps: DepsMut, info: MessageInfo, new_rate: Uint128) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;
+    let old = RATE.load(deps.storage)?;
     RATE.save(deps.storage, &new_rate)?;
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "DepositRateChanged")
+        .add_attribute("old_rate", old)
+        .add_attribute("new_rate", new_rate))
 }
 
 fn execute_swap_goat_for_meat(deps: DepsMut, env: Env, info: MessageInfo, goat_amount: Uint128) -> StdResult<Response> {
@@ -133,7 +149,7 @@ fn execute_swap_goat_for_meat(deps: DepsMut, env: Env, info: MessageInfo, goat_a
     let meat_needed = Uint128::new(goat_amount.u128() * SWAP_RATE);
     let contract = env.contract.address;
     let bal = BALANCES.may_load(deps.storage, &contract)?.unwrap_or_default();
-    let resp = Response::new().add_message(transfer);
+    let mut resp = Response::new().add_message(transfer);
     if bal >= meat_needed {
         sub_balance(deps.storage, &contract, meat_needed)?;
         add_balance(deps.storage, &info.sender, meat_needed)?;
@@ -147,6 +163,11 @@ fn execute_swap_goat_for_meat(deps: DepsMut, env: Env, info: MessageInfo, goat_a
         let total = TOTAL_SUPPLY.load(deps.storage)? + mint_amt;
         TOTAL_SUPPLY.save(deps.storage, &total)?;
     }
+    resp = resp
+        .add_attribute("action", "SwappedGOATForMEAT")
+        .add_attribute("user", info.sender)
+        .add_attribute("goat_in", goat_amount)
+        .add_attribute("meat_out", meat_needed);
     Ok(resp)
 }
 
@@ -177,7 +198,11 @@ fn execute_swap_meat_for_goat(deps: DepsMut, env: Env, info: MessageInfo, meat_a
         msg: to_json_binary(&goat_msg::ExecuteMsg::Transfer { recipient: info.sender.to_string(), amount: goat_amount })?,
         funds: vec![],
     });
-    Ok(resp)
+    Ok(resp
+        .add_attribute("action", "SwappedMEATForGOAT")
+        .add_attribute("user", info.sender)
+        .add_attribute("meat_in", meat_amount)
+        .add_attribute("goat_out", goat_amount))
 }
 
 fn execute_set_swap_enabled(mut deps: DepsMut, info: MessageInfo, enabled: bool) -> StdResult<Response> {

--- a/wasm-contracts/meat/tests/mint.rs
+++ b/wasm-contracts/meat/tests/mint.rs
@@ -43,7 +43,8 @@ fn mint_with_native_mints_meat() {
     let goat_addr = app.instantiate_contract(goat_id, Addr::unchecked("owner"), &starter::msg::InstantiateMsg { meat_contract: "meat".into() }, &[], "goat", None).unwrap();
     let meat_addr = app.instantiate_contract(meat_id, Addr::unchecked("owner"), &MeatInstantiate { goat_contract: goat_addr.to_string() }, &[], "meat", None).unwrap();
 
-    app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::MintWithNative {}, &[coin(1000, "ucosm")]).unwrap();
+    let resp = app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::MintWithNative {}, &[coin(1000, "ucosm")]).unwrap();
+    assert!(resp.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "MintedWithNative")));
     let bal: BalanceResponse = app.wrap().query_wasm_smart(meat_addr, &MeatQuery::Balance { address: "user".into() }).unwrap();
     assert_eq!(bal.balance, Uint128::new(100));
 }

--- a/wasm-contracts/meat/tests/swap.rs
+++ b/wasm-contracts/meat/tests/swap.rs
@@ -29,12 +29,14 @@ fn swap_meat_and_goat() {
     app.execute_contract(Addr::unchecked("owner"), meat_addr.clone(), &MeatExecute::Transfer { recipient: "user".into(), amount: Uint128::new(1000) }, &[]).unwrap();
 
     app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::Approve { spender: meat_addr.to_string(), amount: Uint128::new(1000) }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::SwapMeatForGoat { meat_amount: Uint128::new(1000) }, &[]).unwrap();
+    let swap1 = app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::SwapMeatForGoat { meat_amount: Uint128::new(1000) }, &[]).unwrap();
+    assert!(swap1.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "SwappedMEATForGOAT")));
     let goat_bal: goat_msg::BalanceResponse = app.wrap().query_wasm_smart(goat_addr.clone(), &goat_msg::QueryMsg::Balance { address: "user".into() }).unwrap();
     assert_eq!(goat_bal.balance, Uint128::new(1000 / 85));
 
     app.execute_contract(Addr::unchecked("user"), goat_addr.clone(), &goat_msg::ExecuteMsg::Approve { spender: meat_addr.to_string(), amount: goat_bal.balance }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::SwapGoatForMeat { goat_amount: goat_bal.balance }, &[]).unwrap();
+    let swap2 = app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::SwapGoatForMeat { goat_amount: goat_bal.balance }, &[]).unwrap();
+    assert!(swap2.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "SwappedGOATForMEAT")));
     let meat_bal: BalanceResponse = app.wrap().query_wasm_smart(meat_addr, &MeatQuery::Balance { address: "user".into() }).unwrap();
     assert!(meat_bal.balance > Uint128::zero());
 }

--- a/wasm-contracts/starter/src/lib.rs
+++ b/wasm-contracts/starter/src/lib.rs
@@ -174,7 +174,10 @@ fn execute_stake(deps: DepsMut, env: Env, info: MessageInfo, amount: Uint128) ->
     add_balance(deps.storage, &env.contract.address, amount)?;
     STAKING_BALANCE.update(deps.storage, &info.sender, |b| -> StdResult<_> { Ok(b.unwrap_or_default() + amount) })?;
     LAST_STAKED_TIME.save(deps.storage, &info.sender, &env.block.time.seconds())?;
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "Staked")
+        .add_attribute("user", info.sender)
+        .add_attribute("amount", amount))
 }
 
 fn execute_emergency_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
@@ -200,7 +203,10 @@ fn execute_emergency_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdR
         let supply = TOTAL_SUPPLY.load(deps.storage)? + diff;
         TOTAL_SUPPLY.save(deps.storage, &supply)?;
     }
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "EmergencyUnstaked")
+        .add_attribute("user", info.sender)
+        .add_attribute("amount", staked))
 }
 
 fn execute_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
@@ -232,7 +238,11 @@ fn execute_unstake(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Resp
         let supply = TOTAL_SUPPLY.load(deps.storage)? + diff;
         TOTAL_SUPPLY.save(deps.storage, &supply)?;
     }
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "Unstaked")
+        .add_attribute("user", info.sender)
+        .add_attribute("amount", staked)
+        .add_attribute("reward", reward))
 }
 
 fn execute_claim_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
@@ -261,7 +271,10 @@ fn execute_claim_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult
         TOTAL_SUPPLY.save(deps.storage, &supply)?;
     }
     LAST_STAKED_TIME.save(deps.storage, &info.sender, &env.block.time.seconds())?;
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "RewardClaimed")
+        .add_attribute("user", info.sender)
+        .add_attribute("amount", reward))
 }
 
 fn execute_compound_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
@@ -284,7 +297,10 @@ fn execute_compound_reward(deps: DepsMut, env: Env, info: MessageInfo) -> StdRes
     }
     STAKING_BALANCE.update(deps.storage, &info.sender, |b| -> StdResult<_> { Ok(b.unwrap_or_default() + reward) })?;
     LAST_STAKED_TIME.save(deps.storage, &info.sender, &env.block.time.seconds())?;
-    Ok(Response::new())
+    Ok(Response::new()
+        .add_attribute("action", "Compounded")
+        .add_attribute("user", info.sender)
+        .add_attribute("amount", reward))
 }
 
 #[entry_point]

--- a/wasm-contracts/starter/tests/goat.rs
+++ b/wasm-contracts/starter/tests/goat.rs
@@ -46,9 +46,11 @@ fn stake_and_claim() {
     ).unwrap();
     // mint and stake
     app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
+    let resp = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
+    assert!(resp.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "Staked")));
     app.update_block(|b| b.time = b.time.plus_seconds(1));
-    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::ClaimReward {}, &[]).unwrap();
+    let claim_res = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::ClaimReward {}, &[]).unwrap();
+    assert!(claim_res.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "RewardClaimed")));
     let bal: BalanceResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::Balance { address: "staker".into() }).unwrap();
     assert_eq!(bal.balance, Uint128::new(100));
 }
@@ -63,7 +65,8 @@ fn stake_and_compound() {
         &[]
     ).unwrap();
     app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
+    let stake_res = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
+    assert!(stake_res.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "Staked")));
     app.update_block(|b| b.time = b.time.plus_seconds(1));
     app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::CompoundReward {}, &[]).unwrap();
     let staking: StakingInfoResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::StakingBalance { address: "staker".into() }).unwrap();
@@ -82,7 +85,8 @@ fn stake_and_unstake() {
     app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
     app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
     app.update_block(|b| b.time = b.time.plus_seconds(1));
-    app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Unstake {}, &[]).unwrap();
+    let unstake_res = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Unstake {}, &[]).unwrap();
+    assert!(unstake_res.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "Unstaked")));
     let bal: BalanceResponse = app.wrap().query_wasm_smart(addr.clone(), &QueryMsg::Balance { address: "staker".into() }).unwrap();
     assert_eq!(bal.balance, Uint128::new(200));
 }


### PR DESCRIPTION
## Summary
- emit wasm events for starter and meat contracts
- check emitted events in cw-multi-test integration tests

## Testing
- `cargo test --manifest-path wasm-contracts/starter/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/meat/Cargo.toml`
- `yes | npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68426fecb01c8325b11b860442c396f5