### PR TITLE
codex/goat-address-updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Perubahan alamat penting pada kontrak GOAT dapat dipantau melalui dua event:
 - `MeatAddressUpdated(oldAddress, newAddress)` dicatat ketika pemilik mengganti
   alamat kontrak MEAT.
 - `NftAddressUpdated(oldAddress, newAddress)` dicatat saat alamat GoatNFT diubah.
+- `GoatAddressUpdated(oldAddress, newAddress)` dicatat ketika alamat GOAT pada kontrak MEAT diubah.
 
 MEAT juga memunculkan event utama berikut:
 

--- a/contract-map.md
+++ b/contract-map.md
@@ -28,3 +28,4 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 
 GOAT emits `MeatAddressUpdated` and `NftAddressUpdated` whenever the owner updates
 the linked MEAT or GoatNFT contract addresses.
+MEAT emits `GoatAddressUpdated` whenever the owner updates the linked GOAT contract address.

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -23,6 +23,7 @@ contract MEAT is ERC20 {
     event SwappedMEATForGOAT(address indexed user, uint256 meatIn, uint256 goatOut);
     event InitialSupplyMinted(address indexed to, uint256 amount);
     event MeatRedeemed(address indexed user, uint256 amount);
+    event GoatAddressUpdated(address indexed oldAddress, address indexed newAddress);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
@@ -123,7 +124,9 @@ contract MEAT is ERC20 {
 
     function setGOATAddress(address goatAddress) external onlyOwner {
         require(goatAddress != address(0), "Invalid address");
+        address old = address(GOAT);
         GOAT = IGOAT(goatAddress);
+        emit GoatAddressUpdated(old, goatAddress);
     }
 
     function owner() external view returns (address) {

--- a/test/addressSetter.test.js
+++ b/test/addressSetter.test.js
@@ -66,4 +66,14 @@ describe("Setter address validation", function () {
       .to.emit(goat, "NftAddressUpdated")
       .withArgs(ethers.ZeroAddress, nft.target);
   });
+
+  it("emits GoatAddressUpdated when GOAT address changes", async function () {
+    const GOAT = await ethers.getContractFactory("GOAT");
+    const newGoat = await GOAT.deploy(owner.address);
+    await newGoat.waitForDeployment();
+
+    await expect(meat.setGOATAddress(newGoat.target))
+      .to.emit(meat, "GoatAddressUpdated")
+      .withArgs(goat.target, newGoat.target);
+  });
 });


### PR DESCRIPTION
## Summary
- add `GoatAddressUpdated` event in MEAT token
- emit it in `setGOATAddress`
- test the event emission
- document new event in README and contract map

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68436b9f607c83258cd4954af3586a2d