### PR TITLE
docs: clarify install step before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Seluruh pengujian Hardhat berada di direktori `test/`. Jalankan dengan perintah 
 ```bash
 npm install
 ```
+Pastikan perintah di atas dijalankan sebelum mengeksekusi Hardhat test.
 
 Jika folder `artifacts/` belum berisi kontrak terkompilasi, jalankan:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,7 @@ Folder ini berisi server Express sederhana yang menyajikan statistik cache untuk
    ```bash
    npm install
    ```
+   Jalankan perintah di atas sebelum mengeksekusi Hardhat test apa pun.
 2. Kompilasi kontrak untuk menghasilkan file ABI yang digunakan server:
    ```bash
    npx hardhat compile


### PR DESCRIPTION
## Summary
- clarify that running `npm install` is necessary before Hardhat tests
- mention the step in both README files

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684785ba35948325be1c4336a13af423