### PR TITLE
Update LOD docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
   reward harian pengguna.
 - **minClaimInterval** – interval minimum pengguna dapat mengklaim atau
   meng-unstake dengan reward. Default-nya `7 days`.
- - **LOD** – Level of Decay per komoditas. Nilai awal dihasilkan oleh skrip
-   [`compute_lod.py`](compute_lod.py) dan tersimpan di `lod_data.json`. Data tersebut dapat
+ - **LOD** – Level of Decay per komoditas. Nilai dasar berada pada
+   `lod_data_base.json` dan diolah oleh skrip
+   [`compute_lod.py`](compute_lod.py) menjadi `lod_data.json`. Data tersebut dapat
   diperbarui on-chain lewat `setCommodityRepresentation` pada `RateHandler`.
   Setiap komoditas menyimpan `lodPerDay` untuk layer `NFT`, `VIRTUAL`, dan
   `PRODUCT` beserta parameter transparan seperti `protein_g_per_kg`,

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -25,6 +25,7 @@ Lihat diagram *Canonical Reasoning Path* pada [architecture.md](../architecture.
 File: `lod_data_base.json`
 
 - Tambahkan atau ubah entri komoditas.
+- **Jangan mengedit `compute_lod.py`;** semua perubahan data dilakukan di file ini.
 - Setiap komoditas menyimpan parameter berikut:
   - `protein_g_per_kg`
   - `fat_g_per_kg`

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -1,6 +1,6 @@
 # Level of Decay (LOD)
 
-`LOD` menentukan penurunan nilai barter komoditas setiap hari. File `lod_data.json` di root menyimpan master data yang dihasilkan oleh skrip `compute_lod.py`. Nilai pada berkas ini dapat diperbarui maupun dimuat on-chain melalui fungsi `setCommodityRepresentation` pada `RateHandler`.
+`LOD` menentukan penurunan nilai barter komoditas setiap hari. Data dasar tersimpan pada `lod_data_base.json` dan diolah oleh skrip `compute_lod.py` menjadi `lod_data.json`. Nilai pada berkas keluaran tersebut dapat dimuat on-chain melalui fungsi `setCommodityRepresentation` pada `RateHandler`.
 
 ```json
 [
@@ -57,7 +57,8 @@ Nilai dikalikan `1e18` agar presisi tetap terjaga pada operasi desimal.
 
 Untuk menyesuaikan LOD atau menambah komoditas baru:
 
-1. Edit daftar komoditas di [lod_data_base.json](../lod_data_base.json) sesuai kebutuhan.
+1. Perbarui daftar komoditas di [lod_data_base.json](../lod_data_base.json).
+   Tidak perlu mengubah skrip `compute_lod.py`.
 2. Jalankan perintah berikut di root repositori untuk menghasilkan ulang `lod_data.json`:
 
    ```bash


### PR DESCRIPTION
## Summary
- clarify that governance updates start from `lod_data_base.json` in LOD engine docs
- mention `lod_data_base.json` as the source in general governance guide
- note the base file in README for LOD section

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6847814e0a508325916ea861907d01d1