### PR TITLE
docs: clarify goat minting flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Repositori ini berisi dua token ERC20:
 
-- **GOAT** (Guardian of Agricultural Trade) mendukung proses staking dan penggabungan imbalan. Kontrak MEAT yang ditunjuk dapat mencetak token GOAT baru sementara pemegang token dapat melakukan staking guna memperoleh imbal hasil tahunan yang tinggi.
+- **GOAT** (Guardian of Agricultural Trade) mendukung proses staking. Token GOAT dicetak saat `GoatNFT` dikunci melalui `GoatNFTWrapper`. Pemegang dapat melakukan staking guna memperoleh imbal hasil tahunan tinggi.
 - **MEAT** (Market-Enabled Agricultural Token) memungkinkan pengguna mencetak token dengan mata uang native dan menjadi gerbang utama bagi ekosistem.
 
 ## Cara Kerja Token
@@ -282,9 +282,7 @@ Setelah itu edit `frontend/.env.local` dan isi `NEXT_PUBLIC_GOAT_ADDRESS` serta 
 ## 🧱 Struktur Kontrak
 
 Struktur dan hubungan antar kontrak:
-- `GOAT` (`contracts/GOAT.sol`) mewarisi `ERC20` OpenZeppelin dan menambahkan
-  fungsi staking, klaim, kompaun, serta konfigurasi reward. Hanya kontrak `MEAT`
-  yang dapat mencetak GOAT melalui `mintTo`. Versi CosmWasm memakai pesan `burn_and_mint` untuk menebus GoatNFT dan menyediakan `emergency_unstake`.
+- `GOAT` (`contracts/GOAT.sol`) mewarisi `ERC20` OpenZeppelin dan menambahkan fungsi staking, klaim, kompaun, serta konfigurasi reward. Token hanya dicetak melalui `GoatNFTWrapper` saat NFT dibungkus.
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Pengaturan `set_rate_handler` menghubungkan kontrak RateHandler guna mendukung rasio dinamis.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
@@ -292,8 +290,7 @@ Struktur dan hubungan antar kontrak:
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.
   Pemilik dapat memperbarui berat melalui `updateWeight` (memancarkan `WeightUpdated`); berat terakhir harus
   masih valid (<=7 hari) saat dibakar. Fungsi `burn` kini hanya memicu `GoatNFTBurnHook` untuk mencetak `GOATMEAT`. Event `GoatBurned` tetap dipancarkan sebagai catatan berat dan rasio. Data dapat dibaca ulang melalui `getGoatData` dan dihapus setelah `burn`.
-- `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo`
-  untuk dipanggil MEAT saat membutuhkan GOAT baru. `IGoatToken` dipakai GoatNFT agar kontrak GOAT dapat mencetak token saat NFT dibakar.
+- `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper` saat mencetak GOAT baru. `IGoatToken` dipakai oleh wrapper dan NFT untuk berinteraksi dengan kontrak GOAT.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test
   guna mensimulasikan kegagalan `transfer`.
 - `emergencyUnstake` memungkinkan penarikan token yang di-stake tanpa reward kapan saja.

--- a/architecture.md
+++ b/architecture.md
@@ -4,13 +4,13 @@ Proyek ini berpusat pada dua kontrak ERC20—**GOAT** dan **MEAT**—yang didepl
 
 ## Lapisan On-Chain
 
-* **GOAT (`contracts/GOAT.sol`)** – menyediakan staking dengan reward berbasis waktu, memungkinkan kontrak MEAT mencetak suplai baru, dan menawarkan kontrol pemilik seperti pengaturan reward serta alamat MEAT.
+* **GOAT (`contracts/GOAT.sol`)** – menyediakan staking dengan reward berbasis waktu dan kontrol konfigurasi. Suplai GOAT dicetak melalui `GoatNFTWrapper`.
 * **MEAT (`contracts/MEAT.sol`)** – mencetak token saat menerima mata uang native (menggunakan `DepositRate` per 1000 unit), mengendalikan deposit rate, serta dapat menarik saldo native yang terkumpul.
 * **GoatNFT (`contracts/GoatNFT.sol`)** – menyimpan detail kambing on-chain dalam `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Setiap `nfcId` dipetakan ke token ID sehingga duplikasi ditolak saat mint. Pemilik dapat memanggil `updateWeight` untuk memperbarui berat (menerbitkan `WeightUpdated`). `burn` mensyaratkan pembaruan berat dalam 7 hari terakhir, memicu `GoatNFTBurnHook` dan `GoatBurned` sambil menghapus pemetaan NFC.
 * **GoatNFTBurnHook (`contracts/GoatNFTBurnHook.sol`)** – dipanggil oleh `GoatNFT` saat token dibakar untuk mencetak `GOATMEAT` berdasarkan bobot.
 * **GoatNFTWrapper (`contracts/GoatNFTWrapper.sol`)** – kontrak pembungkus yang mengunci GoatNFT dan mencetak GOAT setara. NFT dapat diambil kembali setelah jumlah GOAT yang sama dibakar.
 * **RateHandler (`contracts/RateHandler.sol`)** – menyimpan `dynamicRate` yang dipakai MEAT dan GoatNFT. Pemilik dapat menetapkan nilai baru melalui `updateRate` (memicu event `RateUpdated`) atau menonaktifkan rate dengan `invalidateRate` sehingga kontrak kembali menggunakan `SWAP_RATE` dari `SwapConfig` serta memancarkan `RateInvalidated`. Kepemilikan dapat dialihkan lewat `transferOwnership`.
-* **Interface dan mock** – `IGOAT` mendefinisikan hook pencetakan yang digunakan MEAT, sedangkan `FailingGOAT` membantu pengujian dengan mensimulasikan kegagalan transfer.
+* **Interface dan mock** – `IGOAT` mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper`, sedangkan `FailingGOAT` membantu pengujian dengan mensimulasikan kegagalan transfer.
 
 ## Backend
 

--- a/contract-map.md
+++ b/contract-map.md
@@ -19,24 +19,24 @@ flowchart TD
 ```
 
 * **MEAT** berperan sebagai gerbang: menerima koin native, mencetak MEAT, dan mengontrol rasio deposit. Pemilik dapat menarik saldo native yang terkumpul.
-* **GOAT** menerima suplai hasil cetak dari MEAT dan menyediakan fungsi staking. Reward serta parameter konfigurasi dapat diatur pemilik.
+* **GOAT** menerima suplai dari GoatNFTWrapper yang mencetak token saat NFT dibungkus. Reward serta parameter konfigurasi dapat diatur pemilik.
   - `emergencyUnstake` memungkinkan staker menarik token tanpa reward kapan saja.
 * **FailingGOAT** hanya untuk pengujian; menerapkan antarmuka yang sama namun memungkinkan simulasi kegagalan transfer.
-* **IGOAT** mendefinisikan fungsi `mintTo` yang memungkinkan MEAT mencetak GOAT bila diperlukan.
-* **IGoatToken** dipakai GoatNFT agar kontrak GOAT dapat mencetak token saat NFT dibakar.
+* **IGOAT** mendefinisikan fungsi `mintTo` yang memungkinkan GoatNFTWrapper mencetak GOAT.
+* **IGoatToken** dipakai GoatNFTWrapper dan GoatNFT untuk berinteraksi dengan kontrak GOAT.
 * **RateHandler** mengendalikan rasio swap terkini. `updateRate` memancarkan `RateUpdated` sedangkan `invalidateRate` mengembalikan nilai ke konstanta di `SwapConfig`.
 
-Kontrak MEAT bergantung pada GOAT untuk mencetak token baru. Keduanya memiliki pemilik yang sama yang dapat mengatur rate. Tabel di bawah merangkum kontrak utama beserta perannya.
+Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontrak utama beserta perannya.
 
 | Kontrak | Deskripsi | Fungsi Kunci |
 |---------|-----------|--------------|
-| GOAT | Token ERC20 untuk staking yang dicetak oleh MEAT dan pembakaran GoatNFT. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `mint`, `setMEATAddress`, `setNFTAddress` |
+| GOAT | Token ERC20 untuk staking yang dicetak oleh GoatNFTWrapper saat NFT dibungkus. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `mint`, `setMEATAddress`, `setNFTAddress` |
 | MEAT | Token ERC20 yang dicetak dengan deposit native. | `changeDepositRate`, `withdrawNative`, `setGOATAddress` |
 | GoatNFT | Identitas kambing ERC721 yang menyimpan metadata di `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Berat dapat diperbarui via `updateWeight` (memancarkan `WeightUpdated`) dan harus segar saat dibakar. Fungsi `burn` memicu `GoatNFTBurnHook` serta event `GoatBurned`. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
 | GoatNFTBurnHook | Kontrak hook yang mencetak `GOATMEAT` setiap kali GoatNFT dibakar. | `onBurn`, `setNFTAddress`, `setMEATAddress` |
 | GoatNFTWrapper | Mengunci GoatNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. | `wrap`, `unwrap`, `setRateHandler` |
-| IGOAT | Antarmuka pencetakan GOAT yang digunakan MEAT. | `mintTo` |
-| IGoatToken | Antarmuka pencetakan GOAT yang digunakan GoatNFT. | `mint`, `burnFrom` |
+| IGOAT | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper. | `mintTo` |
+| IGoatToken | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper dan GoatNFT. | `mint`, `burnFrom` |
 
 GOAT memancarkan `MeatAddressUpdated` dan `NftAddressUpdated` setiap kali pemilik memperbarui alamat kontrak MEAT atau GoatNFT.
 MEAT memancarkan `GoatAddressUpdated` setiap kali pemilik memperbarui alamat kontrak GOAT.

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -76,6 +76,7 @@ wasmd tx wasm execute <nft_address> '{"burn":{"token_id":1}}' \
   --from wallet --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
+Catatan: pesan `burn_and_mint` pada versi terdahulu telah dihapus. Proses burn hanya mencetak `GOATMEAT`. GOAT diperoleh dengan membungkus NFT melalui `GoatNFTWrapper`.
 
 ## Contoh Query
 


### PR DESCRIPTION
## Summary
- clarify that GoatNFTWrapper is the only contract that mints GOAT
- update architecture and contract map to reflect wrapper minting
- note old `burn_and_mint` removal in wasm deploy guide

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6846898f4f44832581500f60aabee0ef