### PR TITLE
codex/goat-nft-address-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,13 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
 
 ## Events
 
-Perubahan alamat penting pada kontrak GOAT dapat dipantau melalui dua event:
+Perubahan alamat penting pada kontrak GOAT dan GoatNFT dapat dipantau melalui event berikut:
 
 - `MeatAddressUpdated(oldAddress, newAddress)` dicatat ketika pemilik mengganti
   alamat kontrak MEAT.
 - `NftAddressUpdated(oldAddress, newAddress)` dicatat saat alamat GoatNFT diubah.
 - `GoatAddressUpdated(oldAddress, newAddress)` dicatat ketika alamat GOAT pada kontrak MEAT diubah.
+- `GoatTokenAddressUpdated(oldAddress, newAddress)` dicatat ketika kontrak GoatNFT mengubah alamat GOAT yang dipakai untuk mint.
 
 MEAT juga memunculkan event utama berikut:
 

--- a/contract-map.md
+++ b/contract-map.md
@@ -29,3 +29,4 @@ The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for G
 GOAT emits `MeatAddressUpdated` and `NftAddressUpdated` whenever the owner updates
 the linked MEAT or GoatNFT contract addresses.
 MEAT emits `GoatAddressUpdated` whenever the owner updates the linked GOAT contract address.
+GoatNFT emits `GoatTokenAddressUpdated` whenever the owner updates the GOAT token address it uses for minting.

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -44,7 +44,10 @@ contract GoatNFT is ERC721Burnable {
     }
 
     function setGoatTokenContract(address goatTokenAddress) external onlyOwner {
+        require(goatTokenAddress != address(0), "Invalid address");
+        address old = address(goatTokenContract);
         goatTokenContract = IGoatToken(goatTokenAddress);
+        emit GoatTokenAddressUpdated(old, goatTokenAddress);
     }
 
     function mint(
@@ -109,6 +112,8 @@ contract GoatNFT is ERC721Burnable {
         return _owner;
     }
 
+    /// @notice Emitted when the GOAT token contract address changes
+    event GoatTokenAddressUpdated(address indexed oldAddress, address indexed newAddress);
     /// @notice Emitted when NFT is burned and GOAT token minted automatically
     event GoatBurned(uint256 indexed tokenId, address indexed user, uint256 weight, uint256 goatAmount);
     /// @notice Emitted when the goat weight is updated

--- a/test/addressSetter.test.js
+++ b/test/addressSetter.test.js
@@ -76,4 +76,20 @@ describe("Setter address validation", function () {
       .to.emit(meat, "GoatAddressUpdated")
       .withArgs(goat.target, newGoat.target);
   });
+
+  it("reverts when setting goat token contract to zero", async function () {
+    await expect(
+      nft.setGoatTokenContract(ethers.ZeroAddress)
+    ).to.be.revertedWith("Invalid address");
+  });
+
+  it("emits GoatTokenAddressUpdated when goat token contract changes", async function () {
+    const GOAT = await ethers.getContractFactory("GOAT");
+    const newGoat = await GOAT.deploy(owner.address);
+    await newGoat.waitForDeployment();
+
+    await expect(nft.setGoatTokenContract(newGoat.target))
+      .to.emit(nft, "GoatTokenAddressUpdated")
+      .withArgs(goat.target, newGoat.target);
+  });
 });


### PR DESCRIPTION
## Summary
- validate `setGoatTokenContract` to block zero address
- emit `GoatTokenAddressUpdated` on success
- test address update and revert logic
- document new event in README and contract map

## Testing
- `npm install`
- `npx hardhat compile`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6843e58b716083259c52a8934b5a1e9c