### PR TITLE
Update docs for new NFT flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Berikut gambaran umum alur penggunaan kedua token:
 3. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
 4. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
 5. **Subtype Registry** – Kontrak MEAT menyimpan saldo per subtype (contoh `GOATMEAT`, `DUCKMEAT`). Hak khusus `mintSubtype` dan `burnSubtype` dapat diberikan ke kontrak lain seperti hook pembakaran NFT untuk mencatat produksi daging spesifik.
-6. **GoatNFTBurnHook** – Hook ini dipanggil saat NFT dibakar dan otomatis mencetak `GOATMEAT` sesuai berat yang dilaporkan.
-7. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya. Untuk membuka kembali, jumlah GOAT yang sama harus dibakar.
+6. **GoatNFTBurnHook** – Hook ini dipanggil saat NFT dibakar dan otomatis mencetak `GOATMEAT` sesuai berat yang dilaporkan untuk dipertukarkan lewat `RateHandler`.
+7. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya untuk keperluan staking. Membuka kembali NFT mengharuskan jumlah GOAT yang sama dibakar.
 
 ## Burn & Redeem Flow
 
@@ -29,19 +29,22 @@ Berikut langkah detail siklus kambing hingga daging tercatat di ledger:
  - Pemilik dapat memperbarui berat melalui `updateWeight()` agar nilainya tetap valid (dibutuhkan sebelum burn).
  - Nilai `weight` disimpan dengan satu tempat desimal menggunakan `WEIGHT_DECIMALS = 1` sehingga `425` berarti **42.5 kg**.
 - NFT (standar ERC721) bebas dipindahtangankan ke pemilik baru.
-- Ketika kambing disembelih, pemilik membakar NFT; kontrak otomatis mencetak GOAT sejumlah `weight / rate` dimana `rate` berasal dari `RateHandler`.
- - GOAT dapat diperdagangkan atau langsung di-stake untuk memperoleh reward.
- - MEAT kemudian ditebus sebagai daging nyata sehingga seluruh riwayat ternak tersimpan on-chain.
+- Untuk memperoleh GOAT sebelum penyembelihan, pemilik mengunci NFT melalui `GoatNFTWrapper` yang mencetak GOAT berdasarkan berat terakhir.
+- Ketika kambing disembelih, pemilik membakar NFT; `GoatNFTBurnHook` mencetak `GOATMEAT` sejumlah `weight / rate` dari `RateHandler`.
+- GOAT digunakan untuk staking sementara GOATMEAT dipertukarkan antar produk melalui `RateHandler`.
+- MEAT kemudian ditebus sebagai daging nyata sehingga seluruh riwayat ternak tersimpan on-chain.
 
 ```mermaid
 flowchart LR
-  GoatNFT -- "burn" --> GOAT
-  GOAT -- "redeemForMeat" --> RealMeat["Real Meat"]
+  GoatNFT -- "wrap" --> GOAT
+  GoatNFT -- "burn" --> GOATMEAT
+  GOAT --> Staking
+  GOATMEAT -- "RateHandler" --> ProductToken["Other Meat Tokens"]
 ```
 
-- Membakar `GoatNFT` otomatis mencetak GOAT sejumlah `weight / rate`.
-- Hook `GoatNFTBurnHook` turut mencetak GOATMEAT berdasarkan bobot ternak.
-- GOAT dapat diperdagangkan atau digunakan dalam ekosistem.
+- Membungkus `GoatNFT` mencetak GOAT yang bisa langsung di-stake.
+- Membakar `GoatNFT` menghasilkan GOATMEAT sesuai bobot ternak.
+- GOATMEAT dapat dipertukarkan dengan token produk lain melalui `RateHandler`.
 - Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**.
 
 ## What is GoatNFT?
@@ -166,7 +169,7 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
 
 ## Parameter Penting
 
-- **SWAP_RATE** – konstanta di `SwapConfig` yang menjadi fallback pada `RateHandler`. Nilai default `85` berarti 1 GOAT setara dengan 85 MEAT.
+ - **SWAP_RATE** – konstanta di `SwapConfig` yang menjadi fallback pada `RateHandler`. Nilai default `85` dipakai menghitung jumlah GOAT atau GOATMEAT dari berat NFT.
 - **dynamicRate** – nilai saat ini dari RateHandler jika masih valid. Diset lewat `updateRate` yang memancarkan event `RateUpdated`. Jika dinonaktifkan dengan `invalidateRate`, kontrak memakai `SWAP_RATE` dan event `RateInvalidated` dicatat.
 - **DepositRate** – rasio pencetakan MEAT ketika menerima native token. Nilai
   dihitung per `DEPOSIT_DIVISOR` (1000) unit native token sehingga `100` berarti
@@ -326,8 +329,9 @@ saldo token pengguna.
 
 ## 🧠 Perubahan Terakhir
 
-Commit *Simplify MEAT swap allowance logic (#12)* awalnya merombak mekanisme swap.
-Kini fungsi swap telah dihapus sehingga perubahan tersebut tidak lagi berlaku.
+Mekanisme tukar langsung GOAT↔MEAT digantikan alur baru:
+- `GoatNFTWrapper` mencetak GOAT untuk staking dengan mengunci NFT.
+- `GoatNFTBurnHook` mencetak GOATMEAT saat NFT dibakar. Token GOATMEAT dapat dibarter lewat `RateHandler`.
 
 ## 🧪 Testing
 

--- a/docs/frontend-pages.md
+++ b/docs/frontend-pages.md
@@ -28,8 +28,8 @@ Dokumen ini merangkum halaman-halaman utama yang akan ada pada UI penuh dan hubu
   - `unstake()` – menarik pokok beserta reward setelah `minClaimInterval`.
 
 ## `/burn`
-*Gambaran*: membakar `GoatNFT` untuk menebus nilai beratnya menjadi token GOAT.
+*Gambaran*: membakar `GoatNFT` untuk mencetak `GOATMEAT` berdasarkan berat ternak.
 - **Input Pengguna**: `tokenId` NFT yang akan dibakar.
-- **Panggilan Kontrak**: `burn(tokenId)` pada `GoatNFT` yang secara internal mencetak GOAT setara.
+- **Panggilan Kontrak**: `burn(tokenId)` pada `GoatNFT` yang memicu `GoatNFTBurnHook`.
 
-Halaman-halaman ini mengikuti alur yang diuji di `test/` seperti `stakingSwap.test.js` dan `nftBurnMint.test.js`, memastikan aksi UI sesuai dengan perilaku on-chain.
+Halaman-halaman ini mengikuti alur yang diuji di `test/` seperti `wrapper.test.js`, `goatMeatHook.test.js`, dan `nftBurnMint.test.js`, memastikan aksi UI sesuai dengan perilaku on-chain.

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -4,8 +4,8 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 
 - Setiap **GoatNFT** mencatat *ras*, *NFC tag*, *tahun lahir*, dan *berat* terkini.
 - Pemilik bebas memindahkan NFT dan memperbarui berat seiring pertumbuhan hewan.
-- Sebelum kambing disembelih, token harus **dibakar** dengan berat terbaru yang secara otomatis mencetak GOAT.
-- Token GOAT kemudian dapat di-stake untuk reward atau ditukar menjadi MEAT.
+- Sebelum kambing disembelih, token dapat **dibakar** dengan berat terbaru yang mencetak `GOATMEAT` melalui `GoatNFTBurnHook`.
+- GOAT diperoleh dengan mengunci NFT pada `GoatNFTWrapper` dan digunakan untuk staking.
 - MEAT pada akhirnya dibakar menggunakan `redeemForMeat` untuk menebus daging fisik.
 
 1. **Mencetak MEAT**
@@ -14,14 +14,15 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 2. **GoatNFT**
    * [GoatNFT](contracts/GoatNFT.sol) mewakili kambing hidup dan menyimpan beratnya di `goatValue`.
    * Pemilik dapat memperbarui berat kapan saja (event `WeightUpdated`). Berat memakai satu desimal (`WEIGHT_DECIMALS = 1`) sehingga `425` berarti **42.5 kg**.
-   * Sebelum membakar NFT, berat harus diperbarui dalam tujuh hari terakhir. Fungsi `burn` otomatis mencetak GOAT dan memancarkan `GoatBurned`.
+   * Sebelum membakar NFT, berat harus diperbarui dalam tujuh hari terakhir. Fungsi `burn` memicu `GoatNFTBurnHook` yang mencetak `GOATMEAT`.
 3. **Staking GOAT**
+   * GOAT diperoleh dengan membungkus GoatNFT melalui `GoatNFTWrapper`.
    * Pemegang GOAT melakukan staking di `GOAT.sol` yang mencatat saldo dan timestamp. Reward terakumulasi secara linier berdasarkan `rewardRate` dan `rewardInterval`.
    * Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil. Klaim terlebih dahulu jika ingin menambah stake.
 4. **Mengambil Reward**
    * Setelah `minClaimInterval`, staker bisa mengambil reward atau menggabungkannya kembali ke stake. Untuk keluar sepenuhnya panggil `unstake` agar pokok dan reward diterima.
-5. **Kembali ke MEAT**
-   * GOAT yang tidak di-stake dapat ditukar kembali ke MEAT yang lalu dapat ditarik dari ekosistem atau digunakan lagi.
+5. **Barter Produk**
+   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler`.
 6. **Menebus MEAT**
    * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
 

--- a/user-journey.md
+++ b/user-journey.md
@@ -5,10 +5,11 @@ Dokumen ini menggambarkan pengalaman umum bagi peserta baru di ekosistem GOAT/ME
 1. **Mendapatkan MEAT**
    * Pengguna membuka aplikasi web, menghubungkan dompet, lalu mengirim sejumlah kecil token native ke kontrak MEAT. Kontrak akan mencetak MEAT sesuai `DepositRate` saat ini.
 2. **Staking untuk Reward**
-   * Dengan token GOAT di dompet, pengguna melakukan staking untuk mulai memperoleh reward. UI menampilkan hitungan mundur hingga klaim diperbolehkan (`minClaimInterval`).
+   * Pengguna membungkus GoatNFT melalui `GoatNFTWrapper` untuk memperoleh GOAT.
+   * GOAT tersebut kemudian di-stake dan UI menampilkan hitungan mundur hingga klaim diperbolehkan (`minClaimInterval`).
 3. **Panen**
    * Setelah interval terpenuhi, pengguna dapat mengklaim reward secara langsung atau menggabungkannya kembali ke staking guna menambah pokok.
 4. **Keluar**
-   * Ketika selesai, pengguna melakukan unstake untuk menarik GOAT asli beserta reward lalu dapat segera menukar kembali ke MEAT. MEAT tersebut bisa diperdagangkan atau disimpan.
+   * Ketika selesai, pengguna melakukan unstake untuk menarik GOAT asli beserta reward. Membakar NFT setelah penyembelihan akan menghasilkan `GOATMEAT` yang dapat dibarter dengan token produk lain melalui `RateHandler`.
 
 Sepanjang siklus ini pengguna berinteraksi dengan kedua kontrak hanya melalui fungsi yang diizinkan sehingga dana tetap aman namun fleksibel.


### PR DESCRIPTION
## Summary
- explain wrapper and GOATMEAT swap flow in docs
- remove outdated GOAT↔MEAT swap references
- reflect new tests mentioned in docs

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684674d2e8f4832584d8fe17c21ecd32