### PR TITLE
Update burn mint check

### DIFF
--- a/wasm-contracts/starter/src/lib.rs
+++ b/wasm-contracts/starter/src/lib.rs
@@ -12,6 +12,7 @@ use crate::msg::{
     PendingRewardResponse,
     NextClaimResponse,
     GoatValueResponse,
+    GoatDataResponse,
 };
 use crate::state::*;
 
@@ -72,7 +73,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::Approve { spender, amount } => execute_approve(deps, info, spender, amount),
         ExecuteMsg::TransferFrom { owner, recipient, amount } => execute_transfer_from(deps, info, owner, recipient, amount),
         ExecuteMsg::MintTo { to, amount } => execute_mint_to(deps, info, to, amount),
-        ExecuteMsg::BurnAndMint { token_id } => execute_burn_and_mint(deps, info, token_id),
+        ExecuteMsg::BurnAndMint { token_id } => execute_burn_and_mint(deps, env, info, token_id),
         ExecuteMsg::Stake { amount } => execute_stake(deps, env, info, amount),
         ExecuteMsg::EmergencyUnstake {} => execute_emergency_unstake(deps, env, info),
         ExecuteMsg::Unstake {} => execute_unstake(deps, env, info),
@@ -120,11 +121,37 @@ fn execute_mint_to(mut deps: DepsMut, info: MessageInfo, to: String, amount: Uin
     Ok(Response::new())
 }
 
-fn execute_burn_and_mint(deps: DepsMut, info: MessageInfo, token_id: u64) -> StdResult<Response> {
-    let nft = NFT_CONTRACT.load(deps.storage)?.ok_or_else(|| StdError::generic_err("NFT not set"))?;
-    let query = to_json_binary(&serde_json::json!({"goat_value": {"token_id": token_id}}))?;
-    let resp: GoatValueResponse = deps.querier.query_wasm_smart(nft.clone(), &query)?;
-    let burn = WasmMsg::Execute { contract_addr: nft.to_string(), msg: to_json_binary(&Cw721ExecuteMsg::Burn { token_id: token_id.to_string() })?, funds: vec![] };
+fn execute_burn_and_mint(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: u64,
+) -> StdResult<Response> {
+    const WEIGHT_UPDATE_VALIDITY: u64 = 60 * 60 * 24 * 7;
+    let nft = NFT_CONTRACT
+        .load(deps.storage)?
+        .ok_or_else(|| StdError::generic_err("NFT not set"))?;
+
+    // query goat value
+    let query_val = to_json_binary(&serde_json::json!({"goat_value": {"token_id": token_id}}))?;
+    let resp: GoatValueResponse = deps.querier.query_wasm_smart(nft.clone(), &query_val)?;
+
+    // query last weight update timestamp via goat_data
+    let query_data = to_json_binary(&serde_json::json!({"goat_data": {"token_id": token_id}}))?;
+    let data: GoatDataResponse = deps.querier.query_wasm_smart(nft.clone(), &query_data)?;
+
+    if env.block.time.seconds().saturating_sub(data.minted_at) > WEIGHT_UPDATE_VALIDITY {
+        return Err(StdError::generic_err("Weight update too old"));
+    }
+
+    let burn = WasmMsg::Execute {
+        contract_addr: nft.to_string(),
+        msg: to_json_binary(&Cw721ExecuteMsg::Burn {
+            token_id: token_id.to_string(),
+        })?,
+        funds: vec![],
+    };
+
     add_balance(deps.storage, &info.sender, resp.value)?;
     let supply = TOTAL_SUPPLY.load(deps.storage)? + resp.value;
     TOTAL_SUPPLY.save(deps.storage, &supply)?;

--- a/wasm-contracts/starter/src/msg.rs
+++ b/wasm-contracts/starter/src/msg.rs
@@ -74,3 +74,12 @@ pub struct NextClaimResponse {
     pub timestamp: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct GoatDataResponse {
+    pub nfc_id: String,
+    pub breed: String,
+    pub birth_year: u64,
+    pub weight: u64,
+    pub minted_at: u64,
+}
+

--- a/wasm-contracts/starter/tests/goat.rs
+++ b/wasm-contracts/starter/tests/goat.rs
@@ -5,6 +5,7 @@ use starter::{execute, instantiate, query};
 use starter::msg::{InstantiateMsg, ExecuteMsg, QueryMsg, BalanceResponse, StakingInfoResponse, TokenInfoResponse, PendingRewardResponse};
 use goatnft::{execute as nft_execute, instantiate as nft_instantiate, query as nft_query};
 use goatnft::msg as nft_msg;
+use goatnft::state::WEIGHT_UPDATE_VALIDITY;
 
 fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
     let contract = ContractWrapper::new(execute, instantiate, query);
@@ -134,7 +135,6 @@ fn burn_and_mint_emits_burn() {
         nft_addr.clone(),
         &nft_msg::ExecuteMsg::Mint {
             to: "user".into(),
-            value: Uint128::new(50),
             nfc_id: "nfc".into(),
             breed: "breed".into(),
             birth_year: 2024,
@@ -169,6 +169,72 @@ fn burn_and_mint_emits_burn() {
 
     let owner_res: Result<String, _> = app.wrap().query_wasm_smart(nft_addr, &nft_msg::QueryMsg::Owner { token_id });
     assert!(owner_res.is_err());
+}
+
+#[test]
+fn burn_and_mint_fails_with_stale_update() {
+    let mut app = App::default();
+    let goat_id = app.store_code(contract_goat());
+    let nft_id = app.store_code(contract_nft());
+
+    let goat_addr = app
+        .instantiate_contract(goat_id, Addr::unchecked("owner"), &InstantiateMsg { meat_contract: "meat".into() }, &[], "goat", None)
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &nft_msg::InstantiateMsg {}, &[], "nft", None)
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        goat_addr.clone(),
+        &ExecuteMsg::SetNftAddress { nft_address: nft_addr.to_string() },
+        &[]
+    ).unwrap();
+
+    let resp = app.execute_contract(
+        Addr::unchecked("owner"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::Mint {
+            to: "user".into(),
+            nfc_id: "nfc".into(),
+            breed: "breed".into(),
+            birth_year: 2024,
+            weight: 10,
+        },
+        &[]
+    ).unwrap();
+    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap()
+        .attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::Approve {
+            spender: goat_addr.to_string(),
+            token_id: token_id.to_string(),
+        },
+        &[]
+    ).unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::UpdateWeight {
+            token_id: token_id.to_string(),
+            new_weight: 12,
+        },
+        &[]
+    ).unwrap();
+
+    app.update_block(|b| b.time = b.time.plus_seconds(WEIGHT_UPDATE_VALIDITY + 1));
+
+    let err = app.execute_contract(
+        Addr::unchecked("user"),
+        goat_addr.clone(),
+        &ExecuteMsg::BurnAndMint { token_id },
+        &[]
+    ).unwrap_err();
+    assert!(!err.to_string().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- query goatnft for metadata in burn_and_mint
- verify weight update timestamp before burning
- add regression test for stale weight update

## Testing
- `yes | npx hardhat test`
- `cargo test` in `wasm-contracts/starter`
- `cargo test` in `wasm-contracts/goatnft`
- `cargo test` in `wasm-contracts/meat`

------
https://chatgpt.com/codex/tasks/task_e_684507ca961883258b8e93a7ee79c7af