### PR TITLE
Add burn & redeem flow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Berikut gambaran umum alur penggunaan kedua token:
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
 5. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
 
+## Burn & Redeem Flow
+
+Diagram sederhana berikut menjelaskan jalur dari kambing hidup hingga daging siap tebus:
+
+```text
+GoatNFT burn --(weight / 85)--> GOAT --(SwapRate)--> MEAT --redeemForMeat--> Real Meat
+```
+
+- Membakar `GoatNFT` otomatis mencetak GOAT sejumlah `weight / 85`.
+- GOAT dapat ditukar dengan MEAT atau sebaliknya menggunakan `SwapRate` yang sama persis dengan fungsi swap pada kontrak.
+- Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**.
+
 ## Deployment
 
 1. Install [Hardhat](https://hardhat.org/) and initialise a project:

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -20,4 +20,6 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
 7. **Redeeming MEAT**
    * Holders burn their MEAT using `redeemForMeat(amount)` which emits `MeatRedeemed` for off-chain processing and delivery of physical meat.
 
+For a concise diagram of this burn and redemption path, see the section [Burn & Redeem Flow](README.md#burn--redeem-flow) in the README.
+
 This lifecycle ensures that every stage of participation is backed by explicit contract functions and transparent token flows.


### PR DESCRIPTION
## Summary
- document burn and redeem flow in README
- cross-reference the diagram in goat-meat-lifecycle
- clarify that 1 MEAT equals 1 KG of real meat

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6843115bbd0083259928ba0443d5980e