### PR TITLE
codex/swap-enabled-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ MEAT juga memunculkan event utama berikut:
 - `MintedWithNative(user, nativeReceived, meatMinted)` dicatat ketika kontrak
   menerima native token dan mencetak MEAT. Pada versi CosmWasm event ini
   dipicu saat `mint_with_native` dipanggil.
+- `SwapEnabledUpdated(status)` dicatat ketika pemilik mengubah status swap
+  MEAT dan GOAT.
 
 ## Running Tests
 

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -27,6 +27,7 @@ contract MEAT is ERC20 {
     event MeatRedeemed(address indexed user, uint256 amount);
     event GoatAddressUpdated(address indexed oldAddress, address indexed newAddress);
     event RateHandlerUpdated(address indexed oldAddress, address indexed newAddress);
+    event SwapEnabledUpdated(bool status);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
@@ -125,6 +126,7 @@ contract MEAT is ERC20 {
 
     function setSwapEnabled(bool status) external onlyOwner {
         swapEnabled = status;
+        emit SwapEnabledUpdated(status);
     }
 
     function setGOATAddress(address goatAddress) external onlyOwner {

--- a/test/fullFlow.test.js
+++ b/test/fullFlow.test.js
@@ -58,13 +58,17 @@ describe("Full flow integration", function () {
       .withArgs(owner.address, totalNative);
     expect(await ethers.provider.getBalance(meat.target)).to.equal(0n);
 
-    await meat.setSwapEnabled(false);
+    await expect(meat.setSwapEnabled(false))
+      .to.emit(meat, "SwapEnabledUpdated")
+      .withArgs(false);
     const amountSwap1 = ethers.parseEther("10");
     await meat.connect(user1).approve(meat.target, amountSwap1);
     await expect(meat.connect(user1).swapMEATForGOAT(amountSwap1)).to.be.revertedWith(
       "Swap disabled"
     );
-    await meat.setSwapEnabled(true);
+    await expect(meat.setSwapEnabled(true))
+      .to.emit(meat, "SwapEnabledUpdated")
+      .withArgs(true);
 
     const goatOut1 = amountSwap1 / SWAP_RATE;
     await expect(meat.connect(user1).swapMEATForGOAT(amountSwap1))


### PR DESCRIPTION
## Summary
- add `SwapEnabledUpdated` event in MEAT.sol
- emit event when toggling swap enabled
- test `setSwapEnabled` emits `SwapEnabledUpdated`
- document the new event in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6845542e24f08325aa74d53df4680e5e