### PR TITLE
Add zero-value MEAT mint test

### DIFF
--- a/test/meat.test.js
+++ b/test/meat.test.js
@@ -17,6 +17,22 @@ describe("MEAT", function () {
     expect(balance).to.equal(ethers.parseEther("1000"));
   });
 
+  it("reverts when sending no native token", async function () {
+    const [owner] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    const goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const meat = await MEAT.deploy(goat.target);
+    await meat.waitForDeployment();
+
+    await expect(
+      owner.sendTransaction({ to: meat.target, value: 0 })
+    ).to.be.revertedWith("Must send Native Token to mint MEAT");
+  });
+
   it("should revert swapMEATForGOAT when GOAT transfer fails", async function () {
     const [owner, user] = await ethers.getSigners();
 


### PR DESCRIPTION
## Summary
- cover MEAT receive() revert when no native token sent

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6845657e7c108325959704f5b69a191b