### PR TITLE
codex/remove-legacy-rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
   `cycle_time_days`. Rasio barter antar layer dihitung dengan
   `computeBarterRate(fromCommodity, fromLayer, toCommodity, toLayer)` yang
   mengembalikan `(lodFrom * 1e18) / lodTo`. Mulai versi 1.1 hanya kombinasi
-  `PRODUCT`↔`PRODUCT` yang diizinkan.
+  `PRODUCT`↔`PRODUCT` yang diizinkan dan jalur lama `computeBarterRate(bytes32)`
+  telah dihapus. Fungsi `getLODPerDay(bytes32)` tetap ada untuk audit namun
+  tidak dipakai dalam logika swap.
 
 ### Memperbarui Data LOD
 

--- a/contracts/RateHandler.sol
+++ b/contracts/RateHandler.sol
@@ -75,6 +75,8 @@ contract RateHandler {
         c.cycle_time_days = data.cycle_time_days;
     }
 
+    /// @notice [DEPRECATED] Use getLODPerDay(bytes32 commodityId, string layer)
+    /// @dev Kept for governance audit compatibility only.
     function getLODPerDay(bytes32 commodity) public view returns (uint256) {
         return commodityLOD[commodity].lodPerDay;
     }
@@ -93,14 +95,9 @@ contract RateHandler {
         }
     }
 
-    function computeBarterRate(bytes32 commodity) public view returns (uint256) {
-        uint256 base = getCurrentRate();
-        uint256 lod = commodityLOD[commodity].lodPerDay;
-        if (lod == 0) return base;
-        uint256 daysPassed = (block.timestamp - lastUpdateTimestamp) / 1 days;
-        return base + (lod * daysPassed);
-    }
 
+    /// @notice Compute barter rate between two commodities
+    /// @dev Only PRODUCT↔PRODUCT swaps are allowed and enforced.
     function computeBarterRate(
         bytes32 fromCommodity,
         string memory fromLayer,

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -77,7 +77,8 @@ npx hardhat test test/RateHandler.test.js
 Semua test harus lulus:
 
 - `getLODPerDay` bekerja untuk tiap layer.
-- `computeBarterRate` benar sesuai rasio LOD.
+  Fungsi versi lama dengan satu argumen dipertahankan hanya untuk audit.
+- `computeBarterRate` benar sesuai rasio LOD (hanya `PRODUCT↔PRODUCT`, versi singkat dihapus).
 - Layer tidak valid harus revert.
 
 ### 6⃣ Commit `lod_data.json`

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -32,9 +32,9 @@ Pemilik kontrak dapat memanggil `setCommodityRepresentation(bytes32 commodityId,
 
 Semua data dihasilkan pipeline `compute_lod.py` dan dirangkum dalam `lod_data.json`.
 
-LOD per layer dapat dibaca melalui `getLODPerDay(bytes32 commodityId, string layer)` dimana `layer` adalah `"NFT"`, `"VIRTUAL"`, atau `"PRODUCT"`.
+LOD per layer dapat dibaca melalui `getLODPerDay(bytes32 commodityId, string layer)` dimana `layer` adalah `"NFT"`, `"VIRTUAL"`, atau `"PRODUCT"`. Versi lama `getLODPerDay(bytes32)` dipertahankan hanya untuk audit governance.
 
-Fungsi `computeBarterRate(fromCommodity, fromLayer, toCommodity, toLayer)` menghitung rasio barter berbasis LOD antar dua representasi. Sejak v1.1, kedua `layer` harus bernilai `"PRODUCT"`.
+Fungsi `computeBarterRate(fromCommodity, fromLayer, toCommodity, toLayer)` menghitung rasio barter berbasis LOD antar dua representasi. Sejak v1.1, kedua `layer` harus bernilai `"PRODUCT"` dan fungsi versi singkat telah dihapus.
 
 ## Formula
 


### PR DESCRIPTION
## Summary
- remove old `computeBarterRate(bytes32)` path
- deprecate `getLODPerDay(bytes32)` and document PRODUCT↔PRODUCT enforcement
- update docs for governance about the deprecated calls

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6846828dc514832586c45f1ab2ca8569