### PR TITLE
codex/weight-decimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Berikut langkah detail siklus kambing hingga daging tercatat di ledger:
 
 - Kambing lahir → pencetakan **GoatNFT** dengan `nfcId`, `breed`, `birthYear`, dan `weight` awal.
 - `nfcId` bersifat unik; pencetakan kedua dengan ID sama akan gagal.
-- Pemilik dapat memperbarui berat melalui `updateWeight()` agar nilainya tetap valid (dibutuhkan sebelum burn).
+ - Pemilik dapat memperbarui berat melalui `updateWeight()` agar nilainya tetap valid (dibutuhkan sebelum burn).
+ - Nilai `weight` disimpan dengan satu tempat desimal menggunakan `WEIGHT_DECIMALS = 1` sehingga `425` berarti **42.5 kg**.
 - NFT (standar ERC721) bebas dipindahtangankan ke pemilik baru.
 - Ketika kambing disembelih, pemilik membakar NFT; kontrak otomatis mencetak GOAT sejumlah `weight / rate` dimana `rate` berasal dari `RateHandler`.
 - GOAT dapat diperdagangkan atau ditukar menjadi MEAT memakai fungsi swap kontrak.

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -36,6 +36,8 @@ contract GoatNFT is ERC721Burnable {
 
     /// @notice Weight update validity window in seconds (7 days)
     uint256 public constant WEIGHT_UPDATE_VALIDITY = 7 days;
+    /// @notice Number of decimal places used for weight values
+    uint256 public constant WEIGHT_DECIMALS = 1;
 
     constructor(address goatTokenAddress) ERC721("Goat Identifier", "GOATNFT") {
         _owner = msg.sender;
@@ -70,6 +72,7 @@ contract GoatNFT is ERC721Burnable {
         return SwapConfig.SWAP_RATE;
     }
 
+    /// @param weight Weight value scaled by `WEIGHT_DECIMALS`
     function mint(
         address to,
         uint256 weight,
@@ -91,7 +94,7 @@ contract GoatNFT is ERC721Burnable {
 
     /// @notice Update the goat's latest weight
     /// @param tokenId ID of the NFT to update
-    /// @param newWeight New weight value in kilograms
+    /// @param newWeight New weight value scaled by `WEIGHT_DECIMALS`
     function updateWeight(uint256 tokenId, uint256 newWeight) external {
         address tokenOwner = ownerOf(tokenId);
         require(msg.sender == tokenOwner, "Not token owner");
@@ -117,7 +120,8 @@ contract GoatNFT is ERC721Burnable {
         bytes32 hash = keccak256(bytes(goatMetadata[tokenId].nfcId));
 
         uint256 rate = _getSwapRate();
-        uint256 goatAmount = (currentWeight * 1e18) / rate;
+        uint256 goatAmount =
+            (currentWeight * 1e18) / rate / (10 ** WEIGHT_DECIMALS);
 
         // Mint GOAT tokens directly to the token owner
         goatTokenContract.mint(tokenOwner, goatAmount);

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -15,7 +15,8 @@ The two tokens form a closed loop that allows value to enter the system via MEAT
    * MEAT can be swapped to GOAT and vice versa through the MEAT contract when `swapEnabled` is true. The conversion rate comes from `RateHandler` with a fallback to `SWAP_RATE`.
 3. **GoatNFTs**
    * A [GoatNFT](contracts/GoatNFT.sol) represents a live goat and stores its current weight in `goatValue`.
-   * Owners may update the weight anytime, emitting `WeightUpdated`. Before burning the NFT the weight must have been updated within the last seven days. `burn` mints GOAT automatically and emits `GoatBurned`.
+   * Owners may update the weight anytime, emitting `WeightUpdated`. The weight uses one decimal place (`WEIGHT_DECIMALS = 1`) so `425` means **42.5 kg**.
+   * Before burning the NFT the weight must have been updated within the last seven days. `burn` mints GOAT automatically and emits `GoatBurned`.
 4. **Staking GOAT**
    * GOAT holders stake tokens in `GOAT.sol` which records staking balances and timestamps. Rewards accrue linearly according to `rewardRate` and `rewardInterval`.
    *Calling `stake()` again resets `lastStakedTime` and discards any pending reward. Claim your reward first if you plan to restake.*

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -26,7 +26,7 @@ describe("GoatNFT burn and GOAT mint", function () {
     const nfcId = "1234";
     const breed = "Boer";
     const birthYear = 2021;
-    const weight = 70;
+    const weight = 700;
     const tx = await nft.mint(
       user.address,
       weight,
@@ -38,13 +38,13 @@ describe("GoatNFT burn and GOAT mint", function () {
     const tokenId = receipt.logs[0].args[2];
 
     // owner updates weight before burning
-    const newWeight = 80n;
+    const newWeight = 800n;
     await nft.connect(user).updateWeight(tokenId, newWeight);
 
     const stored = await nft.getGoatData(tokenId);
     expect(stored.weight).to.equal(newWeight);
 
-    const goatAmount = (newWeight * 10n ** 18n) / SWAP_RATE;
+    const goatAmount = (newWeight * 10n ** 18n) / SWAP_RATE / 10n;
     await expect(nft.connect(user).burn(tokenId))
       .to.emit(nft, "GoatBurned")
       .withArgs(tokenId, user.address, newWeight, goatAmount);
@@ -53,18 +53,32 @@ describe("GoatNFT burn and GOAT mint", function () {
     await expect(nft.ownerOf(tokenId)).to.be.reverted;
   });
 
-  it("emits WeightUpdated when updating weight", async function () {
-    const tx = await nft.mint(user.address, 50, "tag", "type", 2022);
+  it("mints 0.5 GOAT when burning weight 425", async function () {
+    const tx = await nft.mint(user.address, 425, "half", "Boer", 2021);
     const receipt = await tx.wait();
     const tokenId = receipt.logs[0].args[2];
 
-    await expect(nft.connect(user).updateWeight(tokenId, 55n))
+    const expected = (425n * 10n ** 18n) / SWAP_RATE / 10n;
+    // weight already fresh so just burn
+    await expect(nft.connect(user).burn(tokenId))
+      .to.emit(nft, "GoatBurned")
+      .withArgs(tokenId, user.address, 425n, expected);
+    expect(expected).to.equal(5n * 10n ** 17n);
+    expect(await goat.balanceOf(user.address)).to.equal(expected);
+  });
+
+  it("emits WeightUpdated when updating weight", async function () {
+    const tx = await nft.mint(user.address, 500, "tag", "type", 2022);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+
+    await expect(nft.connect(user).updateWeight(tokenId, 550n))
       .to.emit(nft, "WeightUpdated")
-      .withArgs(tokenId, 55n);
+      .withArgs(tokenId, 550n);
   });
 
   it("reverts burn when weight update is stale", async function () {
-    const tx = await nft.mint(user.address, 60, "n", "b", 2020);
+    const tx = await nft.mint(user.address, 600, "n", "b", 2020);
     const receipt = await tx.wait();
     const tokenId = receipt.logs[0].args[2];
 
@@ -78,17 +92,17 @@ describe("GoatNFT burn and GOAT mint", function () {
   });
 
   it("reverts when minting with duplicate nfcId", async function () {
-    await nft.mint(user.address, 40, "dup", "Boer", 2022);
+    await nft.mint(user.address, 400, "dup", "Boer", 2022);
     await expect(
-      nft.mint(user.address, 50, "dup", "Boer", 2022)
+      nft.mint(user.address, 500, "dup", "Boer", 2022)
     ).to.be.revertedWith("NFC ID already used");
   });
 
   it("allows reusing nfcId after burn", async function () {
-    const tx = await nft.mint(user.address, 30, "reuse", "Boer", 2022);
+    const tx = await nft.mint(user.address, 300, "reuse", "Boer", 2022);
     const receipt = await tx.wait();
     const tokenId = receipt.logs[0].args[2];
     await nft.connect(user).burn(tokenId);
-    await expect(nft.mint(user.address, 35, "reuse", "Boer", 2022)).to.not.be.reverted;
+    await expect(nft.mint(user.address, 350, "reuse", "Boer", 2022)).to.not.be.reverted;
   });
 });

--- a/test/rateHandler.test.js
+++ b/test/rateHandler.test.js
@@ -33,15 +33,15 @@ describe("RateHandler integration", function () {
 
     await handler.updateRate(100);
 
-    const tx = await nft.mint(user.address, 50, "id", "breed", 2022);
+    const tx = await nft.mint(user.address, 500, "id", "breed", 2022);
     const receipt = await tx.wait();
     const tokenId = receipt.logs[0].args[2];
-    await nft.connect(user).updateWeight(tokenId, 60);
+    await nft.connect(user).updateWeight(tokenId, 600);
 
-    const expectedGoat = (60n * 10n ** 18n) / 100n;
+    const expectedGoat = (600n * 10n ** 18n) / 100n / 10n;
     await expect(nft.connect(user).burn(tokenId))
       .to.emit(nft, "GoatBurned")
-      .withArgs(tokenId, user.address, 60n, expectedGoat);
+      .withArgs(tokenId, user.address, 600n, expectedGoat);
 
     await goat.connect(user).approve(meat.target, expectedGoat);
     await meat.connect(user).swapGOATForMEAT(expectedGoat);


### PR DESCRIPTION
## Summary
- add `WEIGHT_DECIMALS` constant in `GoatNFT`
- handle weight as fixed-point with one decimal
- adjust burn formula and modify tests
- document weight scaling in README and lifecycle docs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6845729763b8832588998bb378c360d3