### PR TITLE
docs: sync architecture & contract map

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -9,7 +9,7 @@ Proyek ini berpusat pada dua kontrak ERC20—**GOAT** dan **MEAT**—yang didepl
 * **GoatNFT (`contracts/GoatNFT.sol`)** – menyimpan detail kambing on-chain dalam `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Setiap `nfcId` dipetakan ke token ID sehingga duplikasi ditolak saat mint. Pemilik dapat memanggil `updateWeight` untuk memperbarui berat (menerbitkan `WeightUpdated`). `burn` mensyaratkan pembaruan berat dalam 7 hari terakhir, memicu `GoatNFTBurnHook` dan `GoatBurned` sambil menghapus pemetaan NFC.
 * **GoatNFTBurnHook (`contracts/GoatNFTBurnHook.sol`)** – dipanggil oleh `GoatNFT` saat token dibakar untuk mencetak `GOATMEAT` berdasarkan bobot.
 * **GoatNFTWrapper (`contracts/GoatNFTWrapper.sol`)** – kontrak pembungkus yang mengunci GoatNFT dan mencetak GOAT setara. NFT dapat diambil kembali setelah jumlah GOAT yang sama dibakar.
-* **RateHandler (`contracts/RateHandler.sol`)** – menyimpan `dynamicRate` yang dipakai `BarterContract` untuk menentukan nilai tukar antar produk. Pemilik dapat menetapkan nilai baru melalui `updateRate` atau menonaktifkannya dengan `invalidateRate` sehingga kontrak kembali menggunakan `SWAP_RATE` dari `SwapConfig`.
+* **RateHandler (`contracts/RateHandler.sol`)** – menyimpan `dynamicRate` sebagai kurs barter. Komponen ini hanya dipakai `BarterContract` untuk pertukaran PRODUCT↔PRODUCT. Pemilik dapat menetapkan nilai baru melalui `updateRate` atau menonaktifkannya dengan `invalidateRate` agar kembali menggunakan `SWAP_RATE` dari `SwapConfig`.
 * **Interface dan mock** – `IGOAT` mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper`, sedangkan `FailingGOAT` membantu pengujian dengan mensimulasikan kegagalan transfer.
 
 ## Backend

--- a/contract-map.md
+++ b/contract-map.md
@@ -12,7 +12,6 @@ flowchart TD
   UserWallet -- "native token" --> MEAT
   GoatNFT -- burn --> Hook
   Hook --> MEAT
-  %% GOAT and MEAT no longer link addresses
   MEAT -->|withdraw| UserWallet
   RateHandler --> GOAT
   RateHandler --> MEAT
@@ -20,21 +19,20 @@ flowchart TD
 
 * **MEAT** berperan sebagai gerbang: menerima koin native, mencetak MEAT, dan mengontrol rasio deposit. Pemilik dapat menarik saldo native yang terkumpul.
 * **GOAT** menerima suplai dari GoatNFTWrapper yang mencetak token saat NFT dibungkus. Reward serta parameter konfigurasi dapat diatur pemilik.
-  - `emergencyUnstake` memungkinkan staker menarik token tanpa reward kapan saja.
 * **FailingGOAT** hanya untuk pengujian; menerapkan antarmuka yang sama namun memungkinkan simulasi kegagalan transfer.
 * **IGOAT** mendefinisikan fungsi `mintTo` yang memungkinkan GoatNFTWrapper mencetak GOAT.
 * **IGoatToken** dipakai GoatNFTWrapper dan GoatNFT untuk berinteraksi dengan kontrak GOAT.
-* **RateHandler** mengendalikan rasio swap terkini. `updateRate` memancarkan `RateUpdated` sedangkan `invalidateRate` mengembalikan nilai ke konstanta di `SwapConfig`.
+* **RateHandler** mengendalikan rasio swap terkini untuk barter produk.
 
 Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontrak utama beserta perannya.
 
-| Kontrak | Deskripsi | Fungsi Kunci |
-|---------|-----------|--------------|
-| GOAT | Token ERC20 untuk staking yang dicetak oleh GoatNFTWrapper saat NFT dibungkus. | `stake`, `unstake`, `claimReward`, `compoundReward`, `emergencyUnstake`, `mintTo`, `mint` |
-| MEAT | Token ERC20 yang dicetak dengan deposit native. | `changeDepositRate`, `withdrawNative`, `setGOATAddress` |
-| GoatNFT | Identitas kambing ERC721 yang menyimpan metadata di `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Berat dapat diperbarui via `updateWeight` (memancarkan `WeightUpdated`) dan harus segar saat dibakar. Fungsi `burn` memicu `GoatNFTBurnHook` serta event `GoatBurned`. | `mint`, `updateWeight`, `burn`, `goatValue`, `goatMetadata`, `getGoatData` |
-| GoatNFTBurnHook | Kontrak hook yang mencetak `GOATMEAT` setiap kali GoatNFT dibakar. | `onBurn` |
-| GoatNFTWrapper | Mengunci GoatNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. | `wrap`, `unwrap`, `setRateHandler` |
-| IGOAT | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper. | `mintTo` |
-| IGoatToken | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper dan GoatNFT. | `mint`, `burnFrom` |
+| Kontrak | Deskripsi |
+|---------|-----------|
+| GOAT | Token ERC20 untuk staking yang dicetak oleh GoatNFTWrapper saat NFT dibungkus. |
+| MEAT | Token ERC20 yang dicetak dengan deposit native. |
+| GoatNFT | Identitas kambing ERC721 yang menyimpan metadata di `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Berat dapat diperbarui via `updateWeight` dan harus segar saat dibakar. Fungsi `burn` memicu `GoatNFTBurnHook` serta event `GoatBurned`. |
+| GoatNFTBurnHook | Kontrak hook yang mencetak `GOATMEAT` setiap kali GoatNFT dibakar. |
+| GoatNFTWrapper | Mengunci GoatNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. |
+| IGOAT | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper. |
+| IGoatToken | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper dan GoatNFT. |
 


### PR DESCRIPTION
## Summary
- update contract-map to remove GOAT<->MEAT arrow and stale function lists
- clarify RateHandler usage in architecture docs

## Testing
- `yes | npx hardhat test` *(fails: invalid overrides parameter)*

------
https://chatgpt.com/codex/tasks/task_e_6846956f48c48325963bd08c12ed6b7e