### PR TITLE
codex/add-barter-contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Struktur dan hubungan antar kontrak:
 - `GOAT` (`contracts/GOAT.sol`) mewarisi `ERC20` OpenZeppelin dan menambahkan fungsi staking, klaim, kompaun, serta konfigurasi reward. Token hanya dicetak melalui `GoatNFTWrapper` saat NFT dibungkus.
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterContract`.
+- `BarterContract` (`contracts/BarterContract.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT berdasarkan parity LOD dari `RateHandler`.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
   Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.

--- a/architecture.md
+++ b/architecture.md
@@ -10,6 +10,7 @@ Proyek ini berpusat pada dua kontrak ERC20—**GOAT** dan **MEAT**—yang didepl
 * **GoatNFTBurnHook (`contracts/GoatNFTBurnHook.sol`)** – dipanggil oleh `GoatNFT` saat token dibakar untuk mencetak `GOATMEAT` berdasarkan bobot.
 * **GoatNFTWrapper (`contracts/GoatNFTWrapper.sol`)** – kontrak pembungkus yang mengunci GoatNFT dan mencetak GOAT setara. NFT dapat diambil kembali setelah jumlah GOAT yang sama dibakar.
 * **RateHandler (`contracts/RateHandler.sol`)** – menyimpan `dynamicRate` sebagai kurs barter. Komponen ini hanya dipakai `BarterContract` untuk pertukaran PRODUCT↔PRODUCT. Pemilik dapat menetapkan nilai baru melalui `updateRate` atau menonaktifkannya dengan `invalidateRate` agar kembali menggunakan `SWAP_RATE` dari `SwapConfig`.
+* **BarterContract (`contracts/BarterContract.sol`)** – kontrak swap yang membakar subtype MEAT asal lalu mencetak subtype tujuan berdasarkan rasio yang dihitung `RateHandler`.
 * **Interface dan mock** – `IGOAT` mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper`, sedangkan `FailingGOAT` membantu pengujian dengan mensimulasikan kegagalan transfer.
 
 ## Backend

--- a/contracts/BarterContract.sol
+++ b/contracts/BarterContract.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import { RateHandler } from "./RateHandler.sol";
+import { MEAT } from "./MEAT.sol";
+
+/// @title BarterContract v1
+/// @notice Enables PRODUCT↔PRODUCT swap based on RateHandler LOD parity.
+/// @dev Fully Reasoning Path FINAL Compliant. NO cross-layer swap allowed.
+contract BarterContract {
+    address private immutable _owner;
+    RateHandler public rateHandler;
+    MEAT public meatToken;
+
+    event BarterExecuted(
+        address indexed user,
+        bytes32 indexed fromSubtype,
+        uint256 fromAmount,
+        bytes32 indexed toSubtype,
+        uint256 toAmount
+    );
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    constructor(address rateHandlerAddress, address meatAddress) {
+        require(rateHandlerAddress != address(0), "Invalid RateHandler address");
+        require(meatAddress != address(0), "Invalid MEAT address");
+        _owner = msg.sender;
+        rateHandler = RateHandler(rateHandlerAddress);
+        meatToken = MEAT(payable(meatAddress));
+    }
+
+    /// @notice Governance can update RateHandler address if needed
+    function setRateHandler(address rateHandlerAddress) external onlyOwner {
+        require(rateHandlerAddress != address(0), "Invalid RateHandler address");
+        rateHandler = RateHandler(rateHandlerAddress);
+    }
+
+    /// @notice Governance can update MEAT token address if needed
+    function setMEAT(address meatAddress) external onlyOwner {
+        require(meatAddress != address(0), "Invalid MEAT address");
+        meatToken = MEAT(payable(meatAddress));
+    }
+
+    /// @notice PRODUCT↔PRODUCT swap
+    /// @param fromSubtype Subtype of MEAT being burned
+    /// @param toSubtype Subtype of MEAT being minted
+    /// @param fromAmount Amount of fromSubtype to burn
+    function barterProductToProduct(
+        bytes32 fromSubtype,
+        bytes32 toSubtype,
+        uint256 fromAmount
+    ) external {
+        require(fromSubtype != bytes32(0) && toSubtype != bytes32(0), "Invalid subtype");
+        require(fromAmount > 0, "Amount must be > 0");
+        require(fromSubtype != toSubtype, "Cannot swap same subtype");
+
+        uint256 rate = rateHandler.computeBarterRate(
+            fromSubtype,
+            "PRODUCT",
+            toSubtype,
+            "PRODUCT"
+        );
+        require(rate > 0, "Invalid barter rate");
+
+        uint256 toAmount = (fromAmount * rate) / 1e18;
+        require(toAmount > 0, "Resulting toAmount too low");
+
+        meatToken.burnSubtype(msg.sender, fromSubtype, fromAmount);
+        meatToken.mintSubtype(msg.sender, toSubtype, toAmount);
+
+        emit BarterExecuted(msg.sender, fromSubtype, fromAmount, toSubtype, toAmount);
+    }
+
+    /// @notice View function to get current PRODUCT↔PRODUCT rate
+    function getCurrentBarterRate(bytes32 fromSubtype, bytes32 toSubtype)
+        external
+        view
+        returns (uint256)
+    {
+        return
+            rateHandler.computeBarterRate(
+                fromSubtype,
+                "PRODUCT",
+                toSubtype,
+                "PRODUCT"
+            );
+    }
+
+    /// @notice Returns owner
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}
+

--- a/test/barter.test.js
+++ b/test/barter.test.js
@@ -1,0 +1,84 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("BarterContract", function () {
+  let owner, user, handler, meat, barter;
+  const SUBTYPE_A = ethers.encodeBytes32String("GOATMEAT");
+  const SUBTYPE_B = ethers.encodeBytes32String("DUCKMEAT");
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const RateHandler = await ethers.getContractFactory("RateHandler");
+    handler = await RateHandler.deploy();
+    await handler.waitForDeployment();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    meat = await MEAT.deploy();
+    await meat.waitForDeployment();
+
+    const Barter = await ethers.getContractFactory("BarterContract");
+    barter = await Barter.deploy(handler.target, meat.target);
+    await barter.waitForDeployment();
+
+    await meat.setMinter(owner.address, true);
+    await meat.setMinter(barter.target, true);
+    await meat.setBurner(barter.target, true);
+
+    const repA = {
+      nftAddress: ethers.ZeroAddress,
+      tokenVirtualAddress: ethers.ZeroAddress,
+      tokenProductAddress: meat.target,
+      tokenProductSubtype: SUBTYPE_A,
+      isNftActive: true,
+      isTokenVirtualActive: true,
+      isTokenProductActive: true,
+      lodPerDayNft: 2,
+      lodPerDayVirtual: 2,
+      lodPerDayProduct: 4,
+      protein_g_per_kg: 1,
+      fat_g_per_kg: 1,
+      micronutrient_index_x1000: 1,
+      yield_per_cycle_kg: 1,
+      cycle_time_days: 1,
+    };
+
+    const repB = {
+      nftAddress: ethers.ZeroAddress,
+      tokenVirtualAddress: ethers.ZeroAddress,
+      tokenProductAddress: meat.target,
+      tokenProductSubtype: SUBTYPE_B,
+      isNftActive: true,
+      isTokenVirtualActive: true,
+      isTokenProductActive: true,
+      lodPerDayNft: 1,
+      lodPerDayVirtual: 1,
+      lodPerDayProduct: 2,
+      protein_g_per_kg: 1,
+      fat_g_per_kg: 1,
+      micronutrient_index_x1000: 1,
+      yield_per_cycle_kg: 1,
+      cycle_time_days: 1,
+    };
+
+    await handler.setCommodityRepresentation(SUBTYPE_A, repA);
+    await handler.setCommodityRepresentation(SUBTYPE_B, repB);
+
+    await meat.mintSubtype(user.address, SUBTYPE_A, ethers.parseEther("10"));
+  });
+
+  it("barters between product subtypes", async function () {
+    const fromAmount = ethers.parseEther("2");
+    await meat.connect(user).approve(barter.target, fromAmount);
+
+    const rate = await handler.computeBarterRate(SUBTYPE_A, "PRODUCT", SUBTYPE_B, "PRODUCT");
+    const expected = (fromAmount * rate) / 10n ** 18n;
+
+    await expect(barter.connect(user).barterProductToProduct(SUBTYPE_A, SUBTYPE_B, fromAmount))
+      .to.emit(barter, "BarterExecuted")
+      .withArgs(user.address, SUBTYPE_A, fromAmount, SUBTYPE_B, expected);
+
+    expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE_A)).to.equal(ethers.parseEther("8"));
+    expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE_B)).to.equal(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `BarterContract` contract for PRODUCT↔PRODUCT swaps
- document `BarterContract` in README and architecture docs
- provide Hardhat test for basic barter flow

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: invalid overrides parameters in older tests)*

------
https://chatgpt.com/codex/tasks/task_e_68469df4f0108325a7532d73af06eed6