### PR TITLE
Implement unique NFC ID check

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Diagram sederhana berikut menjelaskan jalur dari kambing hidup hingga daging sia
 Berikut langkah detail siklus kambing hingga daging tercatat di ledger:
 
 - Kambing lahir → pencetakan **GoatNFT** dengan `nfcId`, `breed`, `birthYear`, dan `weight` awal.
+- `nfcId` bersifat unik; pencetakan kedua dengan ID sama akan gagal.
 - Pemilik dapat memperbarui berat melalui `updateWeight()` agar nilainya tetap valid (dibutuhkan sebelum burn).
 - NFT (standar ERC721) bebas dipindahtangankan ke pemilik baru.
 - Ketika kambing disembelih, pemilik membakar NFT; kontrak otomatis mencetak GOAT sejumlah `weight / SWAP_RATE`.

--- a/architecture.md
+++ b/architecture.md
@@ -6,7 +6,7 @@ This project revolves around two ERC20 contracts – **GOAT** and **MEAT** – d
 
 * **GOAT (`contracts/GOAT.sol`)** – provides staking with time‑based rewards, the ability for the MEAT contract to mint new supply and various owner controls (reward settings, MEAT address).
 * **MEAT (`contracts/MEAT.sol`)** – mints tokens when receiving native currency (using a `DepositRate` measured per 1000 units), swaps MEAT to and from GOAT, controls swap availability and deposit rate and can withdraw collected native tokens.
-* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Owners may call `updateWeight` to keep the value current, emitting `WeightUpdated`. `burn` requires the weight to have been updated in the last 7 days, mints GOAT automatically and emits `GoatBurned`.
+* **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Each `nfcId` maps to a token ID so duplicates are rejected on mint. Owners may call `updateWeight` to keep the value current, emitting `WeightUpdated`. `burn` requires the weight to have been updated in the last 7 days, mints GOAT automatically and emits `GoatBurned` while clearing the NFC mapping.
 * **Interfaces and mocks** – `IGOAT` defines the minting hook used by MEAT and `FailingGOAT` is a test helper for simulating failed transfers.
 
 ## Backend

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -27,6 +27,7 @@ contract GoatNFT is ERC721Burnable {
 
     mapping(uint256 => GoatData) public goatMetadata;
     mapping(uint256 => uint256) public lastWeightUpdateAt;
+    mapping(bytes32 => uint256) public nfcIdToTokenId;
 
     address private immutable _owner;
     IGoatToken public goatTokenContract;
@@ -59,7 +60,10 @@ contract GoatNFT is ERC721Burnable {
         uint256 birthYear
     ) external onlyOwner returns (uint256) {
         require(weight > 0, "Weight must be > 0");
+        bytes32 hash = keccak256(bytes(nfcId));
+        require(nfcIdToTokenId[hash] == 0, "NFC ID already used");
         uint256 tokenId = ++nextId;
+        nfcIdToTokenId[hash] = tokenId;
         goatValue[tokenId] = weight;
         goatMetadata[tokenId] = GoatData(nfcId, breed, birthYear, weight, block.timestamp);
         lastWeightUpdateAt[tokenId] = block.timestamp;
@@ -92,6 +96,8 @@ contract GoatNFT is ERC721Burnable {
         uint256 currentWeight = goatValue[tokenId];
         require(currentWeight > 0, "Invalid weight");
 
+        bytes32 hash = keccak256(bytes(goatMetadata[tokenId].nfcId));
+
         uint256 goatAmount = (currentWeight * 1e18) / SwapConfig.SWAP_RATE;
 
         // Mint GOAT tokens directly to the token owner
@@ -103,6 +109,7 @@ contract GoatNFT is ERC721Burnable {
         delete goatValue[tokenId];
         delete goatMetadata[tokenId];
         delete lastWeightUpdateAt[tokenId];
+        delete nfcIdToTokenId[hash];
     }
 
     function getGoatData(uint256 tokenId) external view returns (GoatData memory) {

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -76,4 +76,19 @@ describe("GoatNFT burn and GOAT mint", function () {
       "Weight update too old"
     );
   });
+
+  it("reverts when minting with duplicate nfcId", async function () {
+    await nft.mint(user.address, 40, "dup", "Boer", 2022);
+    await expect(
+      nft.mint(user.address, 50, "dup", "Boer", 2022)
+    ).to.be.revertedWith("NFC ID already used");
+  });
+
+  it("allows reusing nfcId after burn", async function () {
+    const tx = await nft.mint(user.address, 30, "reuse", "Boer", 2022);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+    await nft.connect(user).burn(tokenId);
+    await expect(nft.mint(user.address, 35, "reuse", "Boer", 2022)).to.not.be.reverted;
+  });
 });


### PR DESCRIPTION
## Summary
- enforce NFC ID uniqueness in GoatNFT
- document NFC ID uniqueness
- clear NFC registry on burn
- test duplicate and reused IDs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6843ec8f47048325855e9afbfe46a166