### PR TITLE
codex/goat-token-address-tests

### DIFF
--- a/test/addressSetter.test.js
+++ b/test/addressSetter.test.js
@@ -83,6 +83,12 @@ describe("Setter address validation", function () {
     ).to.be.revertedWith("Invalid address");
   });
 
+  it("reverts when non-owner calls setGoatTokenContract", async function () {
+    await expect(
+      nft.connect(nonOwner).setGoatTokenContract(nonOwner.address)
+    ).to.be.revertedWith("Not the owner");
+  });
+
   it("emits GoatTokenAddressUpdated when goat token contract changes", async function () {
     const GOAT = await ethers.getContractFactory("GOAT");
     const newGoat = await GOAT.deploy(owner.address);


### PR DESCRIPTION
## Summary
- test non-owner restriction when updating GOAT token address
- ensure GoatTokenAddressUpdated is emitted on success

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6843f17b9a148325ac457b7f4d7cca0d