### PR TITLE
codex/readme-ratehandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ This repository contains two ERC20 tokens:
 Berikut gambaran umum alur penggunaan kedua token:
 
 1. **Mint MEAT** – Kirim native token langsung ke alamat kontrak `MEAT` untuk mencetak token sesuai rasio `DepositRate`. Fungsi `receive()` otomatis memproses dana dan mengirim MEAT ke pengirim. Versi CosmWasm menggunakan pesan `mint_with_native` seperti dijelaskan pada bagian berikutnya.
-2. **Swap MEAT ⇄ GOAT** – Fitur swap aktif jika `swapEnabled` bernilai `true`. Rasio konversi diambil dari `RateHandler` yang dapat diperbarui secara dinamis, dengan fallback ke `SWAP_RATE` di `SwapConfig` (default `85`). Fungsi `swapMEATForGOAT` menukar MEAT yang dimiliki pengguna menjadi GOAT, sedangkan `swapGOATForMEAT` melakukan sebaliknya.
-RateHandler dikelola pemilik dan menyimpan `dynamicRate` terkini. Pemanggilan `updateRate` menulis nilai baru serta memicu event `RateUpdated`, sedangkan `invalidateRate` menonaktifkan rate dinamis dan memicu `RateInvalidated`. Kepemilikan dapat dialihkan melalui `transferOwnership` yang memancarkan event `OwnershipTransferred`.
+2. **Swap MEAT ⇄ GOAT** – Fitur swap aktif jika `swapEnabled` bernilai `true`. Rasio konversi diperoleh dari `RateHandler` yang bisa diperbarui oleh Oracle melalui `updateRate`. Bila `dynamicRateValid` `false` (contohnya setelah `invalidateRate`), kontrak otomatis memakai `SWAP_RATE` dari `SwapConfig` (default `85`). Fungsi `swapMEATForGOAT` menukar MEAT yang dimiliki pengguna menjadi GOAT, sedangkan `swapGOATForMEAT` melakukan sebaliknya.
+RateHandler mencatat pembaruan melalui event `RateUpdated` dan `RateInvalidated` untuk audit. Alur singkatnya:
+```text
+Oracle --updateRate--> RateHandler --getRate--> MEAT/GOAT
+```
 3. **Stake GOAT** – Pemegang GOAT dapat memanggil `stake(amount)` pada kontrak GOAT untuk mulai memperoleh reward. Besarnya reward dihitung linier berdasarkan `rewardRate` dengan periode akrual `rewardInterval`.
    *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.


### PR DESCRIPTION
## Summary
- document how Oracle feeds swap rate via `updateRate`
- explain fallback to `SwapConfig` when rate is invalid
- mention `RateUpdated` and `RateInvalidated` events
- add small sequence diagram in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6845368aa88083258099966938a49e68