### PR TITLE
Add Sapi NFT contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Berikut gambaran umum alur penggunaan kedua token:
 3. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
 4. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
 5. **Subtype Registry** – Kontrak MEAT menyimpan saldo per subtype (contoh `GOATMEAT`, `DUCKMEAT`). Hak khusus `mintSubtype` dan `burnSubtype` dapat diberikan ke kontrak lain seperti hook pembakaran NFT untuk mencatat produksi daging spesifik.
-6. **GoatNFTBurnHook** – Hook ini dipanggil saat NFT dibakar dan otomatis mencetak `GOATMEAT` sesuai berat yang dilaporkan untuk dipertukarkan lewat `RateHandler`.
-7. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya untuk keperluan staking. Membuka kembali NFT mengharuskan jumlah GOAT yang sama dibakar.
+6. **GoatNFTBurnHook** – Hook ini dipanggil saat NFT kambing dibakar dan otomatis mencetak `GOATMEAT` sesuai berat yang dilaporkan.
+7. **SapiNFTBurnHook** – Versi untuk sapi yang memicu pencetakan `BEEFMEAT` ketika `SapiNFT` dibakar.
+8. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya untuk keperluan staking. Membuka kembali NFT mengharuskan jumlah GOAT yang sama dibakar.
    *GOAT sepenuhnya dicetak oleh `GoatNFTWrapper`; kontrak lain tidak memiliki izin mint.*
 
 ## Burn & Redeem Flow

--- a/contracts/SapiNFT.sol
+++ b/contracts/SapiNFT.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {SapiNFTBurnHook} from "./SapiNFTBurnHook.sol";
+
+/// @title SapiNFT - identitas sapi dalam bentuk token
+/// @notice Menyimpan berat sapi hidup dan metadata terkait
+contract SapiNFT is ERC721Burnable {
+    uint256 public nextId;
+    mapping(uint256 => uint256) public sapiValue;
+
+    struct SapiData {
+        string nfcId;
+        string breed;
+        uint256 birthYear;
+        uint256 weight;
+        uint256 mintedAt;
+    }
+
+    mapping(uint256 => SapiData) public sapiMetadata;
+    mapping(uint256 => uint256) public lastWeightUpdateAt;
+    mapping(bytes32 => uint256) public nfcIdToTokenId;
+
+    address private immutable _owner;
+    SapiNFTBurnHook public burnHook;
+
+    uint256 public constant WEIGHT_UPDATE_VALIDITY = 7 days;
+    uint256 public constant WEIGHT_DECIMALS = 1;
+
+    constructor() ERC721("Sapi Identifier", "SAPINFT") {
+        _owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    function setBurnHook(address hookAddress) external onlyOwner {
+        address old = address(burnHook);
+        burnHook = SapiNFTBurnHook(hookAddress);
+        emit BurnHookUpdated(old, hookAddress);
+    }
+
+    function mint(
+        address to,
+        uint256 weight,
+        string memory nfcId,
+        string memory breed,
+        uint256 birthYear
+    ) external onlyOwner returns (uint256) {
+        require(weight > 0, "Weight must be > 0");
+        bytes32 hash = keccak256(bytes(nfcId));
+        require(nfcIdToTokenId[hash] == 0, "NFC ID already used");
+        uint256 tokenId = ++nextId;
+        nfcIdToTokenId[hash] = tokenId;
+        sapiValue[tokenId] = weight;
+        sapiMetadata[tokenId] = SapiData(nfcId, breed, birthYear, weight, block.timestamp);
+        lastWeightUpdateAt[tokenId] = block.timestamp;
+        _mint(to, tokenId);
+        return tokenId;
+    }
+
+    function updateWeight(uint256 tokenId, uint256 newWeight) external {
+        address tokenOwner = ownerOf(tokenId);
+        require(msg.sender == tokenOwner, "Not token owner");
+        require(newWeight > 0, "Weight must be > 0");
+
+        sapiValue[tokenId] = newWeight;
+        sapiMetadata[tokenId].weight = newWeight;
+        lastWeightUpdateAt[tokenId] = block.timestamp;
+        emit WeightUpdated(tokenId, newWeight);
+    }
+
+    function burn(uint256 tokenId) public override {
+        address tokenOwner = ownerOf(tokenId);
+        require(_isAuthorized(tokenOwner, msg.sender, tokenId), "Not owner");
+        require(block.timestamp - lastWeightUpdateAt[tokenId] <= WEIGHT_UPDATE_VALIDITY, "Weight update too old");
+
+        uint256 currentWeight = sapiValue[tokenId];
+        require(currentWeight > 0, "Invalid weight");
+
+        bytes32 hash = keccak256(bytes(sapiMetadata[tokenId].nfcId));
+
+        if (address(burnHook) != address(0)) {
+            burnHook.onBurn(tokenOwner, currentWeight);
+        }
+
+        emit SapiBurned(tokenId, tokenOwner, currentWeight);
+
+        super.burn(tokenId);
+        delete sapiValue[tokenId];
+        delete sapiMetadata[tokenId];
+        delete lastWeightUpdateAt[tokenId];
+        delete nfcIdToTokenId[hash];
+    }
+
+    function getSapiData(uint256 tokenId) external view returns (SapiData memory) {
+        return sapiMetadata[tokenId];
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    event BurnHookUpdated(address indexed oldAddress, address indexed newAddress);
+    event SapiBurned(uint256 indexed tokenId, address indexed user, uint256 weight);
+    event WeightUpdated(uint256 indexed tokenId, uint256 newWeight);
+}

--- a/contracts/SapiNFTBurnHook.sol
+++ b/contracts/SapiNFTBurnHook.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import { ISapiNFT } from "./interfaces/ISapiNFT.sol";
+import { IMeat } from "./interfaces/IMeat.sol";
+
+/// @title SapiNFTBurnHook
+/// @notice Mints BEEFMEAT tokens when a SapiNFT is burned
+contract SapiNFTBurnHook {
+    ISapiNFT public sapiNFT;
+    IMeat public meatToken;
+
+    address private immutable _owner;
+
+    bytes32 public constant BEEFMEAT_SUBTYPE = keccak256("BEEFMEAT");
+    uint256 public constant SLAUGHTER_YIELD_BPS = 6500;
+    uint256 public constant WEIGHT_DECIMALS = 1;
+
+    event MeatAddressUpdated(address indexed oldAddress, address indexed newAddress);
+    event NFTAddressUpdated(address indexed oldAddress, address indexed newAddress);
+    event BeefMeatMinted(address indexed to, uint256 amount);
+
+    constructor(address nftAddress, address meatAddress) {
+        require(nftAddress != address(0) && meatAddress != address(0), "Invalid address");
+        _owner = msg.sender;
+        sapiNFT = ISapiNFT(nftAddress);
+        meatToken = IMeat(meatAddress);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    function setNFTAddress(address nftAddress) external onlyOwner {
+        require(nftAddress != address(0), "Invalid address");
+        address old = address(sapiNFT);
+        sapiNFT = ISapiNFT(nftAddress);
+        emit NFTAddressUpdated(old, nftAddress);
+    }
+
+    function setMEATAddress(address meatAddress) external onlyOwner {
+        require(meatAddress != address(0), "Invalid address");
+        address old = address(meatToken);
+        meatToken = IMeat(meatAddress);
+        emit MeatAddressUpdated(old, meatAddress);
+    }
+
+    /// @notice Called by SapiNFT when a token is burned
+    /// @param to recipient of BEEFMEAT
+    /// @param weight weight value from SapiNFT (scaled with WEIGHT_DECIMALS)
+    function onBurn(address to, uint256 weight) external {
+        require(msg.sender == address(sapiNFT), "Unauthorized");
+        if (weight == 0) return;
+        uint256 meatAmount = (weight * 1e18 * SLAUGHTER_YIELD_BPS) / (10000 * (10 ** WEIGHT_DECIMALS));
+        meatToken.mintSubtype(to, BEEFMEAT_SUBTYPE, meatAmount);
+        emit BeefMeatMinted(to, meatAmount);
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}

--- a/contracts/SwapConfig.sol
+++ b/contracts/SwapConfig.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+/// @title SwapConfig
+/// @notice Provides swap rate constant for wrappers
+library SwapConfig {
+    uint256 internal constant SWAP_RATE = 85;
+}

--- a/contracts/interfaces/ISapiNFT.sol
+++ b/contracts/interfaces/ISapiNFT.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+interface ISapiNFT {
+    function sapiValue(uint256 tokenId) external view returns (uint256);
+    function burn(uint256 tokenId) external;
+    function ownerOf(uint256 tokenId) external view returns (address);
+}

--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("GoatNFT burn", function () {
-  let owner, user, goat, nft, swapConfig, SWAP_RATE;
+  let owner, user, goat, nft, SWAP_RATE;
 
   beforeEach(async function () {
     [owner, user] = await ethers.getSigners();
@@ -11,9 +11,7 @@ describe("GoatNFT burn", function () {
     goat = await GOAT.deploy();
     await goat.waitForDeployment();
 
-    swapConfig = await ethers.deployContract("SwapConfig");
-    await swapConfig.waitForDeployment();
-    SWAP_RATE = await swapConfig.SWAP_RATE();
+    SWAP_RATE = 85n;
 
     const GoatNFT = await ethers.getContractFactory("GoatNFT");
     nft = await GoatNFT.deploy();

--- a/test/sapiMeatHook.test.js
+++ b/test/sapiMeatHook.test.js
@@ -1,0 +1,45 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("SapiNFTBurnHook", function () {
+  let owner, user, meat, nft, hook;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    meat = await MEAT.deploy();
+    await meat.waitForDeployment();
+    await meat.setMinter(owner.address, true);
+
+    const SapiNFT = await ethers.getContractFactory("SapiNFT");
+    nft = await SapiNFT.deploy();
+    await nft.waitForDeployment();
+
+    const Hook = await ethers.getContractFactory("SapiNFTBurnHook");
+    hook = await Hook.deploy(nft.target, meat.target);
+    await hook.waitForDeployment();
+
+    await meat.setMinter(hook.target, true);
+    await nft.setBurnHook(hook.target);
+  });
+
+  it("mints BEEFMEAT on burn", async function () {
+    const weight = 700n; // 70 kg
+    const tx = await nft.mint(user.address, weight, "tagS", "Brahman", 2021);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+
+    await nft.connect(user).updateWeight(tokenId, weight);
+
+    const yieldBps = await hook.SLAUGHTER_YIELD_BPS();
+    const meatAmount = (weight * 10n ** 18n * yieldBps) / 10000n / 10n;
+
+    const subtype = await hook.BEEFMEAT_SUBTYPE();
+    await expect(nft.connect(user).burn(tokenId))
+      .to.emit(meat, "SubtypeMinted")
+      .withArgs(user.address, subtype, meatAmount);
+
+    expect(await meat.getBalanceOfSubtype(user.address, subtype)).to.equal(meatAmount);
+  });
+});

--- a/test/sapiNftBurn.test.js
+++ b/test/sapiNftBurn.test.js
@@ -1,0 +1,41 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("SapiNFT burn", function () {
+  let owner, user, nft;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const SapiNFT = await ethers.getContractFactory("SapiNFT");
+    nft = await SapiNFT.deploy();
+    await nft.waitForDeployment();
+  });
+
+  it("burns NFT and emits event", async function () {
+    const tx = await nft.mint(user.address, 800, "c123", "Brahman", 2019);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+
+    await nft.connect(user).updateWeight(tokenId, 850n);
+
+    await expect(nft.connect(user).burn(tokenId))
+      .to.emit(nft, "SapiBurned")
+      .withArgs(tokenId, user.address, 850n);
+
+    await expect(nft.ownerOf(tokenId)).to.be.reverted;
+  });
+
+  it("reverts burn when weight update is stale", async function () {
+    const tx = await nft.mint(user.address, 600, "sapi", "Brahman", 2020);
+    const receipt = await tx.wait();
+    const tokenId = receipt.logs[0].args[2];
+
+    await ethers.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(nft.connect(user).burn(tokenId)).to.be.revertedWith(
+      "Weight update too old"
+    );
+  });
+});

--- a/test/sapiNftOwner.test.js
+++ b/test/sapiNftOwner.test.js
@@ -1,0 +1,19 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("SapiNFT owner restrictions", function () {
+  let owner, nonOwner, nft;
+
+  beforeEach(async function () {
+    [owner, nonOwner] = await ethers.getSigners();
+    const SapiNFT = await ethers.getContractFactory("SapiNFT");
+    nft = await SapiNFT.deploy();
+    await nft.waitForDeployment();
+  });
+
+  it("reverts when a non-owner calls mint", async function () {
+    await expect(
+      nft.connect(nonOwner).mint(nonOwner.address, 50, "nfc", "breed", 2020)
+    ).to.be.revertedWith("Not the owner");
+  });
+});

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -21,9 +21,7 @@ describe("GoatNFTWrapper", function () {
 
     await goat.setWrapperContract(wrapper.target);
 
-    const swapConfig = await ethers.deployContract("SwapConfig");
-    await swapConfig.waitForDeployment();
-    swapRate = await swapConfig.SWAP_RATE();
+    swapRate = 85n;
   });
 
   it("wraps NFT and mints GOAT", async function () {


### PR DESCRIPTION
## Summary
- implement `SapiNFT` ERC721 contract following `GoatNFT`
- add `SapiNFTBurnHook` minting `BEEFMEAT`
- provide `ISapiNFT` interface and `SwapConfig` constant contract
- extend tests for Sapi NFT and hook
- update wrapper to use constant rate and adjust tests
- document `SapiNFTBurnHook` in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6846af6a4cbc8325a3476b2ff44f3486