### PR TITLE
Add RateHandler docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Berikut gambaran umum alur penggunaan kedua token:
 
 1. **Mint MEAT** – Kirim native token langsung ke alamat kontrak `MEAT` untuk mencetak token sesuai rasio `DepositRate`. Fungsi `receive()` otomatis memproses dana dan mengirim MEAT ke pengirim. Versi CosmWasm menggunakan pesan `mint_with_native` seperti dijelaskan pada bagian berikutnya.
 2. **Swap MEAT ⇄ GOAT** – Fitur swap aktif jika `swapEnabled` bernilai `true`. Rasio konversi diambil dari `RateHandler` yang dapat diperbarui secara dinamis, dengan fallback ke `SWAP_RATE` di `SwapConfig` (default `85`). Fungsi `swapMEATForGOAT` menukar MEAT yang dimiliki pengguna menjadi GOAT, sedangkan `swapGOATForMEAT` melakukan sebaliknya.
+RateHandler dikelola pemilik dan menyimpan `dynamicRate` terkini. Pemanggilan `updateRate` menulis nilai baru serta memicu event `RateUpdated`, sedangkan `invalidateRate` menonaktifkan rate dinamis dan memicu `RateInvalidated`.
 3. **Stake GOAT** – Pemegang GOAT dapat memanggil `stake(amount)` pada kontrak GOAT untuk mulai memperoleh reward. Besarnya reward dihitung linier berdasarkan `rewardRate` dengan periode akrual `rewardInterval`.
    *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
@@ -163,6 +164,7 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
 ## Parameter Penting
 
 - **SWAP_RATE** – konstanta di `SwapConfig` yang menjadi fallback pada `RateHandler`. Nilai default `85` berarti 1 GOAT setara dengan 85 MEAT.
+- **dynamicRate** – nilai saat ini dari RateHandler jika masih valid. Diset lewat `updateRate` yang memancarkan event `RateUpdated`. Jika dinonaktifkan dengan `invalidateRate`, kontrak memakai `SWAP_RATE` dan event `RateInvalidated` dicatat.
 - **DepositRate** – rasio pencetakan MEAT ketika menerima native token. Nilai
   dihitung per 1000 unit native token sehingga `100` berarti 100 MEAT untuk 1000
   unit native (0.1 MEAT per 1 unit).
@@ -181,6 +183,8 @@ Perubahan alamat penting pada kontrak GOAT dan GoatNFT dapat dipantau melalui ev
 - `NftAddressUpdated(oldAddress, newAddress)` dicatat saat alamat GoatNFT diubah.
 - `GoatAddressUpdated(oldAddress, newAddress)` dicatat ketika alamat GOAT pada kontrak MEAT diubah.
 - `GoatTokenAddressUpdated(oldAddress, newAddress)` dicatat ketika kontrak GoatNFT mengubah alamat GOAT yang dipakai untuk mint.
+- `RateUpdated(newRate, timestamp)` dicatat oleh RateHandler ketika pemilik mengatur konversi baru.
+- `RateInvalidated(timestamp)` dicatat saat pemilik menonaktifkan rate dinamis sehingga fallback ke `SWAP_RATE`.
 
 MEAT juga memunculkan event utama berikut:
 

--- a/architecture.md
+++ b/architecture.md
@@ -7,6 +7,7 @@ This project revolves around two ERC20 contracts – **GOAT** and **MEAT** – d
 * **GOAT (`contracts/GOAT.sol`)** – provides staking with time‑based rewards, the ability for the MEAT contract to mint new supply and various owner controls (reward settings, MEAT address).
 * **MEAT (`contracts/MEAT.sol`)** – mints tokens when receiving native currency (using a `DepositRate` measured per 1000 units), swaps MEAT to and from GOAT, controls swap availability and deposit rate and can withdraw collected native tokens.
 * **GoatNFT (`contracts/GoatNFT.sol`)** – stores goat details on‑chain in `goatMetadata` as `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Each `nfcId` maps to a token ID so duplicates are rejected on mint. Owners may call `updateWeight` to keep the value current, emitting `WeightUpdated`. `burn` requires the weight to have been updated in the last 7 days, mints GOAT automatically and emits `GoatBurned` while clearing the NFC mapping.
+* **RateHandler (`contracts/RateHandler.sol`)** – menyimpan `dynamicRate` yang dipakai GOAT, MEAT dan GoatNFT. Pemilik dapat mengatur nilai baru dengan `updateRate` (menimbulkan event `RateUpdated`) atau menonaktifkan rate dengan `invalidateRate` sehingga kontrak kembali memakai `SWAP_RATE` dari `SwapConfig` dan memicu `RateInvalidated`.
 * **Interfaces and mocks** – `IGOAT` defines the minting hook used by MEAT and `FailingGOAT` is a test helper for simulating failed transfers.
 
 ## Backend

--- a/contract-map.md
+++ b/contract-map.md
@@ -16,6 +16,7 @@
 * **FailingGOAT** is only for testing; it implements the same interface but allows simulated transfer failures.
 * **IGOAT** defines the `mintTo` function which enables MEAT to mint GOAT when necessary.
 * **IGoatToken** is used by GoatNFT so the GOAT contract can mint upon burn.
+* **RateHandler** controls the current swap rate. `updateRate` emits `RateUpdated` while `invalidateRate` reverts to the constant in `SwapConfig`.
 
 The MEAT contract relies on GOAT for minting new tokens when swapping MEAT for GOAT. Both share the same owner who can manage rates and enable or disable swapping. The table below summarises the main contracts and their roles.
 | Contract | Description | Key Functions |


### PR DESCRIPTION
## Summary
- explain RateHandler update/invalidate events and SwapConfig fallback in README
- document RateHandler contract in architecture overview
- mention RateHandler in contract-map

## Testing
- `npm install`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_6844f404a7cc83258267c5881eb148b9