### PR TITLE
Add WeightUpdated event and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Struktur dan hubungan antar kontrak:
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
   Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.
-  Pemilik dapat memperbarui berat melalui `updateWeight`; berat terakhir harus
+  Pemilik dapat memperbarui berat melalui `updateWeight` (memancarkan `WeightUpdated`); berat terakhir harus
   masih valid (<=7 hari) saat dibakar. Fungsi `burn` kini memanggil kontrak GOAT untuk mencetak token otomatis dan memancarkan event `GoatBurned` berisi jumlah GOAT yang dicetak. Data dapat dibaca ulang melalui `getGoatData` dan dihapus setelah `burn`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
   untuk dipanggil MEAT saat membutuhkan GOAT baru. `IGoatToken` dipakai GoatNFT agar kontrak GOAT dapat mencetak token saat NFT dibakar.

--- a/architecture.md
+++ b/architecture.md
@@ -6,7 +6,7 @@ This project revolves around two ERC20 contracts – **GOAT** and **MEAT** – d
 
 * **GOAT (`contracts/GOAT.sol`)** – provides staking with time‑based rewards, the ability for the MEAT contract to mint new supply and various owner controls (reward settings, MEAT address).
 * **MEAT (`contracts/MEAT.sol`)** – mints tokens when receiving native currency (using a `DepositRate` measured per 1000 units), swaps MEAT to and from GOAT, controls swap availability and deposit rate and can withdraw collected native tokens.
-* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Owners may call `updateWeight` to keep the value current. `burn` requires the weight to have been updated in the last 7 days, mints GOAT automatically and emits `GoatBurned`.
+* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Owners may call `updateWeight` to keep the value current, emitting `WeightUpdated`. `burn` requires the weight to have been updated in the last 7 days, mints GOAT automatically and emits `GoatBurned`.
 * **Interfaces and mocks** – `IGOAT` defines the minting hook used by MEAT and `FailingGOAT` is a test helper for simulating failed transfers.
 
 ## Backend

--- a/contract-map.md
+++ b/contract-map.md
@@ -22,7 +22,7 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 |---------|-------------|---------------|
 | GOAT | ERC20 staking token minted by MEAT and GoatNFT burns. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `mint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | ERC20 token minted with native deposits and swapped with GOAT. | `swapMEATForGOAT`, `swapGOATForMEAT`, `changeDepositRate`, `withdrawNative`, `setSwapEnabled`, `setGOATAddress` |
-| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Weight can be updated via `updateWeight` and must be fresh when burning. Burning mints GOAT automatically and emits `GoatBurned`. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
+| GoatNFT | ERC721 goat identifier redeemable for GOAT. Metadata stored on-chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Weight can be updated via `updateWeight` (emits `WeightUpdated`) and must be fresh when burning. Burning mints GOAT automatically and emits `GoatBurned`. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | IGOAT | Interface for GOAT minting used by MEAT. | `mintTo` |
 | IGoatToken | Interface for GOAT minting used by GoatNFT. | `mint` |
 

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -71,6 +71,7 @@ contract GoatNFT is ERC721Burnable {
         goatValue[tokenId] = newWeight;
         goatMetadata[tokenId].weight = newWeight;
         lastWeightUpdateAt[tokenId] = block.timestamp;
+        emit WeightUpdated(tokenId, newWeight);
     }
 
     function burn(uint256 tokenId) public override {
@@ -107,4 +108,6 @@ contract GoatNFT is ERC721Burnable {
 
     /// @notice Emitted when NFT is burned and GOAT token minted automatically
     event GoatBurned(uint256 indexed tokenId, address indexed user, uint256 weight, uint256 goatAmount);
+    /// @notice Emitted when the goat weight is updated
+    event WeightUpdated(uint256 indexed tokenId, uint256 newWeight);
 }

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -9,7 +9,7 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The fixed conversion constant `SwapRate` maintains proportional supply.
 3. **GoatNFTs**
    * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its current weight in `goatValue`.
-   * Owners may update the weight anytime. Before burning the NFT the weight must have been updated within the last seven days. `burn` mints GOAT automatically and emits `GoatBurned`.
+   * Owners may update the weight anytime, emitting `WeightUpdated`. Before burning the NFT the weight must have been updated within the last seven days. `burn` mints GOAT automatically and emits `GoatBurned`.
 4. **Staking GOAT**
    * GOAT holders stake tokens in `GOAT.sol` which records staking balances and timestamps. Rewards accrue linearly according to `rewardRate` and `rewardInterval`.
    *Calling `stake()` again resets `lastStakedTime` and discards any pending reward. Claim your reward first if you plan to restake.*

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -51,6 +51,16 @@ describe("GoatNFT burn and GOAT mint", function () {
     await expect(nft.ownerOf(tokenId)).to.be.reverted;
   });
 
+  it("emits WeightUpdated when updating weight", async function () {
+    const tx = await nft.mint(user.address, 1, "tag", "type", 2022, 50);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+
+    await expect(nft.connect(user).updateWeight(tokenId, 55n))
+      .to.emit(nft, "WeightUpdated")
+      .withArgs(tokenId, 55n);
+  });
+
   it("reverts burn when weight update is stale", async function () {
     const value = ethers.parseEther("2");
     const tx = await nft.mint(user.address, value, "n", "b", 2020, 60);


### PR DESCRIPTION
## Summary
- add `WeightUpdated` event in `GoatNFT`
- emit `WeightUpdated` in `updateWeight`
- test event emission when updating weight
- document the new event in README and docs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68436f7911288325a18f0e69c0a92619