### PR TITLE
Remove leftover swap artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ saldo token pengguna.
 
 ## 🧠 Perubahan Terakhir
 
-Mekanisme tukar langsung GOAT↔MEAT digantikan alur baru:
+Mekanisme lama digantikan alur baru:
 - `GoatNFTWrapper` mencetak GOAT untuk staking dengan mengunci NFT.
 - `GoatNFTBurnHook` mencetak GOATMEAT saat NFT dibakar. Token GOATMEAT dapat dibarter lewat `RateHandler`.
 

--- a/backend/abi/MEAT.json
+++ b/backend/abi/MEAT.json
@@ -318,69 +318,6 @@
       "anonymous": false,
       "inputs": [
         {
-          "indexed": false,
-          "internalType": "bool",
-          "name": "status",
-          "type": "bool"
-        }
-      ],
-      "name": "SwapEnabledUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "user",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "goatIn",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "meatOut",
-          "type": "uint256"
-        }
-      ],
-      "name": "SwappedGOATForMEAT",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "user",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "meatIn",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "goatOut",
-          "type": "uint256"
-        }
-      ],
-      "name": "SwappedMEATForGOAT",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
           "indexed": true,
           "internalType": "address",
           "name": "from",
@@ -816,19 +753,6 @@
     {
       "inputs": [
         {
-          "internalType": "bool",
-          "name": "status",
-          "type": "bool"
-        }
-      ],
-      "name": "setSwapEnabled",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
           "internalType": "address",
           "name": "",
           "type": "address"
@@ -864,19 +788,6 @@
           "internalType": "uint256",
           "name": "",
           "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "swapEnabled",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
         }
       ],
       "stateMutability": "view",

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -29,19 +29,15 @@ contract MEAT is ERC20 {
     /// token native. Nilai default 1000 berarti deposit rate dihitung per 1000
     /// unit native token.
     uint256 public constant DEPOSIT_DIVISOR = 1000;
-    bool public swapEnabled = true;
     RateHandler public rateHandler;
 
     event DepositRateChanged(uint256 oldRate, uint256 newRate);
     event MintedWithNative(address indexed user, uint256 nativeReceived, uint256 meatMinted);
     event NativeWithdrawn(address indexed to, uint256 amount);
-    event SwappedGOATForMEAT(address indexed user, uint256 goatIn, uint256 meatOut);
-    event SwappedMEATForGOAT(address indexed user, uint256 meatIn, uint256 goatOut);
     event InitialSupplyMinted(address indexed to, uint256 amount);
     event MeatRedeemed(address indexed user, uint256 amount);
     event GoatAddressUpdated(address indexed oldAddress, address indexed newAddress);
     event RateHandlerUpdated(address indexed oldAddress, address indexed newAddress);
-    event SwapEnabledUpdated(bool status);
     event SubtypeMinted(address indexed to, bytes32 indexed subtype, uint256 amount);
     event SubtypeBurned(address indexed from, bytes32 indexed subtype, uint256 amount);
 
@@ -114,11 +110,6 @@ contract MEAT is ERC20 {
         require(amount > 0, "Amount must be > 0");
         _burn(msg.sender, amount);
         emit MeatRedeemed(msg.sender, amount);
-    }
-
-    function setSwapEnabled(bool status) external onlyOwner {
-        swapEnabled = status;
-        emit SwapEnabledUpdated(status);
     }
 
     function setGOATAddress(address goatAddress) external onlyOwner {


### PR DESCRIPTION
## Summary
- remove unused swap flags and events from `MEAT.sol`
- drop related ABI entries
- update README to remove mention of GOAT↔MEAT swap

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684687d6e71c8325b1eee5cc03d25a46