### PR TITLE
codex/update-goatnft-burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,28 +210,18 @@ Struktur dan hubungan antar kontrak:
   Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.
   Pemilik dapat memperbarui berat melalui `updateWeight`; berat terakhir harus
-  masih valid (<=7 hari) saat dibakar. Fungsi `burn` memverifikasi syarat ini dan
-  memancarkan event `GoatBurned` berisi berat terkini dan jumlah GOAT yang harus
-  dicetak eksternal. Data dapat dibaca ulang melalui `getGoatData` dan dihapus
-  setelah `burn`.
+  masih valid (<=7 hari) saat dibakar. Fungsi `burn` kini memanggil kontrak GOAT untuk mencetak token otomatis dan memancarkan event `GoatBurned` berisi jumlah GOAT yang dicetak. Data dapat dibaca ulang melalui `getGoatData` dan dihapus setelah `burn`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
-  untuk dipanggil MEAT saat membutuhkan GOAT baru.
+  untuk dipanggil MEAT saat membutuhkan GOAT baru. `IGoatToken` dipakai GoatNFT agar kontrak GOAT dapat mencetak token saat NFT dibakar.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test
   guna mensimulasikan kegagalan `transfer`.
-- `burnAndMint` pada GOAT memungkinkan pemilik `GoatNFT` menukar NFT mereka
-  menjadi token GOAT setara nilai `goatValue`. Sebelum memanggil fungsi ini
-  pemilik harus `approve` token tersebut ke kontrak GOAT. Fungsi kemudian
-  memanggil `burn` di `GoatNFT` dan mencetak jumlah GOAT yang sama ke alamat
-  pemilik.
 - `emergencyUnstake` memungkinkan penarikan token yang di-stake tanpa reward kapan saja.
 
 ### Contoh Penggunaan
 
 ```solidity
 // asumsikan "nft" dan "goat" sudah terdeploy
-nft.approve(goatAddress, tokenId);
-goat.burnAndMint(tokenId);
-```
+nft.burn(tokenId);
 
 Alur panggilan eksternal–internal secara ringkas:
 1. `swapMEATForGOAT` memanggil `transferFrom` MEAT dan `mintTo` GOAT jika saldo

--- a/architecture.md
+++ b/architecture.md
@@ -6,7 +6,7 @@ This project revolves around two ERC20 contracts – **GOAT** and **MEAT** – d
 
 * **GOAT (`contracts/GOAT.sol`)** – provides staking with time‑based rewards, the ability for the MEAT contract to mint new supply and various owner controls (reward settings, MEAT address).
 * **MEAT (`contracts/MEAT.sol`)** – mints tokens when receiving native currency (using a `DepositRate` measured per 1000 units), swaps MEAT to and from GOAT, controls swap availability and deposit rate and can withdraw collected native tokens.
-* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Owners may call `updateWeight` to keep the value current. `burn` requires the weight to have been updated in the last 7 days and emits `GoatBurned` so external logic can mint the correct amount of GOAT.
+* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Owners may call `updateWeight` to keep the value current. `burn` requires the weight to have been updated in the last 7 days, mints GOAT automatically and emits `GoatBurned`.
 * **Interfaces and mocks** – `IGOAT` defines the minting hook used by MEAT and `FailingGOAT` is a test helper for simulating failed transfers.
 
 ## Backend

--- a/contract-map.md
+++ b/contract-map.md
@@ -15,14 +15,16 @@
   - `emergencyUnstake` allows stakers to withdraw tokens without rewards at any time.
 * **FailingGOAT** is only for testing; it implements the same interface but allows simulated transfer failures.
 * **IGOAT** defines the `mintTo` function which enables MEAT to mint GOAT when necessary.
+* **IGoatToken** is used by GoatNFT so the GOAT contract can mint upon burn.
 
 The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for GOAT. Both share the same owner who can manage rates and enable or disable swapping. The table below summarises the main contracts and their roles.
 | Contract | Description | Key Functions |
 |---------|-------------|---------------|
-| GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `burnAndMint`, `setMEATAddress`, `setNFTAddress` |
+| GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `mint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
-| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Weight can be updated via `updateWeight` and must be fresh when burning. Burning emits `GoatBurned` for off-chain GOAT minting. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Weight can be updated via `updateWeight` and must be fresh when burning. Burning mints GOAT automatically and emits `GoatBurned`. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |
+| IGoatToken | Interface for GOAT minting used by GoatNFT. | `mint` |
 
 GOAT emits `MeatAddressUpdated` and `NftAddressUpdated` whenever the owner updates
 the linked MEAT or GoatNFT contract addresses.

--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.29;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { IGoatNFT } from "./interfaces/IGoatNFT.sol";
 
 /// @title GOAT Token - Guardian of Organic Agriculture Trust
 /// @notice A smart contract enabling staking, compounding, and minting by MEAT contract
-contract GOAT is ERC20 { address private immutable _owner;
+contract GOAT is ERC20 {
+    address private immutable _owner;
 
 event RewardConfigChanged(
     uint256 oldRate,
@@ -64,17 +64,13 @@ function mintTo(address to, uint256 amount) external {
     require(msg.sender == meatContract, "Unauthorized mint");
     _mint(to, amount);
 }
-/// @notice Burn a Goat NFT to receive GOAT tokens
-/// @dev The GoatNFT contract must be trusted; a malicious contract could reenter
-///      or change the token's value during burn.
-/// @param tokenId ID of the NFT to burn
-function burnAndMint(uint256 tokenId) external {
-    require(nftContract != address(0), "NFT not set");
-    IGoatNFT nft = IGoatNFT(nftContract);
-    require(nft.ownerOf(tokenId) == msg.sender, "Not token owner");
-    uint256 amount = nft.goatValue(tokenId); // store before burn (Checks-Effects-Interactions)
-    nft.burn(tokenId);
-    _mint(msg.sender, amount);
+
+/// @notice Mint tokens when a GoatNFT is burned
+/// @param to Recipient of minted GOAT
+/// @param amount Amount to mint
+function mint(address to, uint256 amount) external {
+    require(msg.sender == nftContract, "Unauthorized mint");
+    _mint(to, amount);
 }
 /// @notice Stake GOAT tokens to earn rewards
 /// @param amount The amount of GOAT tokens to stake

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {IGoatToken} from "./interfaces/IGoatToken.sol";
 
 /// @title GoatNFT - tokenized goat identification
 /// @notice Each NFT holds a value redeemable for GOAT tokens
@@ -23,17 +24,23 @@ contract GoatNFT is ERC721Burnable {
     mapping(uint256 => uint256) public lastWeightUpdateAt;
 
     address private immutable _owner;
+    IGoatToken public goatTokenContract;
 
     /// @notice Weight update validity window in seconds (7 days)
     uint256 public constant WEIGHT_UPDATE_VALIDITY = 7 days;
 
-    constructor() ERC721("Goat Identifier", "GOATNFT") {
+    constructor(address goatTokenAddress) ERC721("Goat Identifier", "GOATNFT") {
         _owner = msg.sender;
+        goatTokenContract = IGoatToken(goatTokenAddress);
     }
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
         _;
+    }
+
+    function setGoatTokenContract(address goatTokenAddress) external onlyOwner {
+        goatTokenContract = IGoatToken(goatTokenAddress);
     }
 
     function mint(
@@ -78,6 +85,10 @@ contract GoatNFT is ERC721Burnable {
         require(currentWeight > 0, "Invalid weight");
 
         uint256 goatAmount = (currentWeight * 1e18) / 85;
+
+        // Mint GOAT tokens directly to the token owner
+        goatTokenContract.mint(tokenOwner, goatAmount);
+
         emit GoatBurned(tokenId, tokenOwner, currentWeight, goatAmount);
 
         super.burn(tokenId);
@@ -94,6 +105,6 @@ contract GoatNFT is ERC721Burnable {
         return _owner;
     }
 
-    /// @notice Emitted when NFT is burned and GOAT token should be minted externally
+    /// @notice Emitted when NFT is burned and GOAT token minted automatically
     event GoatBurned(uint256 indexed tokenId, address indexed user, uint256 weight, uint256 goatAmount);
 }

--- a/contracts/interfaces/IGoatToken.sol
+++ b/contracts/interfaces/IGoatToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+/// @title Interface for GOAT token minting by GoatNFT
+interface IGoatToken {
+    /// @notice Mint tokens to `to`
+    /// @param to recipient address
+    /// @param amount amount of GOAT tokens
+    function mint(address to, uint256 amount) external;
+}

--- a/docs/frontend-pages.md
+++ b/docs/frontend-pages.md
@@ -29,7 +29,7 @@ This document summarises the main pages expected in the full UI and how they map
 
 ## `/burn`
 *Overview*: burn a `GoatNFT` to redeem its value in GOAT tokens.
-- **User Inputs**: NFT `tokenId` to burn (requires prior `approve` to the GOAT contract).
-- **Contract Calls**: `burnAndMint(tokenId)` on `GOAT.sol` which calls `burn` on `GoatNFT` and mints equivalent GOAT.
+- **User Inputs**: NFT `tokenId` to burn.
+- **Contract Calls**: `burn(tokenId)` on `GoatNFT` which internally mints equivalent GOAT.
 
 These pages align with the flows tested under `test/` such as `stakingSwap.test.js` and `nftBurnMint.test.js`, ensuring UI actions correspond to on-chain behaviour.

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -9,7 +9,7 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The fixed conversion constant `SwapRate` maintains proportional supply.
 3. **GoatNFTs**
    * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its current weight in `goatValue`.
-   * Owners may update the weight anytime. Before `burnAndMint` is executed the weight must have been updated within the last seven days. `burn` emits `GoatBurned` so off-chain logic can mint GOAT tokens matching the weight.
+   * Owners may update the weight anytime. Before burning the NFT the weight must have been updated within the last seven days. `burn` mints GOAT automatically and emits `GoatBurned`.
 4. **Staking GOAT**
    * GOAT holders stake tokens in `GOAT.sol` which records staking balances and timestamps. Rewards accrue linearly according to `rewardRate` and `rewardInterval`.
    *Calling `stake()` again resets `lastStakedTime` and discards any pending reward. Claim your reward first if you plan to restake.*

--- a/test/addressSetter.test.js
+++ b/test/addressSetter.test.js
@@ -15,7 +15,7 @@ describe("Setter address validation", function () {
     await meat.waitForDeployment();
 
     const GoatNFT = await ethers.getContractFactory("GoatNFT");
-    nft = await GoatNFT.deploy();
+    nft = await GoatNFT.deploy(goat.target);
     await nft.waitForDeployment();
   });
 

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -12,7 +12,7 @@ describe("GoatNFT burn and GOAT mint", function () {
     await goat.waitForDeployment();
 
     const GoatNFT = await ethers.getContractFactory("GoatNFT");
-    nft = await GoatNFT.deploy();
+    nft = await GoatNFT.deploy(goat.target);
     await nft.waitForDeployment();
 
     await goat.setNFTAddress(nft.target);
@@ -42,14 +42,12 @@ describe("GoatNFT burn and GOAT mint", function () {
     const stored = await nft.getGoatData(tokenId);
     expect(stored.weight).to.equal(newWeight);
 
-    await nft.connect(user).approve(goat.target, tokenId);
-
     const goatAmount = (newWeight * 10n ** 18n) / 85n;
-    await expect(goat.connect(user).burnAndMint(tokenId))
+    await expect(nft.connect(user).burn(tokenId))
       .to.emit(nft, "GoatBurned")
       .withArgs(tokenId, user.address, newWeight, goatAmount);
 
-    expect(await goat.balanceOf(user.address)).to.equal(newWeight);
+    expect(await goat.balanceOf(user.address)).to.equal(goatAmount);
     await expect(nft.ownerOf(tokenId)).to.be.reverted;
   });
 
@@ -63,8 +61,7 @@ describe("GoatNFT burn and GOAT mint", function () {
     await ethers.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
     await ethers.provider.send("evm_mine", []);
 
-    await nft.connect(user).approve(goat.target, tokenId);
-    await expect(goat.connect(user).burnAndMint(tokenId)).to.be.revertedWith(
+    await expect(nft.connect(user).burn(tokenId)).to.be.revertedWith(
       "Weight update too old"
     );
   });

--- a/test/nftOwner.test.js
+++ b/test/nftOwner.test.js
@@ -2,12 +2,16 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("GoatNFT owner restrictions", function () {
-  let owner, nonOwner, nft;
+  let owner, nonOwner, nft, goat;
 
   beforeEach(async function () {
     [owner, nonOwner] = await ethers.getSigners();
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
     const GoatNFT = await ethers.getContractFactory("GoatNFT");
-    nft = await GoatNFT.deploy();
+    nft = await GoatNFT.deploy(goat.target);
     await nft.waitForDeployment();
   });
 


### PR DESCRIPTION
## Summary
- auto-mint GOAT tokens when burning GoatNFTs
- add IGoatToken interface and allow GOAT contract to mint from NFT
- adjust tests for new GoatNFT constructor and burn flow
- document updated burn behaviour across README and docs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68430af994c883259a4cf8e38656610d