### PR TITLE
Add RateHandler event tests

### DIFF
--- a/test/rateHandler.test.js
+++ b/test/rateHandler.test.js
@@ -63,4 +63,32 @@ describe("RateHandler integration", function () {
       .to.emit(meat, "SwappedMEATForGOAT")
       .withArgs(user.address, amount, goatOut);
   });
+
+  it("emits RateUpdated and updates timestamp", async function () {
+    const before = await handler.lastUpdateTimestamp();
+    expect(before).to.equal(0n);
+
+    const tx = await handler.updateRate(150);
+    const receipt = await tx.wait();
+    const block = await ethers.provider.getBlock(receipt.blockNumber);
+
+    await expect(tx)
+      .to.emit(handler, "RateUpdated")
+      .withArgs(150n, BigInt(block.timestamp));
+
+    expect(await handler.lastUpdateTimestamp()).to.equal(BigInt(block.timestamp));
+  });
+
+  it("emits RateInvalidated after invalidateRate", async function () {
+    await handler.updateRate(200);
+    const tx = await handler.invalidateRate();
+    const receipt = await tx.wait();
+    const block = await ethers.provider.getBlock(receipt.blockNumber);
+
+    await expect(tx)
+      .to.emit(handler, "RateInvalidated")
+      .withArgs(BigInt(block.timestamp));
+
+    expect(await handler.dynamicRateValid()).to.be.false;
+  });
 });


### PR DESCRIPTION
## Summary
- extend `rateHandler.test.js` with coverage for RateUpdated and RateInvalidated
- verify `lastUpdateTimestamp` after calling `updateRate`

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6844f5685f24832582820b6d0d40c49e