### PR TITLE
codex/meat-redemption

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Berikut gambaran umum alur penggunaan kedua token:
 3. **Stake GOAT** – Pemegang GOAT dapat memanggil `stake(amount)` pada kontrak GOAT untuk mulai memperoleh reward. Besarnya reward dihitung linier berdasarkan `rewardRate` dengan periode akrual `rewardInterval`.
    *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
+5. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
 
 ## Deployment
 

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -22,6 +22,7 @@ contract MEAT is ERC20 {
     event SwappedGOATForMEAT(address indexed user, uint256 goatIn, uint256 meatOut);
     event SwappedMEATForGOAT(address indexed user, uint256 meatIn, uint256 goatOut);
     event InitialSupplyMinted(address indexed to, uint256 amount);
+    event MeatRedeemed(address indexed user, uint256 amount);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
@@ -108,6 +109,12 @@ contract MEAT is ERC20 {
         }
         GOAT.transfer(msg.sender, goatAmount);
         emit SwappedMEATForGOAT(msg.sender, meatAmount, goatAmount);
+    }
+
+    function redeemForMeat(uint256 amount) external {
+        require(amount > 0, "Amount must be > 0");
+        _burn(msg.sender, amount);
+        emit MeatRedeemed(msg.sender, amount);
     }
 
     function setSwapEnabled(bool status) external onlyOwner {

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -17,5 +17,7 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * After `minClaimInterval` stakers may claim rewards or compound them back into the stake. If they choose to exit entirely they call `unstake` to receive the principal plus reward.
 6. **Returning to MEAT**
    * Unstaked GOAT can be swapped back for MEAT which may then be withdrawn from the ecosystem or used again for future interactions.
+7. **Redeeming MEAT**
+   * Holders burn their MEAT using `redeemForMeat(amount)` which emits `MeatRedeemed` for off-chain processing and delivery of physical meat.
 
 This lifecycle ensures that every stage of participation is backed by explicit contract functions and transparent token flows.

--- a/test/meat.test.js
+++ b/test/meat.test.js
@@ -40,4 +40,25 @@ describe("MEAT", function () {
       meat.connect(user).swapMEATForGOAT(meatAmount)
     ).to.be.revertedWith("Transfer failed");
   });
+
+  it("should burn tokens on redeem", async function () {
+    const [owner, user] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    const goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const meat = await MEAT.deploy(goat.target);
+    await meat.waitForDeployment();
+
+    const amount = ethers.parseEther("50");
+    await meat.transfer(user.address, amount);
+
+    await expect(meat.connect(user).redeemForMeat(amount))
+      .to.emit(meat, "MeatRedeemed")
+      .withArgs(user.address, amount);
+
+    expect(await meat.balanceOf(user.address)).to.equal(0n);
+  });
 });


### PR DESCRIPTION
## Summary
- extend MEAT token with `redeemForMeat` burn function
- test MEAT redemption and burning
- document redemption flow in README
- update lifecycle docs with redemption step

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684310197f3883259452c29e3c434395