### PR TITLE
Add canonical reasoning path diagram

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -21,3 +21,51 @@ Lingkungan Hardhat menjalankan proses deployment (`scripts/deploy.js`) dan pengu
 Frontend berkomunikasi dengan kontrak yang telah dideploy menggunakan `ethers.js`, menyediakan alur untuk mencetak MEAT serta melakukan staking dan klaim reward. Frontend mengandalkan alamat deployment dan artefak ABI yang dihasilkan Hardhat.
 
 Gabungan komponen ini membentuk stack lengkap di mana pengguna berinteraksi melalui frontend, yang selanjutnya terhubung ke blockchain lewat kontrak GOAT dan MEAT.
+
+## Token Layer Separation & LOD Engine Enforcement
+
+```mermaid
+graph TD
+    subgraph LIVESTOCK_CAPITAL_LAYER ["🐐 LIVESTOCK CAPITAL LAYER"]
+        GoatNFT[GoatNFT (ERC721)<br>Physical Goat Identity] -- wrapToGOAT --> GOAT[GOAT Token (ERC20)<br>Financial Layer Only]
+        GOAT -- unwrapToNFT --> GoatNFT
+        GOAT -- staking --> RewardPool[Reward Pool / Governance]
+    end
+
+    subgraph PRODUCT_LAYER ["🥩 PRODUCT LAYER"]
+        GoatNFT -- burnForMeat --> GOATMEAT[MEAT.sol<br>subtype=GOATMEAT<br>Product Token]
+        GOATMEAT -- barter/sell/deliver --> RealEconomy[Real Economy<br>(Barter / Swap / Deliver)]
+    end
+
+    subgraph LOD_MASTER ["📚 LOD MASTER"]
+        LOD[LOD Engine<br>commodity_type=HEWAN] -->|LOD parity| GOATMEAT
+    end
+
+    subgraph FORBIDDEN_PATH ["🚫 FORBIDDEN PATH (Explicit Blocked)"]
+        GOAT -.X.-> GOATMEAT
+        GOATMEAT -.X.-> GOAT
+        RateHandler -.X.-> CrossLayerSwap[Cross Layer Swap<br>FORBIDDEN]
+    end
+```
+
+**🐐 LIVESTOCK CAPITAL LAYER**
+
+GoatNFT → wrap → GOAT token → Financial token only → untuk staking/gov/ROI dan tidak digunakan di RateHandler.
+
+GOAT token → unwrap → mengembalikan GoatNFT secara reversibel.
+
+Staking GOAT → lapisan finansial → mengalir ke Reward Pool.
+
+**🥩 PRODUCT LAYER**
+
+GoatNFT dibakar → mencetak GOATMEAT sebagai hasil penyembelihan.
+
+GOATMEAT diperdagangkan → barter, jual, atau dikirim ke ekonomi riil.
+
+**📚 LOD MASTER**
+
+LOD Engine mengawasi paritas → commodity_type=HEWAN → dipetakan ke subtype GOATMEAT.
+
+**🚫 FORBIDDEN PATH**
+
+Pertukaran langsung GOAT ↔ GOATMEAT dilarang. RateHandler hanya memperbolehkan swap PRODUCT↔PRODUCT agar nilai tetap hidup dan tidak bocor.

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -14,6 +14,8 @@ Setiap komoditas direpresentasikan sebagai:
 
 LOD per hari untuk tiap layer disimpan on-chain.
 
+Lihat diagram *Canonical Reasoning Path* pada [architecture.md](../architecture.md#token-layer-separation--lod-engine-enforcement) bagian 4 untuk pemahaman menyeluruh mengenai pemisahan layer dan aturan swap.
+
 ---
 
 ## 🛠️ Governance Workflow

--- a/goat-meat-lifecycle.md
+++ b/goat-meat-lifecycle.md
@@ -27,3 +27,31 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
    * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
 
 Siklus ini memastikan setiap tahap partisipasi didukung oleh fungsi kontrak yang eksplisit dan alur token yang transparan.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph LIVESTOCK_CAPITAL_LAYER ["🐐 LIVESTOCK CAPITAL LAYER"]
+        GoatNFT[GoatNFT (ERC721)<br>Physical Goat Identity] -- wrapToGOAT --> GOAT[GOAT Token (ERC20)<br>Financial Layer Only]
+        GOAT -- unwrapToNFT --> GoatNFT
+        GOAT -- staking --> RewardPool[Reward Pool / Governance]
+    end
+
+    subgraph PRODUCT_LAYER ["🥩 PRODUCT LAYER"]
+        GoatNFT -- burnForMeat --> GOATMEAT[MEAT.sol<br>subtype=GOATMEAT<br>Product Token]
+        GOATMEAT -- barter/sell/deliver --> RealEconomy[Real Economy<br>(Barter / Swap / Deliver)]
+    end
+
+    subgraph LOD_MASTER ["📚 LOD MASTER"]
+        LOD[LOD Engine<br>commodity_type=HEWAN] -->|LOD parity| GOATMEAT
+    end
+
+    subgraph FORBIDDEN_PATH ["🚫 FORBIDDEN PATH (Explicit Blocked)"]
+        GOAT -.X.-> GOATMEAT
+        GOATMEAT -.X.-> GOAT
+        RateHandler -.X.-> CrossLayerSwap[Cross Layer Swap<br>FORBIDDEN]
+    end
+```
+
+Diagram di atas menunjukkan pemisahan lapisan token dan jalur pertukaran yang diizinkan.


### PR DESCRIPTION
## Summary
- document token separation with LOD enforcement
- embed mermaid architecture diagram in GOAT/MEAT lifecycle
- add reference in governance guide

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68467d502e888325a32bfe69409d2e7d