### PR TITLE
Add MEAT redemption burn logic

### DIFF
--- a/wasm-contracts/meat/src/lib.rs
+++ b/wasm-contracts/meat/src/lib.rs
@@ -55,6 +55,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::ChangeDepositRate { new_rate } => execute_change_rate(deps, info, new_rate),
         ExecuteMsg::SwapGoatForMeat { goat_amount } => execute_swap_goat_for_meat(deps, env, info, goat_amount),
         ExecuteMsg::SwapMeatForGoat { meat_amount } => execute_swap_meat_for_goat(deps, env, info, meat_amount),
+        ExecuteMsg::RedeemForMeat { amount } => execute_redeem_for_meat(deps, info, amount),
         ExecuteMsg::SetSwapEnabled { enabled } => execute_set_swap_enabled(deps, info, enabled),
         ExecuteMsg::SetGoatAddress { goat_address } => execute_set_goat(deps, info, goat_address),
     }
@@ -203,6 +204,22 @@ fn execute_swap_meat_for_goat(deps: DepsMut, env: Env, info: MessageInfo, meat_a
         .add_attribute("user", info.sender)
         .add_attribute("meat_in", meat_amount)
         .add_attribute("goat_out", goat_amount))
+}
+
+fn execute_redeem_for_meat(deps: DepsMut, info: MessageInfo, amount: Uint128) -> StdResult<Response> {
+    if amount.is_zero() {
+        return Err(StdError::generic_err("Amount must be > 0"));
+    }
+    sub_balance(deps.storage, &info.sender, amount)?;
+    let total = TOTAL_SUPPLY.load(deps.storage)?;
+    if total < amount {
+        return Err(StdError::generic_err("Insufficient total supply"));
+    }
+    TOTAL_SUPPLY.save(deps.storage, &(total - amount))?;
+    Ok(Response::new()
+        .add_attribute("action", "MeatRedeemed")
+        .add_attribute("user", info.sender)
+        .add_attribute("amount", amount))
 }
 
 fn execute_set_swap_enabled(mut deps: DepsMut, info: MessageInfo, enabled: bool) -> StdResult<Response> {

--- a/wasm-contracts/meat/src/msg.rs
+++ b/wasm-contracts/meat/src/msg.rs
@@ -18,6 +18,7 @@ pub enum ExecuteMsg {
     ChangeDepositRate { new_rate: Uint128 },
     SwapGoatForMeat { goat_amount: Uint128 },
     SwapMeatForGoat { meat_amount: Uint128 },
+    RedeemForMeat { amount: Uint128 },
     SetSwapEnabled { enabled: bool },
     SetGoatAddress { goat_address: String },
 }

--- a/wasm-contracts/meat/tests/redeem.rs
+++ b/wasm-contracts/meat/tests/redeem.rs
@@ -1,0 +1,39 @@
+use cosmwasm_std::{coin, Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
+use meat::{execute, instantiate, query};
+use meat::msg::{InstantiateMsg as MeatInstantiate, ExecuteMsg as MeatExecute, QueryMsg as MeatQuery, BalanceResponse, TokenInfoResponse};
+
+fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(goat_execute, goat_instantiate, goat_query))
+}
+
+fn contract_meat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+#[test]
+fn redeem_burns_supply() {
+    let mut app = App::new(|router, _, storage| {
+        router.bank.init_balance(storage, &Addr::unchecked("owner"), vec![coin(1, "ucosm")]).unwrap();
+        router.bank.init_balance(storage, &Addr::unchecked("user"), vec![coin(2000, "ucosm")]).unwrap();
+    });
+    let goat_id = app.store_code(contract_goat());
+    let meat_id = app.store_code(contract_meat());
+
+    let goat_addr = app.instantiate_contract(goat_id, Addr::unchecked("owner"), &starter::msg::InstantiateMsg { meat_contract: "meat".into() }, &[], "goat", None).unwrap();
+    let meat_addr = app.instantiate_contract(meat_id, Addr::unchecked("owner"), &MeatInstantiate { goat_contract: goat_addr.to_string() }, &[], "meat", None).unwrap();
+
+    app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::MintWithNative {}, &[coin(1000, "ucosm")]).unwrap();
+
+    let info_before: TokenInfoResponse = app.wrap().query_wasm_smart(meat_addr.clone(), &MeatQuery::TokenInfo {}).unwrap();
+
+    let resp = app.execute_contract(Addr::unchecked("user"), meat_addr.clone(), &MeatExecute::RedeemForMeat { amount: Uint128::new(50) }, &[]).unwrap();
+    assert!(resp.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "MeatRedeemed")));
+
+    let bal: BalanceResponse = app.wrap().query_wasm_smart(meat_addr.clone(), &MeatQuery::Balance { address: "user".into() }).unwrap();
+    assert_eq!(bal.balance, Uint128::new(50));
+    let info_after: TokenInfoResponse = app.wrap().query_wasm_smart(meat_addr, &MeatQuery::TokenInfo {}).unwrap();
+    assert_eq!(info_after.total_supply, info_before.total_supply - Uint128::new(50));
+}


### PR DESCRIPTION
## Summary
- add `RedeemForMeat` execute message
- implement burn handler reducing balance and total supply
- dispatch new execute variant
- test MEAT redemption reduces supply

## Testing
- `yes | npx hardhat test`
- `cargo test --manifest-path wasm-contracts/meat/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6844fda44bc083259e7e46c76270a345