### PR TITLE
Integrate RateHandler for dynamic swap rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains two ERC20 tokens:
 Berikut gambaran umum alur penggunaan kedua token:
 
 1. **Mint MEAT** – Kirim native token langsung ke alamat kontrak `MEAT` untuk mencetak token sesuai rasio `DepositRate`. Fungsi `receive()` otomatis memproses dana dan mengirim MEAT ke pengirim. Versi CosmWasm menggunakan pesan `mint_with_native` seperti dijelaskan pada bagian berikutnya.
-2. **Swap MEAT ⇄ GOAT** – Fitur swap aktif jika `swapEnabled` bernilai `true`. Rasio konversi ditentukan oleh konstanta `SWAP_RATE` di `SwapConfig` (default `85`). Fungsi `swapMEATForGOAT` menukar MEAT yang dimiliki pengguna menjadi GOAT, sedangkan `swapGOATForMEAT` melakukan sebaliknya.
+2. **Swap MEAT ⇄ GOAT** – Fitur swap aktif jika `swapEnabled` bernilai `true`. Rasio konversi diambil dari `RateHandler` yang dapat diperbarui secara dinamis, dengan fallback ke `SWAP_RATE` di `SwapConfig` (default `85`). Fungsi `swapMEATForGOAT` menukar MEAT yang dimiliki pengguna menjadi GOAT, sedangkan `swapGOATForMEAT` melakukan sebaliknya.
 3. **Stake GOAT** – Pemegang GOAT dapat memanggil `stake(amount)` pada kontrak GOAT untuk mulai memperoleh reward. Besarnya reward dihitung linier berdasarkan `rewardRate` dengan periode akrual `rewardInterval`.
    *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
@@ -26,16 +26,16 @@ Berikut langkah detail siklus kambing hingga daging tercatat di ledger:
 - `nfcId` bersifat unik; pencetakan kedua dengan ID sama akan gagal.
 - Pemilik dapat memperbarui berat melalui `updateWeight()` agar nilainya tetap valid (dibutuhkan sebelum burn).
 - NFT (standar ERC721) bebas dipindahtangankan ke pemilik baru.
-- Ketika kambing disembelih, pemilik membakar NFT; kontrak otomatis mencetak GOAT sejumlah `weight / SWAP_RATE`.
+- Ketika kambing disembelih, pemilik membakar NFT; kontrak otomatis mencetak GOAT sejumlah `weight / rate` dimana `rate` berasal dari `RateHandler`.
 - GOAT dapat diperdagangkan atau ditukar menjadi MEAT memakai fungsi swap kontrak.
 - MEAT kemudian ditebus sebagai daging nyata sehingga seluruh riwayat ternak tersimpan on-chain.
 
 ```text
-GoatNFT burn --(weight / SWAP_RATE)--> GOAT --(SWAP_RATE)--> MEAT --redeemForMeat--> Real Meat
+GoatNFT burn --(weight / rate)--> GOAT --(rate)--> MEAT --redeemForMeat--> Real Meat
 ```
 
-- Membakar `GoatNFT` otomatis mencetak GOAT sejumlah `weight / SWAP_RATE`.
-- GOAT dapat ditukar dengan MEAT atau sebaliknya menggunakan `SWAP_RATE` yang sama persis dengan fungsi swap pada kontrak.
+- Membakar `GoatNFT` otomatis mencetak GOAT sejumlah `weight / rate`.
+- GOAT dapat ditukar dengan MEAT atau sebaliknya menggunakan rate yang sama dari `RateHandler`.
 - Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**.
 
 ## What is GoatNFT?
@@ -162,7 +162,7 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
 
 ## Parameter Penting
 
-- **SWAP_RATE** – konstanta di `SwapConfig` yang menentukan rasio penukaran antar kedua token. Nilai default `85` berarti 1 GOAT setara dengan 85 MEAT.
+- **SWAP_RATE** – konstanta di `SwapConfig` yang menjadi fallback pada `RateHandler`. Nilai default `85` berarti 1 GOAT setara dengan 85 MEAT.
 - **DepositRate** – rasio pencetakan MEAT ketika menerima native token. Nilai
   dihitung per 1000 unit native token sehingga `100` berarti 100 MEAT untuk 1000
   unit native (0.1 MEAT per 1 unit).

--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { RateHandler } from "./RateHandler.sol";
 
 /// @title GOAT Token - Guardian of Organic Agriculture Trust
 /// @notice A smart contract enabling staking, compounding, and minting by MEAT contract
@@ -24,6 +25,7 @@ event RewardClaimed(address indexed user, uint256 reward);
 event Compounded(address indexed user, uint256 reward);
 event MeatAddressUpdated(address indexed oldAddress, address indexed newAddress);
 event NftAddressUpdated(address indexed oldAddress, address indexed newAddress);
+event RateHandlerUpdated(address indexed oldAddress, address indexed newAddress);
 mapping(address => uint256) public stakingBalance;
 mapping(address => uint256) public lastStakedTime;
 uint256 public rewardRate = 5e18; // 500% per year, scaled to 1e18
@@ -32,6 +34,7 @@ uint256 public minClaimInterval = 7 days;
 uint256 private constant REWARD_PRECISION = 1e18;
 address public meatContract;
 address public nftContract;
+RateHandler public rateHandler;
 
 constructor(address meatAddress) ERC20("Guardian of Agricultural Trade", "GOAT") {
     _owner = msg.sender;
@@ -57,6 +60,14 @@ function setNFTAddress(address nftAddress) external onlyOwner {
     address old = nftContract;
     nftContract = nftAddress;
     emit NftAddressUpdated(old, nftAddress);
+}
+/// @notice Sets the rate handler contract address
+/// @param rateHandlerAddress Address of the RateHandler contract
+function setRateHandler(address rateHandlerAddress) external onlyOwner {
+    require(rateHandlerAddress != address(0), "Invalid address");
+    address old = address(rateHandler);
+    rateHandler = RateHandler(rateHandlerAddress);
+    emit RateHandlerUpdated(old, rateHandlerAddress);
 }
 /// @notice Allows the MEAT contract to mint GOAT tokens to any address
 /// @param to The recipient address

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -5,6 +5,7 @@ import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ER
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {IGoatToken} from "./interfaces/IGoatToken.sol";
 import {SwapConfig} from "./SwapConfig.sol";
+import {RateHandler} from "./RateHandler.sol";
 
 /// @title GoatNFT - tokenized goat identification
 /// @notice Each NFT holds a weight value redeemable for GOAT tokens
@@ -31,6 +32,7 @@ contract GoatNFT is ERC721Burnable {
 
     address private immutable _owner;
     IGoatToken public goatTokenContract;
+    RateHandler public rateHandler;
 
     /// @notice Weight update validity window in seconds (7 days)
     uint256 public constant WEIGHT_UPDATE_VALIDITY = 7 days;
@@ -50,6 +52,22 @@ contract GoatNFT is ERC721Burnable {
         address old = address(goatTokenContract);
         goatTokenContract = IGoatToken(goatTokenAddress);
         emit GoatTokenAddressUpdated(old, goatTokenAddress);
+    }
+
+    /// @notice Sets the rate handler contract used for GOAT mint amounts
+    /// @param rateHandlerAddress Address of the RateHandler contract
+    function setRateHandler(address rateHandlerAddress) external onlyOwner {
+        require(rateHandlerAddress != address(0), "Invalid address");
+        address old = address(rateHandler);
+        rateHandler = RateHandler(rateHandlerAddress);
+        emit RateHandlerUpdated(old, rateHandlerAddress);
+    }
+
+    function _getSwapRate() internal view returns (uint256) {
+        if (address(rateHandler) != address(0)) {
+            return rateHandler.getCurrentRate();
+        }
+        return SwapConfig.SWAP_RATE;
     }
 
     function mint(
@@ -98,7 +116,8 @@ contract GoatNFT is ERC721Burnable {
 
         bytes32 hash = keccak256(bytes(goatMetadata[tokenId].nfcId));
 
-        uint256 goatAmount = (currentWeight * 1e18) / SwapConfig.SWAP_RATE;
+        uint256 rate = _getSwapRate();
+        uint256 goatAmount = (currentWeight * 1e18) / rate;
 
         // Mint GOAT tokens directly to the token owner
         goatTokenContract.mint(tokenOwner, goatAmount);
@@ -122,6 +141,7 @@ contract GoatNFT is ERC721Burnable {
 
     /// @notice Emitted when the GOAT token contract address changes
     event GoatTokenAddressUpdated(address indexed oldAddress, address indexed newAddress);
+    event RateHandlerUpdated(address indexed oldAddress, address indexed newAddress);
     /// @notice Emitted when NFT is burned and GOAT token minted automatically
     event GoatBurned(uint256 indexed tokenId, address indexed user, uint256 weight, uint256 goatAmount);
     /// @notice Emitted when the goat weight is updated

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -5,6 +5,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IGOAT } from "./interfaces/IGOAT.sol";
 import { SwapConfig } from "./SwapConfig.sol";
+import { RateHandler } from "./RateHandler.sol";
 
 /// @title MEAT Token - Monetary Exchange for Agricultural Transactions
 /// @notice Smart contract untuk mint MEAT pakai Native Token dan swap ke GOAT serta sebaliknya.
@@ -15,6 +16,7 @@ contract MEAT is ERC20 {
 
     uint256 private _rate = 100;
     bool public swapEnabled = true;
+    RateHandler public rateHandler;
 
     event DepositRateChanged(uint256 oldRate, uint256 newRate);
     event MintedWithNative(address indexed user, uint256 nativeReceived, uint256 meatMinted);
@@ -24,6 +26,7 @@ contract MEAT is ERC20 {
     event InitialSupplyMinted(address indexed to, uint256 amount);
     event MeatRedeemed(address indexed user, uint256 amount);
     event GoatAddressUpdated(address indexed oldAddress, address indexed newAddress);
+    event RateHandlerUpdated(address indexed oldAddress, address indexed newAddress);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
@@ -83,7 +86,8 @@ contract MEAT is ERC20 {
         require(goatAmount > 0, "Amount must be > 0");
         GOAT.transferFrom(msg.sender, address(this), goatAmount);
 
-        uint256 meatAmount = goatAmount * SwapConfig.SWAP_RATE;
+        uint256 rate = _getSwapRate();
+        uint256 meatAmount = goatAmount * rate;
         uint256 contractBalance = balanceOf(address(this));
         if (contractBalance >= meatAmount) {
             _transfer(address(this), msg.sender, meatAmount);
@@ -103,7 +107,8 @@ contract MEAT is ERC20 {
         require(meatAmount > 0, "Amount must be > 0");
         IERC20(address(this)).transferFrom(msg.sender, address(this), meatAmount);
 
-        uint256 goatAmount = meatAmount / SwapConfig.SWAP_RATE;
+        uint256 rate = _getSwapRate();
+        uint256 goatAmount = meatAmount / rate;
         uint256 goatBalance = GOAT.balanceOf(address(this));
         if (goatBalance < goatAmount) {
             GOAT.mintTo(address(this), goatAmount - goatBalance);
@@ -129,15 +134,33 @@ contract MEAT is ERC20 {
         emit GoatAddressUpdated(old, goatAddress);
     }
 
+    /// @notice Sets the rate handler contract address used for swap rates
+    /// @param rateHandlerAddress Address of the RateHandler contract
+    function setRateHandler(address rateHandlerAddress) external onlyOwner {
+        require(rateHandlerAddress != address(0), "Invalid address");
+        address old = address(rateHandler);
+        rateHandler = RateHandler(rateHandlerAddress);
+        emit RateHandlerUpdated(old, rateHandlerAddress);
+    }
+
+    function _getSwapRate() internal view returns (uint256) {
+        if (address(rateHandler) != address(0)) {
+            return rateHandler.getCurrentRate();
+        }
+        return SwapConfig.SWAP_RATE;
+    }
+
     function owner() external view returns (address) {
         return _owner;
     }
 
-    function getEquivalentMEAT(uint256 goatAmount) external pure returns (uint256) {
-        return goatAmount * SwapConfig.SWAP_RATE;
+    function getEquivalentMEAT(uint256 goatAmount) external view returns (uint256) {
+        uint256 rate = _getSwapRate();
+        return goatAmount * rate;
     }
 
-    function getEquivalentGOAT(uint256 meatAmount) external pure returns (uint256) {
-        return meatAmount / SwapConfig.SWAP_RATE;
+    function getEquivalentGOAT(uint256 meatAmount) external view returns (uint256) {
+        uint256 rate = _getSwapRate();
+        return meatAmount / rate;
     }
 }

--- a/contracts/RateHandler.sol
+++ b/contracts/RateHandler.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {SwapConfig} from "./SwapConfig.sol";
+
+contract RateHandler {
+    address private immutable _owner;
+
+    uint256 public dynamicRate;
+    uint256 public lastUpdateTimestamp;
+    bool public dynamicRateValid;
+
+    event RateUpdated(uint256 newRate, uint256 timestamp);
+    event RateInvalidated(uint256 timestamp);
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    constructor() {
+        _owner = msg.sender;
+        dynamicRateValid = false;
+    }
+
+    function updateRate(uint256 newRate) external onlyOwner {
+        require(newRate > 0, "Rate must be > 0");
+        dynamicRate = newRate;
+        lastUpdateTimestamp = block.timestamp;
+        dynamicRateValid = true;
+        emit RateUpdated(newRate, block.timestamp);
+    }
+
+    function invalidateRate() external onlyOwner {
+        dynamicRateValid = false;
+        emit RateInvalidated(block.timestamp);
+    }
+
+    function getCurrentRate() public view returns (uint256) {
+        if (dynamicRateValid) {
+            return dynamicRate;
+        } else {
+            return SwapConfig.SWAP_RATE;
+        }
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -12,7 +12,7 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * Users send native currency to the MEAT contract. Its `receive()` function mints MEAT to the sender using the `DepositRate`, scaled per 1000 units (default `100`, i.e. 100 MEAT per 1000 native).
    * The contract emits `MintedWithNative(user, nativeReceived, meatMinted)` recording who minted and how much native token was received.
 2. **Swapping**
-   * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The fixed conversion constant `SWAP_RATE` maintains proportional supply.
+   * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The conversion rate comes from `RateHandler` with a fallback to `SWAP_RATE`.
 3. **GoatNFTs**
    * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its current weight in `goatValue`.
    * Owners may update the weight anytime, emitting `WeightUpdated`. Before burning the NFT the weight must have been updated within the last seven days. `burn` mints GOAT automatically and emits `GoatBurned`.

--- a/test/rateHandler.test.js
+++ b/test/rateHandler.test.js
@@ -1,0 +1,66 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("RateHandler integration", function () {
+  let owner, user, goat, meat, nft, handler;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    meat = await MEAT.deploy(goat.target);
+    await meat.waitForDeployment();
+    await goat.setMEATAddress(meat.target);
+
+    const GoatNFT = await ethers.getContractFactory("GoatNFT");
+    nft = await GoatNFT.deploy(goat.target);
+    await nft.waitForDeployment();
+    await goat.setNFTAddress(nft.target);
+
+    const RateHandler = await ethers.getContractFactory("RateHandler");
+    handler = await RateHandler.deploy();
+    await handler.waitForDeployment();
+  });
+
+  it("uses dynamic rate when valid", async function () {
+    await meat.setRateHandler(handler.target);
+    await nft.setRateHandler(handler.target);
+
+    await handler.updateRate(100);
+
+    const tx = await nft.mint(user.address, 50, "id", "breed", 2022);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+    await nft.connect(user).updateWeight(tokenId, 60);
+
+    const expectedGoat = (60n * 10n ** 18n) / 100n;
+    await expect(nft.connect(user).burn(tokenId))
+      .to.emit(nft, "GoatBurned")
+      .withArgs(tokenId, user.address, 60n, expectedGoat);
+
+    await goat.connect(user).approve(meat.target, expectedGoat);
+    await meat.connect(user).swapGOATForMEAT(expectedGoat);
+    const expectedMeat = expectedGoat * 100n;
+    expect(await meat.balanceOf(user.address)).to.equal(expectedMeat);
+  });
+
+  it("falls back to SwapConfig when invalid", async function () {
+    await meat.setRateHandler(handler.target);
+    await handler.updateRate(200);
+    await handler.invalidateRate();
+
+    const amount = ethers.parseEther("10");
+    await meat.transfer(user.address, amount);
+    await meat.connect(user).approve(meat.target, amount);
+
+    const fallbackRate = 85n;
+    const goatOut = amount / fallbackRate;
+    await expect(meat.connect(user).swapMEATForGOAT(amount))
+      .to.emit(meat, "SwappedMEATForGOAT")
+      .withArgs(user.address, amount, goatOut);
+  });
+});

--- a/user-journey.md
+++ b/user-journey.md
@@ -5,7 +5,7 @@ This document outlines a typical experience for a new participant in the GOAT/ME
 1. **Acquire MEAT**
    * The user opens the web app, connects their wallet and sends a small amount of native token to the MEAT contract. The contract mints MEAT based on the current `DepositRate`.
 2. **Convert to GOAT**
-   * Using the swap interface they approve MEAT and call `swapMEATForGOAT` which transfers MEAT and returns GOAT at the fixed `SWAP_RATE`.
+   * Using the swap interface they approve MEAT and call `swapMEATForGOAT` which transfers MEAT and returns GOAT based on the current rate from `RateHandler`.
 3. **Stake for Rewards**
    * With GOAT tokens in the wallet the user stakes them to start accruing rewards. The UI shows how long until claiming is allowed (`minClaimInterval`).
 4. **Harvest**


### PR DESCRIPTION
## Summary
- add RateHandler contract with dynamic rate and fallback
- wire RateHandler into GOAT, MEAT, and GoatNFT contracts
- update swap and NFT burn logic to use dynamic rate
- document RateHandler usage
- add tests covering dynamic rate behaviour

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6844edc26a508325b23421b731824a24