### PR TITLE
Add GoatNFT wrapper and burn hook CosmWasm crates

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -6,6 +6,8 @@ Proyek ini menyertakan implementasi CosmWasm untuk seluruh kontrak inti di direk
 - `meat` – token MEAT yang mendukung pencetakan menggunakan native token. Menyediakan `redeem_for_meat`. Rasio barter dikelola `BarterContract` melalui `RateHandler`.
 - `goatnft` – kontrak NFT sederhana tempat setiap token menyimpan nilai berat yang dapat ditebus menjadi GOAT
 - `ratehandler` – utilitas kecil yang menyimpan rasio konversi terbaru dan memungkinkan pemilik memperbarui atau menonaktifkannya
+- `goatnftwrapper` – membungkus GoatNFT untuk mencetak GOAT, NFT dikunci hingga pengguna melakukan `unwrap`
+- `goatnftburnhook` – hook sederhana yang dipanggil saat NFT dibakar dan mencatat jumlah GOATMEAT yang seharusnya dicetak
 
 Paket-paket ini mencerminkan kontrak Solidity di `contracts/`. Sebagian besar fungsi memiliki pesan execute yang setara, namun terdapat beberapa perbedaan penting:
 
@@ -54,7 +56,20 @@ wasmd tx wasm instantiate <code_id> '{"meat_contract":"cosmos1..."}' \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
-Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan akan dikonfigurasi di `BarterContract` untuk menentukan rasio barter.
+Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan akan dikonfigurasi di `BarterContract` untuk menentukan rasio barter. Setelah itu deploy `goatnftwrapper` dan `goatnftburnhook` dengan parameter alamat kontrak terkait:
+```bash
+# contoh instansiasi goatnftwrapper
+wasmd tx wasm instantiate <code_id_wrapper> '{"nft_contract":"<nft_addr>","goat_contract":"<goat_addr>"}' \
+  --from wallet --label "wrapper" \
+  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+
+# contoh instansiasi burn hook
+wasmd tx wasm instantiate <code_id_hook> '{"nft_contract":"<nft_addr>"}' \
+  --from wallet --label "burnhook" \
+  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+```
 
 ### Mencetak MEAT
 

--- a/wasm-contracts/build.sh
+++ b/wasm-contracts/build.sh
@@ -9,7 +9,7 @@ if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
   rustup target add wasm32-unknown-unknown
 fi
 
-for pkg in starter meat goatnft ratehandler; do
+for pkg in starter meat goatnft ratehandler goatnftwrapper goatnftburnhook; do
   cd "$DIR/$pkg"
   cargo build --release --target wasm32-unknown-unknown
   mkdir -p "$DIR/../artifacts"

--- a/wasm-contracts/goatnftburnhook/Cargo.toml
+++ b/wasm-contracts/goatnftburnhook/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "goatnftburnhook"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+cw2 = "1.1"
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8"
+cw-storage-plus = "1.1"
+

--- a/wasm-contracts/goatnftburnhook/src/lib.rs
+++ b/wasm-contracts/goatnftburnhook/src/lib.rs
@@ -1,0 +1,74 @@
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult,
+};
+use cw2::set_contract_version;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::state::{GOAT_NFT, OWNER};
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "goatnftburnhook";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+const SLAUGHTER_YIELD_BPS: u64 = 6000;
+const WEIGHT_DECIMALS: u32 = 1;
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    GOAT_NFT.save(deps.storage, &deps.api.addr_validate(&msg.nft_contract)?)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::OnBurn { to, weight } => execute_on_burn(deps, info, to, weight),
+    }
+}
+
+fn execute_on_burn(
+    deps: DepsMut,
+    info: MessageInfo,
+    to: String,
+    weight: u64,
+) -> StdResult<Response> {
+    let nft = GOAT_NFT.load(deps.storage)?;
+    if info.sender != nft {
+        return Err(StdError::generic_err("Unauthorized"));
+    }
+    if weight == 0 {
+        return Ok(Response::default());
+    }
+    let amount = weight as u128 * 1_000_000_000_000_000_000u128 * SLAUGHTER_YIELD_BPS as u128
+        / 10u128.pow(WEIGHT_DECIMALS)
+        / 10_000u128;
+    Ok(Response::new()
+        .add_attribute("action", "GoatMeatMinted")
+        .add_attribute("to", to)
+        .add_attribute("amount", amount.to_string()))
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Owner {} => {
+            let owner = OWNER.load(deps.storage)?;
+            Ok(to_json_binary(&owner.into_string())?)
+        }
+    }
+}

--- a/wasm-contracts/goatnftburnhook/src/msg.rs
+++ b/wasm-contracts/goatnftburnhook/src/msg.rs
@@ -1,0 +1,19 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub nft_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    OnBurn { to: String, weight: u64 },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Owner {},
+}

--- a/wasm-contracts/goatnftburnhook/src/state.rs
+++ b/wasm-contracts/goatnftburnhook/src/state.rs
@@ -1,0 +1,5 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const GOAT_NFT: Item<Addr> = Item::new("goat_nft");

--- a/wasm-contracts/goatnftwrapper/Cargo.toml
+++ b/wasm-contracts/goatnftwrapper/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "goatnftwrapper"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+cw2 = "1.1"
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8"
+serde-json-wasm = "0.5"
+cw-storage-plus = "1.1"
+
+starter = { path = "../starter" }
+goatnft = { path = "../goatnft" }

--- a/wasm-contracts/goatnftwrapper/src/lib.rs
+++ b/wasm-contracts/goatnftwrapper/src/lib.rs
@@ -1,0 +1,153 @@
+use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg};
+use cw2::set_contract_version;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, WrappedResponse};
+use crate::state::{WrappedInfo, GOAT_NFT, GOAT_TOKEN, OWNER, WRAPPED};
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "goatnftwrapper";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+const GOAT_WRAP_RATE: u64 = 85;
+const WEIGHT_DECIMALS: u32 = 1;
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    GOAT_NFT.save(deps.storage, &deps.api.addr_validate(&msg.nft_contract)?)?;
+    GOAT_TOKEN.save(deps.storage, &deps.api.addr_validate(&msg.goat_contract)?)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::Wrap { token_id } => execute_wrap(deps, env, info, token_id),
+        ExecuteMsg::Unwrap { token_id } => execute_unwrap(deps, env, info, token_id),
+    }
+}
+
+fn execute_wrap(deps: DepsMut, env: Env, info: MessageInfo, token_id: u64) -> StdResult<Response> {
+    let nft = GOAT_NFT.load(deps.storage)?;
+    let goat = GOAT_TOKEN.load(deps.storage)?;
+
+    let owner_query = to_json_binary(&goatnft::msg::QueryMsg::Owner { token_id })?;
+    let owner: String = deps.querier.query_wasm_smart(nft.clone(), &owner_query)?;
+    if owner != info.sender {
+        return Err(StdError::generic_err("Not token owner"));
+    }
+
+    let value_query = to_json_binary(&goatnft::msg::QueryMsg::GoatValue { token_id })?;
+    let value: goatnft::msg::GoatValueResponse =
+        deps.querier.query_wasm_smart(nft.clone(), &value_query)?;
+
+    let goat_amount = Uint128::new(
+        value.value.u128() * 1_000_000_000_000_000_000u128
+            / GOAT_WRAP_RATE as u128
+            / 10u128.pow(WEIGHT_DECIMALS),
+    );
+
+    let transfer = WasmMsg::Execute {
+        contract_addr: nft.to_string(),
+        msg: to_json_binary(&goatnft::msg::ExecuteMsg::TransferFrom {
+            owner: info.sender.to_string(),
+            to: env.contract.address.to_string(),
+            token_id: token_id.to_string(),
+        })?,
+        funds: vec![],
+    };
+
+    let mint = WasmMsg::Execute {
+        contract_addr: goat.to_string(),
+        msg: to_json_binary(&starter::msg::ExecuteMsg::MintTo {
+            to: info.sender.to_string(),
+            amount: goat_amount,
+        })?,
+        funds: vec![],
+    };
+
+    WRAPPED.save(
+        deps.storage,
+        token_id,
+        &WrappedInfo {
+            owner: info.sender.clone(),
+            goat_amount,
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_message(transfer)
+        .add_message(mint)
+        .add_attribute("action", "Wrapped")
+        .add_attribute("user", info.sender)
+        .add_attribute("token_id", token_id.to_string())
+        .add_attribute("goat_amount", goat_amount))
+}
+
+fn execute_unwrap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: u64,
+) -> StdResult<Response> {
+    let nft = GOAT_NFT.load(deps.storage)?;
+    let goat = GOAT_TOKEN.load(deps.storage)?;
+    let info_wrapped = WRAPPED.load(deps.storage, token_id)?;
+    if info_wrapped.owner != info.sender {
+        return Err(StdError::generic_err("Not owner"));
+    }
+
+    let burn = WasmMsg::Execute {
+        contract_addr: goat.to_string(),
+        msg: to_json_binary(&starter::msg::ExecuteMsg::TransferFrom {
+            owner: info.sender.to_string(),
+            recipient: env.contract.address.to_string(),
+            amount: info_wrapped.goat_amount,
+        })?,
+        funds: vec![],
+    };
+
+    let transfer = WasmMsg::Execute {
+        contract_addr: nft.to_string(),
+        msg: to_json_binary(&goatnft::msg::ExecuteMsg::Transfer {
+            to: info.sender.to_string(),
+            token_id: token_id.to_string(),
+        })?,
+        funds: vec![],
+    };
+
+    WRAPPED.remove(deps.storage, token_id);
+
+    Ok(Response::new()
+        .add_message(burn)
+        .add_message(transfer)
+        .add_attribute("action", "Unwrapped")
+        .add_attribute("user", info.sender)
+        .add_attribute("token_id", token_id.to_string())
+        .add_attribute("goat_amount", info_wrapped.goat_amount))
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Wrapped { token_id } => {
+            let info = WRAPPED.load(deps.storage, token_id)?;
+            Ok(to_json_binary(&WrappedResponse {
+                owner: info.owner.into_string(),
+                goat_amount: info.goat_amount,
+            })?)
+        }
+        QueryMsg::Owner {} => {
+            let owner = OWNER.load(deps.storage)?;
+            Ok(to_json_binary(&owner.into_string())?)
+        }
+    }
+}

--- a/wasm-contracts/goatnftwrapper/src/msg.rs
+++ b/wasm-contracts/goatnftwrapper/src/msg.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::Uint128;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub nft_contract: String,
+    pub goat_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Wrap { token_id: u64 },
+    Unwrap { token_id: u64 },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Wrapped { token_id: u64 },
+    Owner {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct WrappedResponse {
+    pub owner: String,
+    pub goat_amount: Uint128,
+}

--- a/wasm-contracts/goatnftwrapper/src/state.rs
+++ b/wasm-contracts/goatnftwrapper/src/state.rs
@@ -1,0 +1,14 @@
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const GOAT_NFT: Item<Addr> = Item::new("goat_nft");
+pub const GOAT_TOKEN: Item<Addr> = Item::new("goat_token");
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct WrappedInfo {
+    pub owner: Addr,
+    pub goat_amount: Uint128,
+}
+
+pub const WRAPPED: Map<u64, WrappedInfo> = Map::new("wrapped");

--- a/wasm-contracts/starter/Cargo.toml
+++ b/wasm-contracts/starter/Cargo.toml
@@ -20,3 +20,5 @@ serde_json = "1.0"
 [dev-dependencies]
 cw-multi-test = "0.16"
 goatnft = { path = "../goatnft" }
+goatnftwrapper = { path = "../goatnftwrapper" }
+goatnftburnhook = { path = "../goatnftburnhook" }

--- a/wasm-contracts/starter/tests/wrapper.rs
+++ b/wasm-contracts/starter/tests/wrapper.rs
@@ -1,0 +1,222 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use goatnft::msg as nft_msg;
+use goatnft::{execute as nft_execute, instantiate as nft_instantiate, query as nft_query};
+use goatnftburnhook::msg as hook_msg;
+use goatnftburnhook::{
+    execute as hook_execute, instantiate as hook_instantiate, query as hook_query,
+};
+use goatnftwrapper::msg as wrap_msg;
+use goatnftwrapper::{
+    execute as wrap_execute, instantiate as wrap_instantiate, query as wrap_query,
+};
+use starter::msg as goat_msg;
+use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
+
+fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        goat_execute,
+        goat_instantiate,
+        goat_query,
+    ))
+}
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        nft_execute,
+        nft_instantiate,
+        nft_query,
+    ))
+}
+
+fn contract_wrapper() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        wrap_execute,
+        wrap_instantiate,
+        wrap_query,
+    ))
+}
+
+fn contract_hook() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        hook_execute,
+        hook_instantiate,
+        hook_query,
+    ))
+}
+
+#[test]
+fn wrap_and_unwrap_flow() {
+    let mut app = App::default();
+    let goat_id = app.store_code(contract_goat());
+    let nft_id = app.store_code(contract_nft());
+    let wrap_id = app.store_code(contract_wrapper());
+    let hook_id = app.store_code(contract_hook());
+
+    let goat_addr = app
+        .instantiate_contract(
+            goat_id,
+            Addr::unchecked("owner"),
+            &goat_msg::InstantiateMsg {
+                meat_contract: "meat".into(),
+            },
+            &[],
+            "goat",
+            None,
+        )
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &nft_msg::InstantiateMsg {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+    let _hook_addr = app
+        .instantiate_contract(
+            hook_id,
+            Addr::unchecked("owner"),
+            &hook_msg::InstantiateMsg {
+                nft_contract: nft_addr.to_string(),
+            },
+            &[],
+            "hook",
+            None,
+        )
+        .unwrap();
+    let wrapper_addr = app
+        .instantiate_contract(
+            wrap_id,
+            Addr::unchecked("owner"),
+            &wrap_msg::InstantiateMsg {
+                nft_contract: nft_addr.to_string(),
+                goat_contract: goat_addr.to_string(),
+            },
+            &[],
+            "wrapper",
+            None,
+        )
+        .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        goat_addr.clone(),
+        &goat_msg::ExecuteMsg::SetMeatAddress { meat_address: wrapper_addr.to_string() },
+        &[],
+    ).unwrap();
+
+    // mint nft
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &nft_msg::ExecuteMsg::Mint {
+                to: "user".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 10,
+            },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap();
+
+    // approve wrapper
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::Approve {
+            spender: wrapper_addr.to_string(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    // wrap nft
+    let res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            wrapper_addr.clone(),
+            &wrap_msg::ExecuteMsg::Wrap { token_id },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "Wrapped")));
+
+    // approve goat burn
+    app.execute_contract(
+        Addr::unchecked("user"),
+        goat_addr.clone(),
+        &goat_msg::ExecuteMsg::Approve {
+            spender: wrapper_addr.to_string(),
+            amount: Uint128::new(117647058823529400),
+        },
+        &[],
+    )
+    .unwrap();
+    let res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            wrapper_addr.clone(),
+            &wrap_msg::ExecuteMsg::Unwrap { token_id },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "Unwrapped")));
+}
+
+#[test]
+fn burn_hook_emits_event() {
+    let mut app = App::default();
+    let hook_id = app.store_code(contract_hook());
+    let _nft_id = app.store_code(contract_nft());
+    let hook_addr = app
+        .instantiate_contract(
+            hook_id,
+            Addr::unchecked("owner"),
+            &hook_msg::InstantiateMsg {
+                nft_contract: "nft".into(),
+            },
+            &[],
+            "hook",
+            None,
+        )
+        .unwrap();
+    let res = app
+        .execute_contract(
+            Addr::unchecked("nft"),
+            hook_addr,
+            &hook_msg::ExecuteMsg::OnBurn {
+                to: "user".into(),
+                weight: 10,
+            },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "GoatMeatMinted")));
+}


### PR DESCRIPTION
## Summary
- implement GoatNFTWrapper and GoatNFTBurnHook contracts in `wasm-contracts/`
- compile new crates in build script
- extend tests to cover wrapper and hook logic
- document deploying new contracts

## Testing
- `yes | npx hardhat test`
- `cargo test` for starter, goatnftwrapper, goatnftburnhook, and goatnft

------
https://chatgpt.com/codex/tasks/task_e_6846f1b876188325ba3a9a182a72b2ec