### PR TITLE
codex/meat-subtype-registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ sequenceDiagram
    *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 4. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
 5. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
+6. **Subtype Registry** – Kontrak MEAT menyimpan saldo per subtype (contoh `GOATMEAT`, `DUCKMEAT`). Hak khusus `mintSubtype` dan `burnSubtype` dapat diberikan ke kontrak lain seperti hook pembakaran NFT untuk mencatat produksi daging spesifik.
 
 ## Burn & Redeem Flow
 
@@ -226,6 +227,10 @@ MEAT juga memunculkan event utama berikut:
   dipicu saat `mint_with_native` dipanggil.
 - `SwapEnabledUpdated(status)` dicatat ketika pemilik mengubah status swap
   MEAT dan GOAT.
+- `SubtypeMinted(to, subtype, amount)` dicatat ketika minter terotorisasi
+  mencetak MEAT untuk subtype tertentu.
+- `SubtypeBurned(from, subtype, amount)` dicatat ketika burner terotorisasi
+  membakar MEAT subtype.
 
 ## Running Tests
 

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -14,6 +14,16 @@ contract MEAT is ERC20 {
     IGOAT public GOAT;
     address private immutable _owner;
 
+    // Authorized addresses allowed to mint or burn subtype balances
+    mapping(address => bool) public isMinter;
+    mapping(address => bool) public isBurner;
+
+    // Balance per user per subtype
+    mapping(address => mapping(bytes32 => uint256)) public subtypeBalances;
+
+    // Total supply per subtype
+    mapping(bytes32 => uint256) public subtypeTotalSupply;
+
     uint256 private _rate = 100;
     /// @notice Divisor untuk perhitungan jumlah MEAT yang dicetak saat menerima
     /// token native. Nilai default 1000 berarti deposit rate dihitung per 1000
@@ -32,9 +42,21 @@ contract MEAT is ERC20 {
     event GoatAddressUpdated(address indexed oldAddress, address indexed newAddress);
     event RateHandlerUpdated(address indexed oldAddress, address indexed newAddress);
     event SwapEnabledUpdated(bool status);
+    event SubtypeMinted(address indexed to, bytes32 indexed subtype, uint256 amount);
+    event SubtypeBurned(address indexed from, bytes32 indexed subtype, uint256 amount);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    modifier onlyMinter() {
+        require(isMinter[msg.sender], "Not minter");
+        _;
+    }
+
+    modifier onlyBurner() {
+        require(isBurner[msg.sender], "Not burner");
         _;
     }
 
@@ -139,6 +161,49 @@ contract MEAT is ERC20 {
         address old = address(GOAT);
         GOAT = IGOAT(goatAddress);
         emit GoatAddressUpdated(old, goatAddress);
+    }
+
+    /// @notice Menetapkan atau mencabut hak minter untuk alamat tertentu
+    function setMinter(address account, bool status) external onlyOwner {
+        isMinter[account] = status;
+    }
+
+    /// @notice Menetapkan atau mencabut hak burner untuk alamat tertentu
+    function setBurner(address account, bool status) external onlyOwner {
+        isBurner[account] = status;
+    }
+
+    function mintSubtype(address to, bytes32 subtype, uint256 amount) public onlyMinter {
+        require(subtype != bytes32(0), "Invalid subtype");
+        require(amount > 0, "Invalid amount");
+
+        subtypeBalances[to][subtype] += amount;
+        subtypeTotalSupply[subtype] += amount;
+
+        _mint(to, amount);
+
+        emit SubtypeMinted(to, subtype, amount);
+    }
+
+    function burnSubtype(address from, bytes32 subtype, uint256 amount) public onlyBurner {
+        require(subtype != bytes32(0), "Invalid subtype");
+        require(amount > 0, "Invalid amount");
+        require(subtypeBalances[from][subtype] >= amount, "Insufficient subtype balance");
+
+        subtypeBalances[from][subtype] -= amount;
+        subtypeTotalSupply[subtype] -= amount;
+
+        _burn(from, amount);
+
+        emit SubtypeBurned(from, subtype, amount);
+    }
+
+    function getBalanceOfSubtype(address user, bytes32 subtype) public view returns (uint256) {
+        return subtypeBalances[user][subtype];
+    }
+
+    function getTotalSupplyOfSubtype(bytes32 subtype) public view returns (uint256) {
+        return subtypeTotalSupply[subtype];
     }
 
     /// @notice Mengatur alamat kontrak rate handler untuk perhitungan swap

--- a/test/meatSubtype.test.js
+++ b/test/meatSubtype.test.js
@@ -1,0 +1,57 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MEAT subtype functions", function () {
+  let owner, minter, burner, user, goat, meat;
+
+  beforeEach(async function () {
+    [owner, minter, burner, user] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy(owner.address);
+    await goat.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    meat = await MEAT.deploy(goat.target);
+    await meat.waitForDeployment();
+
+    await meat.setMinter(minter.address, true);
+    await meat.setBurner(burner.address, true);
+  });
+
+  it("mints and burns subtype tokens", async function () {
+    const subtype = ethers.encodeBytes32String("GOATMEAT");
+    const amount = ethers.parseEther("10");
+
+    await expect(
+      meat.connect(minter).mintSubtype(user.address, subtype, amount)
+    )
+      .to.emit(meat, "SubtypeMinted")
+      .withArgs(user.address, subtype, amount);
+
+    expect(
+      await meat.getBalanceOfSubtype(user.address, subtype)
+    ).to.equal(amount);
+    expect(await meat.getTotalSupplyOfSubtype(subtype)).to.equal(amount);
+    expect(await meat.balanceOf(user.address)).to.equal(amount);
+
+    await expect(
+      meat.connect(burner).burnSubtype(user.address, subtype, amount)
+    )
+      .to.emit(meat, "SubtypeBurned")
+      .withArgs(user.address, subtype, amount);
+
+    expect(
+      await meat.getBalanceOfSubtype(user.address, subtype)
+    ).to.equal(0n);
+    expect(await meat.getTotalSupplyOfSubtype(subtype)).to.equal(0n);
+    expect(await meat.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("reverts burn with insufficient balance", async function () {
+    const subtype = ethers.encodeBytes32String("DUCKMEAT");
+    await expect(
+      meat.connect(burner).burnSubtype(user.address, subtype, 1)
+    ).to.be.revertedWith("Insufficient subtype balance");
+  });
+});


### PR DESCRIPTION
## Summary
- extend MEAT.sol with subtype registry and role-based mint/burn
- add helper functions and events for subtype operations
- update README with subtype usage and events
- test mintSubtype and burnSubtype logic

## Testing
- `npm install`
- `npx hardhat compile`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6846628421ec8325ac5c8ce321c30208