### PR TITLE
codex/add-weight-update

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -14,7 +14,9 @@ functions have equivalent execute messages, but there are notable differences:
 - **starter** implements GOAT staking and NFT redemption exactly like
   `GOAT.sol`, though events become log attributes.
 - **goatnft** stores goat metadata and weight the same way as `GoatNFT.sol` with
-  minor naming changes.
+  minor naming changes. Owners can call `update_weight` to refresh a goat's
+  weight. Burning requires the last update to be within
+  `WEIGHT_UPDATE_VALIDITY` (7 days).
 
 ## Building
 

--- a/wasm-contracts/goatnft/src/lib.rs
+++ b/wasm-contracts/goatnft/src/lib.rs
@@ -6,13 +6,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use serde_json_wasm;
 
-use crate::msg::{
-    ExecuteMsg,
-    GoatValueResponse,
-    GoatDataResponse,
-    InstantiateMsg,
-    QueryMsg,
-};
+use crate::msg::{ExecuteMsg, GoatDataResponse, GoatValueResponse, InstantiateMsg, QueryMsg};
 use crate::state::*;
 
 pub mod msg;
@@ -42,25 +36,37 @@ fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
     Ok(())
 }
 
-fn handle_execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
-    match msg {
-        ExecuteMsg::Mint { to, nfc_id, breed, birth_year, weight } => {
-            execute_mint(deps, env, info, to, weight, nfc_id, breed, birth_year)
-        }
-        ExecuteMsg::Burn { token_id } => execute_burn(deps, info, token_id),
-        ExecuteMsg::Approve { spender, token_id } => execute_approve(deps, info, spender, token_id),
-        ExecuteMsg::Transfer { to, token_id } => execute_transfer(deps, info, to, token_id),
-        ExecuteMsg::TransferFrom { owner, to, token_id } => execute_transfer_from(deps, info, owner, to, token_id),
-    }
-}
-
-#[entry_point]
-pub fn execute(
+fn handle_execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::Mint {
+            to,
+            nfc_id,
+            breed,
+            birth_year,
+            weight,
+        } => execute_mint(deps, env, info, to, weight, nfc_id, breed, birth_year),
+        ExecuteMsg::Burn { token_id } => execute_burn(deps, env, info, token_id),
+        ExecuteMsg::Approve { spender, token_id } => execute_approve(deps, info, spender, token_id),
+        ExecuteMsg::Transfer { to, token_id } => execute_transfer(deps, info, to, token_id),
+        ExecuteMsg::TransferFrom {
+            owner,
+            to,
+            token_id,
+        } => execute_transfer_from(deps, info, owner, to, token_id),
+        ExecuteMsg::UpdateWeight {
+            token_id,
+            new_weight,
+        } => execute_update_weight(deps, env, info, token_id, new_weight),
+    }
+}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     handle_execute(deps, env, info, msg)
 }
 
@@ -78,23 +84,36 @@ fn execute_mint(
     if weight == 0 {
         return Err(StdError::generic_err("Weight must be > 0"));
     }
+    if NFC_TO_TOKEN
+        .may_load(deps.storage, nfc_id.as_bytes())?
+        .is_some()
+    {
+        return Err(StdError::generic_err("NFC ID already used"));
+    }
     let to_addr = deps.api.addr_validate(&to)?;
     let id = NEXT_ID.load(deps.storage)? + 1;
     NEXT_ID.save(deps.storage, &id)?;
     OWNER_OF.save(deps.storage, id, &to_addr)?;
     GOAT_VALUE.save(deps.storage, id, &Uint128::from(weight as u128))?;
     let data = GoatData {
-        nfc_id,
+        nfc_id: nfc_id.clone(),
         breed,
         birth_year,
         weight,
         minted_at: env.block.time.seconds(),
     };
     GOAT_METADATA.save(deps.storage, id, &data)?;
+    LAST_WEIGHT_UPDATE.save(deps.storage, id, &env.block.time.seconds())?;
+    NFC_TO_TOKEN.save(deps.storage, nfc_id.as_bytes(), &id)?;
     Ok(Response::new().add_attribute("token_id", id.to_string()))
 }
 
-fn execute_burn(deps: DepsMut, info: MessageInfo, token_id: String) -> StdResult<Response> {
+fn execute_burn(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: String,
+) -> StdResult<Response> {
     let id: u64 = token_id
         .parse()
         .map_err(|_| StdError::generic_err("invalid id"))?;
@@ -102,18 +121,30 @@ fn execute_burn(deps: DepsMut, info: MessageInfo, token_id: String) -> StdResult
     if owner != info.sender {
         let approved = APPROVALS.may_load(deps.storage, id)?;
         match approved {
-            Some(addr) if addr == info.sender => {},
+            Some(addr) if addr == info.sender => {}
             _ => return Err(StdError::generic_err("Unauthorized")),
         }
     }
+    let last_update = LAST_WEIGHT_UPDATE.load(deps.storage, id)?;
+    if env.block.time.seconds() - last_update > WEIGHT_UPDATE_VALIDITY {
+        return Err(StdError::generic_err("Weight update too old"));
+    }
+    let data = GOAT_METADATA.load(deps.storage, id)?;
     OWNER_OF.remove(deps.storage, id);
     GOAT_VALUE.remove(deps.storage, id);
     GOAT_METADATA.remove(deps.storage, id);
     APPROVALS.remove(deps.storage, id);
+    LAST_WEIGHT_UPDATE.remove(deps.storage, id);
+    NFC_TO_TOKEN.remove(deps.storage, data.nfc_id.as_bytes());
     Ok(Response::new())
 }
 
-fn execute_approve(deps: DepsMut, info: MessageInfo, spender: String, token_id: String) -> StdResult<Response> {
+fn execute_approve(
+    deps: DepsMut,
+    info: MessageInfo,
+    spender: String,
+    token_id: String,
+) -> StdResult<Response> {
     let id: u64 = token_id
         .parse()
         .map_err(|_| StdError::generic_err("invalid id"))?;
@@ -126,7 +157,12 @@ fn execute_approve(deps: DepsMut, info: MessageInfo, spender: String, token_id: 
     Ok(Response::new())
 }
 
-fn execute_transfer(deps: DepsMut, info: MessageInfo, to: String, token_id: String) -> StdResult<Response> {
+fn execute_transfer(
+    deps: DepsMut,
+    info: MessageInfo,
+    to: String,
+    token_id: String,
+) -> StdResult<Response> {
     let id: u64 = token_id
         .parse()
         .map_err(|_| StdError::generic_err("invalid id"))?;
@@ -134,7 +170,7 @@ fn execute_transfer(deps: DepsMut, info: MessageInfo, to: String, token_id: Stri
     if owner != info.sender {
         let approved = APPROVALS.may_load(deps.storage, id)?;
         match approved {
-            Some(addr) if addr == info.sender => {},
+            Some(addr) if addr == info.sender => {}
             _ => return Err(StdError::generic_err("Unauthorized")),
         }
     }
@@ -162,13 +198,38 @@ fn execute_transfer_from(
     if owner_addr != info.sender {
         let approved = APPROVALS.may_load(deps.storage, id)?;
         match approved {
-            Some(addr) if addr == info.sender => {},
+            Some(addr) if addr == info.sender => {}
             _ => return Err(StdError::generic_err("Unauthorized")),
         }
     }
     let to_addr = deps.api.addr_validate(&to)?;
     OWNER_OF.save(deps.storage, id, &to_addr)?;
     APPROVALS.remove(deps.storage, id);
+    Ok(Response::new())
+}
+
+fn execute_update_weight(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: String,
+    new_weight: u64,
+) -> StdResult<Response> {
+    if new_weight == 0 {
+        return Err(StdError::generic_err("Weight must be > 0"));
+    }
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        return Err(StdError::generic_err("Not token owner"));
+    }
+    GOAT_VALUE.save(deps.storage, id, &Uint128::from(new_weight as u128))?;
+    let mut data = GOAT_METADATA.load(deps.storage, id)?;
+    data.weight = new_weight;
+    GOAT_METADATA.save(deps.storage, id, &data)?;
+    LAST_WEIGHT_UPDATE.save(deps.storage, id, &env.block.time.seconds())?;
     Ok(Response::new())
 }
 

--- a/wasm-contracts/goatnft/src/msg.rs
+++ b/wasm-contracts/goatnft/src/msg.rs
@@ -15,10 +15,26 @@ pub enum ExecuteMsg {
         birth_year: u64,
         weight: u64,
     },
-    Burn { token_id: String },
-    Approve { spender: String, token_id: String },
-    Transfer { to: String, token_id: String },
-    TransferFrom { owner: String, to: String, token_id: String },
+    Burn {
+        token_id: String,
+    },
+    Approve {
+        spender: String,
+        token_id: String,
+    },
+    Transfer {
+        to: String,
+        token_id: String,
+    },
+    TransferFrom {
+        owner: String,
+        to: String,
+        token_id: String,
+    },
+    UpdateWeight {
+        token_id: String,
+        new_weight: u64,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/wasm-contracts/goatnft/src/state.rs
+++ b/wasm-contracts/goatnft/src/state.rs
@@ -1,7 +1,9 @@
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
 pub struct GoatData {
     pub nfc_id: String,
     pub breed: String,
@@ -17,3 +19,11 @@ pub const GOAT_VALUE: Map<u64, Uint128> = Map::new("goat_value");
 pub const GOAT_METADATA: Map<u64, GoatData> = Map::new("goat_metadata");
 pub const APPROVALS: Map<u64, Addr> = Map::new("approvals");
 
+/// Timestamp of the last weight update for each token
+pub const LAST_WEIGHT_UPDATE: Map<u64, u64> = Map::new("last_weight_update");
+
+/// Mapping from NFC id bytes to token id to ensure uniqueness
+pub const NFC_TO_TOKEN: Map<&[u8], u64> = Map::new("nfc_to_token");
+
+/// Weight update validity window (7 days)
+pub const WEIGHT_UPDATE_VALIDITY: u64 = 60 * 60 * 24 * 7;

--- a/wasm-contracts/goatnft/tests/weight.rs
+++ b/wasm-contracts/goatnft/tests/weight.rs
@@ -1,0 +1,118 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use goatnft::msg::{
+    ExecuteMsg as NftExecute, InstantiateMsg as NftInstantiate, QueryMsg as NftQuery,
+};
+use goatnft::state::WEIGHT_UPDATE_VALIDITY;
+use goatnft::{execute, instantiate, query};
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+fn mint_sample(app: &mut App, nft_addr: Addr) -> u64 {
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 5,
+            },
+            &[],
+        )
+        .unwrap();
+    resp.events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap()
+}
+
+#[test]
+fn duplicate_nfc_fails() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &NftInstantiate {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+
+    let _ = mint_sample(&mut app, nft_addr.clone());
+    let err = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "other".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 5,
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}
+
+#[test]
+fn burn_requires_recent_update() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &NftInstantiate {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+
+    let token_id = mint_sample(&mut app, nft_addr.clone());
+
+    app.update_block(|b| b.time = b.time.plus_seconds(WEIGHT_UPDATE_VALIDITY + 1));
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &NftExecute::UpdateWeight {
+            token_id: token_id.to_string(),
+            new_weight: 8,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.update_block(|b| b.time = b.time.plus_seconds(WEIGHT_UPDATE_VALIDITY + 1));
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            nft_addr,
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}


### PR DESCRIPTION
## Summary
- add last weight update and NFC uniqueness checks in GoatNFT cosmwasm contract
- implement update weight message with validity checks
- enforce unique NFC IDs and recent weight update on burn
- document weight update usage in the wasm deploy guide
- test duplicate NFC protection and weight update validity

## Testing
- `cargo test` in `wasm-contracts/goatnft`
- `yes | npx hardhat test` *(fails: Trying to use a non-local installation of Hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_684503d4b9808325be9c4a9eb5f65e70