### PR TITLE
codex/fractional-swap-tests

### DIFF
--- a/test/meat.test.js
+++ b/test/meat.test.js
@@ -102,4 +102,30 @@ describe("MEAT", function () {
 
     expect(await goat.balanceOf(user.address)).to.equal(goatOut);
   });
+
+  it("swaps GOAT for MEAT with fractional amount", async function () {
+    const [owner, user] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    const goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const meat = await MEAT.deploy(goat.target);
+    await meat.waitForDeployment();
+
+    const goatAmount = ethers.parseEther("0.25");
+    await goat.mintTo(user.address, goatAmount);
+
+    await goat.setMEATAddress(meat.target);
+
+    await goat.connect(user).approve(meat.target, goatAmount);
+
+    const meatOut = ethers.parseEther("21.25");
+    await expect(meat.connect(user).swapGOATForMEAT(goatAmount))
+      .to.emit(meat, "SwappedGOATForMEAT")
+      .withArgs(user.address, goatAmount, meatOut);
+
+    expect(await meat.balanceOf(user.address)).to.equal(meatOut);
+  });
 });


### PR DESCRIPTION
## Summary
- add fractional swap test for GOAT->MEAT
- verify events for both MEAT->GOAT and GOAT->MEAT swaps

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6845750677a88325857c0543b8680a2b