### PR TITLE
Restrict barter rates to PRODUCT layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
   `fat_g_per_kg`, `micronutrient_index_x1000`, `yield_per_cycle_kg`, dan
   `cycle_time_days`. Rasio barter antar layer dihitung dengan
   `computeBarterRate(fromCommodity, fromLayer, toCommodity, toLayer)` yang
-  mengembalikan `(lodFrom * 1e18) / lodTo`.
+  mengembalikan `(lodFrom * 1e18) / lodTo`. Mulai versi 1.1 hanya kombinasi
+  `PRODUCT`↔`PRODUCT` yang diizinkan.
 
 ### Memperbarui Data LOD
 

--- a/contracts/RateHandler.sol
+++ b/contracts/RateHandler.sol
@@ -107,6 +107,16 @@ contract RateHandler {
         bytes32 toCommodity,
         string memory toLayer
     ) public view returns (uint256) {
+        bytes32 productHash = keccak256("PRODUCT");
+        require(
+            keccak256(bytes(fromLayer)) == productHash,
+            "FROM layer must be PRODUCT"
+        );
+        require(
+            keccak256(bytes(toLayer)) == productHash,
+            "TO layer must be PRODUCT"
+        );
+
         uint256 fromLOD = getLODPerDay(fromCommodity, fromLayer);
         uint256 toLOD = getLODPerDay(toCommodity, toLayer);
 

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -34,7 +34,7 @@ Semua data dihasilkan pipeline `compute_lod.py` dan dirangkum dalam `lod_data.js
 
 LOD per layer dapat dibaca melalui `getLODPerDay(bytes32 commodityId, string layer)` dimana `layer` adalah `"NFT"`, `"VIRTUAL"`, atau `"PRODUCT"`.
 
-Fungsi `computeBarterRate(fromCommodity, fromLayer, toCommodity, toLayer)` menghitung rasio barter berbasis LOD antar dua representasi.
+Fungsi `computeBarterRate(fromCommodity, fromLayer, toCommodity, toLayer)` menghitung rasio barter berbasis LOD antar dua representasi. Sejak v1.1, kedua `layer` harus bernilai `"PRODUCT"`.
 
 ## Formula
 

--- a/test/rateHandler.test.js
+++ b/test/rateHandler.test.js
@@ -136,7 +136,7 @@ describe("RateHandler integration", function () {
     ).to.equal(4n);
   });
 
-  it("computes barter rate between layers", async function () {
+  it("computes barter rate for PRODUCT to PRODUCT", async function () {
     const wheat = ethers.encodeBytes32String("WHEAT");
     const rice = ethers.encodeBytes32String("RICE");
     await handler.setCommodityRepresentation(wheat, {
@@ -176,11 +176,11 @@ describe("RateHandler integration", function () {
 
     const rate = await handler[
       "computeBarterRate(bytes32,string,bytes32,string)"
-    ](wheat, "NFT", rice, "PRODUCT");
-    expect(rate).to.equal((2n * 10n ** 18n) / 10n);
+    ](wheat, "PRODUCT", rice, "PRODUCT");
+    expect(rate).to.equal((4n * 10n ** 18n) / 10n);
   });
 
-  it("computes barter rates across layer combinations", async function () {
+  it("reverts when layers are not PRODUCT", async function () {
     const barley = ethers.encodeBytes32String("BARLEY");
     await handler.setCommodityRepresentation(barley, {
       nftAddress: ethers.ZeroAddress,
@@ -200,24 +200,22 @@ describe("RateHandler integration", function () {
       cycle_time_days: 1,
     });
 
-    const rateNV = await handler[
-      "computeBarterRate(bytes32,string,bytes32,string)"
-    ](barley, "NFT", barley, "VIRTUAL");
-    expect(rateNV).to.equal((2n * 10n ** 18n) / 4n);
+    await expect(
+      handler["computeBarterRate(bytes32,string,bytes32,string)"](
+        barley,
+        "NFT",
+        barley,
+        "VIRTUAL"
+      )
+    ).to.be.revertedWith("FROM layer must be PRODUCT");
 
-    const rateVP = await handler[
-      "computeBarterRate(bytes32,string,bytes32,string)"
-    ](barley, "VIRTUAL", barley, "PRODUCT");
-    expect(rateVP).to.equal((4n * 10n ** 18n) / 8n);
-
-    const ratePP = await handler[
-      "computeBarterRate(bytes32,string,bytes32,string)"
-    ](barley, "PRODUCT", barley, "PRODUCT");
-    expect(ratePP).to.equal(10n ** 18n);
-
-    const rateNN = await handler[
-      "computeBarterRate(bytes32,string,bytes32,string)"
-    ](barley, "NFT", barley, "NFT");
-    expect(rateNN).to.equal(10n ** 18n);
+    await expect(
+      handler["computeBarterRate(bytes32,string,bytes32,string)"](
+        barley,
+        "PRODUCT",
+        barley,
+        "VIRTUAL"
+      )
+    ).to.be.revertedWith("TO layer must be PRODUCT");
   });
 });


### PR DESCRIPTION
## Summary
- require both layers be `PRODUCT` in `computeBarterRate`
- adjust integration tests for new requirement
- document limitation in README and governance docs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684667705c84832591387869fba2db19