### PR TITLE
codex/add-lod-rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
   reward harian pengguna.
 - **minClaimInterval** – interval minimum pengguna dapat mengklaim atau
   meng-unstake dengan reward. Default-nya `7 days`.
+- **LOD** – Level of Decay per komoditas. Nilai awal tersimpan di `lod_data.json`
+  dan dapat diperbarui on-chain lewat `setCommodityLOD` pada `RateHandler`.
+  Barter rate akhir dihitung dengan formula `currentRate + (lodPerDay *
+  daysSinceUpdate)`.
 
 ## Events
 
@@ -387,6 +391,7 @@ Dokumen pendukung lain tersedia untuk memahami keseluruhan proyek:
 - [Integration Bridge](integration-bridge.md)
 - [CosmWasm Deployment](docs/wasm-deploy.md)
 - [Frontend Pages](docs/frontend-pages.md)
+- [LOD Governance](docs/lod-governance.md)
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -27,4 +27,10 @@ Jalankan server dengan:
 npm run start:server
 ```
 
+Endpoint tambahan disediakan untuk mengakses data LOD per komoditas:
+
+```bash
+curl http://localhost:3001/api/LOD/GOAT_MEAT
+```
+
 Untuk gambaran lengkap arsitektur dan interaksi kontrak, lihat [README](../README.md) utama.

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,8 @@ const meatAbi = require('./abi/MEAT.json').abi;
 const app = express();
 const cache = new NodeCache({ stdTTL: 60 });
 
+const lodData = require('../lod_data.json');
+
 const provider = new ethers.JsonRpcProvider(process.env.RPC_URL || 'http://localhost:8545');
 const goatAddress = process.env.GOAT_ADDRESS;
 const meatAddress = process.env.MEAT_ADDRESS;
@@ -45,6 +47,15 @@ app.get('/stats', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'failed' });
+  }
+});
+
+app.get('/api/LOD/:commodity', (req, res) => {
+  const key = req.params.commodity.toUpperCase();
+  if (lodData[key]) {
+    res.json(lodData[key]);
+  } else {
+    res.status(404).json({ error: 'not found' });
   }
 });
 

--- a/contracts/RateHandler.sol
+++ b/contracts/RateHandler.sol
@@ -10,6 +10,13 @@ contract RateHandler {
     uint256 public lastUpdateTimestamp;
     bool public dynamicRateValid;
 
+    struct CommodityLOD {
+        uint256 lodPerDay;
+        uint256 lastSet;
+    }
+
+    mapping(bytes32 => CommodityLOD) public commodityLOD;
+
     event RateUpdated(uint256 newRate, uint256 timestamp);
     event RateInvalidated(uint256 timestamp);
     event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
@@ -22,6 +29,23 @@ contract RateHandler {
     constructor() {
         _owner = msg.sender;
         dynamicRateValid = false;
+    }
+
+    function setCommodityLOD(bytes32 commodity, uint256 lodPerDay) external onlyOwner {
+        require(commodity != bytes32(0), "Invalid commodity");
+        commodityLOD[commodity] = CommodityLOD(lodPerDay, block.timestamp);
+    }
+
+    function getLODPerDay(bytes32 commodity) public view returns (uint256) {
+        return commodityLOD[commodity].lodPerDay;
+    }
+
+    function computeBarterRate(bytes32 commodity) public view returns (uint256) {
+        uint256 base = getCurrentRate();
+        uint256 lod = commodityLOD[commodity].lodPerDay;
+        if (lod == 0) return base;
+        uint256 daysPassed = (block.timestamp - lastUpdateTimestamp) / 1 days;
+        return base + (lod * daysPassed);
     }
 
     function updateRate(uint256 newRate) external onlyOwner {

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -1,0 +1,23 @@
+# Level of Decay (LOD)
+
+`LOD` menentukan penurunan nilai barter komoditas setiap hari. File `lod_data.json` di root menyimpan master data awal yang dapat diperbarui melalui fungsi `setCommodityLOD` pada `RateHandler`.
+
+```json
+{
+  "GOAT_MEAT": { "lodPerDay": 5 },
+  "RAW_MILK": { "lodPerDay": 10 },
+  "WHEAT": { "lodPerDay": 1 }
+}
+```
+
+Pemilik kontrak dapat memanggil `setCommodityLOD(bytes32 commodity, uint256 lodPerDay)` untuk memperbarui nilai tersebut secara on-chain.
+
+## Formula
+
+Barter rate dihitung menggunakan dynamic rate terbaru yang dikelola `RateHandler` kemudian ditambah kenaikan sesuai LOD per hari sejak pembaruan rate:
+
+```
+finalRate = currentRate + (lodPerDay * daysSinceUpdate)
+```
+
+`daysSinceUpdate` dihitung berdasarkan `lastUpdateTimestamp` pada kontrak. Jika LOD belum diset, nilai final sama dengan `currentRate`.

--- a/lod_data.json
+++ b/lod_data.json
@@ -1,0 +1,5 @@
+{
+  "GOAT_MEAT": { "lodPerDay": 5 },
+  "RAW_MILK": { "lodPerDay": 10 },
+  "WHEAT": { "lodPerDay": 1 }
+}

--- a/test/rateHandler.test.js
+++ b/test/rateHandler.test.js
@@ -104,4 +104,20 @@ describe("RateHandler integration", function () {
       .to.emit(handler, "RateUpdated")
       .withArgs(300n, anyValue);
   });
+
+  it("stores and reads commodity LOD", async function () {
+    const wheat = ethers.encodeBytes32String("WHEAT");
+    await handler.setCommodityLOD(wheat, 2);
+    expect(await handler.getLODPerDay(wheat)).to.equal(2n);
+  });
+
+  it("computes barter rate with LOD multiplier", async function () {
+    const wheat = ethers.encodeBytes32String("WHEAT");
+    await handler.setCommodityLOD(wheat, 2);
+    await handler.updateRate(100);
+    await ethers.provider.send("evm_increaseTime", [3 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
+    const rate = await handler.computeBarterRate(wheat);
+    expect(rate).to.equal(106n); // 100 + 2*3
+  });
 });


### PR DESCRIPTION
## Summary
- store master commodity values in `lod_data.json`
- support LOD mapping and computation in `RateHandler`
- test LOD logic in rate handler
- document JSON governance and formula
- expose REST endpoint for LOD data

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68464102f3a483258af9212ff156fd64