### PR TITLE
Introduce deposit divisor constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
 - **SWAP_RATE** – konstanta di `SwapConfig` yang menjadi fallback pada `RateHandler`. Nilai default `85` berarti 1 GOAT setara dengan 85 MEAT.
 - **dynamicRate** – nilai saat ini dari RateHandler jika masih valid. Diset lewat `updateRate` yang memancarkan event `RateUpdated`. Jika dinonaktifkan dengan `invalidateRate`, kontrak memakai `SWAP_RATE` dan event `RateInvalidated` dicatat.
 - **DepositRate** – rasio pencetakan MEAT ketika menerima native token. Nilai
-  dihitung per 1000 unit native token sehingga `100` berarti 100 MEAT untuk 1000
-  unit native (0.1 MEAT per 1 unit).
+  dihitung per `DEPOSIT_DIVISOR` (1000) unit native token sehingga `100` berarti
+  100 MEAT untuk 1000 unit native (0.1 MEAT per 1 unit).
 - **rewardRate** – tingkat imbal hasil tahunan di kontrak GOAT (dalam skala
   `1e18`). Nilai ini dikombinasikan dengan `rewardInterval` untuk menghitung
   reward harian pengguna.

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -15,6 +15,10 @@ contract MEAT is ERC20 {
     address private immutable _owner;
 
     uint256 private _rate = 100;
+    /// @notice Divisor untuk perhitungan jumlah MEAT yang dicetak saat menerima
+    /// token native. Nilai default 1000 berarti deposit rate dihitung per 1000
+    /// unit native token.
+    uint256 public constant DEPOSIT_DIVISOR = 1000;
     bool public swapEnabled = true;
     RateHandler public rateHandler;
 
@@ -47,7 +51,7 @@ contract MEAT is ERC20 {
     /// @notice Menerima token native dan mencetak MEAT sesuai rate
     receive() external payable {
         require(msg.value != 0, "Must send Native Token to mint MEAT");
-        uint256 meatAmount = (msg.value * _rate) / 1e3;
+        uint256 meatAmount = (msg.value * _rate) / DEPOSIT_DIVISOR;
         require(meatAmount != 0, "Mint amount too low");
 
         uint256 contractBalance = balanceOf(address(this));


### PR DESCRIPTION
## Summary
- add `DEPOSIT_DIVISOR` constant in `MEAT.sol`
- use `DEPOSIT_DIVISOR` when minting from native token
- document constant usage in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68463615ebd883259c75f08bfb986733