### PR TITLE
Update GoatNFT weight handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,13 @@ Struktur dan hubungan antar kontrak:
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint, memungkinkan penukaran MEAT ↔ GOAT, dan mengontrol fitur swap.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
-  Metadata tiap token dikemas dalam struct `GoatData` (menyimpan `nfcId` bertipe
-  `string`, `breed`, `birthYear`, `weight`, dan `mintedAt`) dan disimpan pada
-  mapping `goatMetadata`. Fungsi `mint` menerima kelima data tersebut; data dapat
-  dibaca ulang melalui `getGoatData` dan dihapus saat
-  `burn`.
+  Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
+  `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.
+  Pemilik dapat memperbarui berat melalui `updateWeight`; berat terakhir harus
+  masih valid (<=7 hari) saat dibakar. Fungsi `burn` memverifikasi syarat ini dan
+  memancarkan event `GoatBurned` berisi berat terkini dan jumlah GOAT yang harus
+  dicetak eksternal. Data dapat dibaca ulang melalui `getGoatData` dan dihapus
+  setelah `burn`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
   untuk dipanggil MEAT saat membutuhkan GOAT baru.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test

--- a/architecture.md
+++ b/architecture.md
@@ -6,7 +6,7 @@ This project revolves around two ERC20 contracts – **GOAT** and **MEAT** – d
 
 * **GOAT (`contracts/GOAT.sol`)** – provides staking with time‑based rewards, the ability for the MEAT contract to mint new supply and various owner controls (reward settings, MEAT address).
 * **MEAT (`contracts/MEAT.sol`)** – mints tokens when receiving native currency (using a `DepositRate` measured per 1000 units), swaps MEAT to and from GOAT, controls swap availability and deposit rate and can withdraw collected native tokens.
-* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`) and tracks a redeemable value in `goatValue`. GOAT's `burnAndMint` burns the NFT and mints the same amount of GOAT to its owner.
+* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Owners may call `updateWeight` to keep the value current. `burn` requires the weight to have been updated in the last 7 days and emits `GoatBurned` so external logic can mint the correct amount of GOAT.
 * **Interfaces and mocks** – `IGOAT` defines the minting hook used by MEAT and `FailingGOAT` is a test helper for simulating failed transfers.
 
 ## Backend

--- a/contract-map.md
+++ b/contract-map.md
@@ -21,7 +21,7 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 |---------|-------------|---------------|
 | GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
-| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). | `mint`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Weight can be updated via `updateWeight` and must be fresh when burning. Burning emits `GoatBurned` for off-chain GOAT minting. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |
 
 GOAT emits `MeatAddressUpdated` and `NftAddressUpdated` whenever the owner updates

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -6,9 +6,11 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 /// @title GoatNFT - tokenized goat identification
 /// @notice Each NFT holds a value redeemable for GOAT tokens
+/// @dev Enforces fresh weight updates before burning so GOAT minted matches the actual commodity value.
 contract GoatNFT is ERC721Burnable {
     uint256 public nextId;
     mapping(uint256 => uint256) public goatValue;
+
     struct GoatData {
         string nfcId;
         string breed;
@@ -16,8 +18,14 @@ contract GoatNFT is ERC721Burnable {
         uint256 weight;
         uint256 mintedAt;
     }
+
     mapping(uint256 => GoatData) public goatMetadata;
+    mapping(uint256 => uint256) public lastWeightUpdateAt;
+
     address private immutable _owner;
+
+    /// @notice Weight update validity window in seconds (7 days)
+    uint256 public constant WEIGHT_UPDATE_VALIDITY = 7 days;
 
     constructor() ERC721("Goat Identifier", "GOATNFT") {
         _owner = msg.sender;
@@ -40,16 +48,42 @@ contract GoatNFT is ERC721Burnable {
         uint256 tokenId = ++nextId;
         goatValue[tokenId] = value;
         goatMetadata[tokenId] = GoatData(nfcId, breed, birthYear, weight, block.timestamp);
+        lastWeightUpdateAt[tokenId] = block.timestamp;
         _mint(to, tokenId);
         return tokenId;
+    }
+
+    /// @notice Update the goat's latest weight
+    /// @param tokenId ID of the NFT to update
+    /// @param newWeight New weight value in kilograms
+    function updateWeight(uint256 tokenId, uint256 newWeight) external {
+        address tokenOwner = ownerOf(tokenId);
+        require(msg.sender == tokenOwner, "Not token owner");
+        require(newWeight > 0, "Weight must be > 0");
+
+        goatValue[tokenId] = newWeight;
+        goatMetadata[tokenId].weight = newWeight;
+        lastWeightUpdateAt[tokenId] = block.timestamp;
     }
 
     function burn(uint256 tokenId) public override {
         address tokenOwner = ownerOf(tokenId);
         require(_isAuthorized(tokenOwner, msg.sender, tokenId), "Not owner");
+        require(
+            block.timestamp - lastWeightUpdateAt[tokenId] <= WEIGHT_UPDATE_VALIDITY,
+            "Weight update too old"
+        );
+
+        uint256 currentWeight = goatValue[tokenId];
+        require(currentWeight > 0, "Invalid weight");
+
+        uint256 goatAmount = (currentWeight * 1e18) / 85;
+        emit GoatBurned(tokenId, tokenOwner, currentWeight, goatAmount);
+
         super.burn(tokenId);
         delete goatValue[tokenId];
         delete goatMetadata[tokenId];
+        delete lastWeightUpdateAt[tokenId];
     }
 
     function getGoatData(uint256 tokenId) external view returns (GoatData memory) {
@@ -59,4 +93,7 @@ contract GoatNFT is ERC721Burnable {
     function owner() external view returns (address) {
         return _owner;
     }
+
+    /// @notice Emitted when NFT is burned and GOAT token should be minted externally
+    event GoatBurned(uint256 indexed tokenId, address indexed user, uint256 weight, uint256 goatAmount);
 }

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -8,8 +8,8 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
 2. **Swapping**
    * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The fixed conversion constant `SwapRate` maintains proportional supply.
 3. **GoatNFTs**
-   * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its value in `goatValue`.
-   * By calling `burnAndMint` on `GOAT.sol`, the NFT is burned and the same amount of GOAT is minted to the owner.
+   * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its current weight in `goatValue`.
+   * Owners may update the weight anytime. Before `burnAndMint` is executed the weight must have been updated within the last seven days. `burn` emits `GoatBurned` so off-chain logic can mint GOAT tokens matching the weight.
 4. **Staking GOAT**
    * GOAT holders stake tokens in `GOAT.sol` which records staking balances and timestamps. Rewards accrue linearly according to `rewardRate` and `rewardInterval`.
    *Calling `stake()` again resets `lastStakedTime` and discards any pending reward. Claim your reward first if you plan to restake.*

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -24,24 +24,48 @@ describe("GoatNFT burn and GOAT mint", function () {
     const breed = "Boer";
     const birthYear = 2021;
     const weight = 70;
-    const tx = await nft.mint(user.address, value, nfcId, breed, birthYear, weight);
+    const tx = await nft.mint(
+      user.address,
+      value,
+      nfcId,
+      breed,
+      birthYear,
+      weight
+    );
     const receipt = await tx.wait();
-    const tokenId = receipt.logs[0].args[2]; // Transfer event
+    const tokenId = receipt.logs[0].args[2];
+
+    // owner updates weight before burning
+    const newWeight = 80n;
+    await nft.connect(user).updateWeight(tokenId, newWeight);
 
     const stored = await nft.getGoatData(tokenId);
-    expect(stored.nfcId).to.equal(nfcId);
-    expect(stored.breed).to.equal(breed);
-    expect(stored.birthYear).to.equal(birthYear);
-    expect(stored.weight).to.equal(weight);
-    expect(stored.mintedAt).to.be.gt(0);
+    expect(stored.weight).to.equal(newWeight);
 
     await nft.connect(user).approve(goat.target, tokenId);
-    await expect(goat.connect(user).burnAndMint(tokenId)).to.not.be.reverted;
 
-    const afterBurn = await nft.getGoatData(tokenId);
-    expect(afterBurn.nfcId).to.equal("");
-  
-    expect(await goat.balanceOf(user.address)).to.equal(value);
+    const goatAmount = (newWeight * 10n ** 18n) / 85n;
+    await expect(goat.connect(user).burnAndMint(tokenId))
+      .to.emit(nft, "GoatBurned")
+      .withArgs(tokenId, user.address, newWeight, goatAmount);
+
+    expect(await goat.balanceOf(user.address)).to.equal(newWeight);
     await expect(nft.ownerOf(tokenId)).to.be.reverted;
+  });
+
+  it("reverts burn when weight update is stale", async function () {
+    const value = ethers.parseEther("2");
+    const tx = await nft.mint(user.address, value, "n", "b", 2020, 60);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+
+    // fast forward beyond validity window
+    await ethers.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
+
+    await nft.connect(user).approve(goat.target, tokenId);
+    await expect(goat.connect(user).burnAndMint(tokenId)).to.be.revertedWith(
+      "Weight update too old"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- enforce weight freshness for GoatNFT burns
- emit `GoatBurned` event with GOAT amount to mint
- document the updated NFT flow
- test weight updates and burn restrictions

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68430453ddf083259b4027f35788283b