### PR TITLE
codex/nft-owner-tests

### DIFF
--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -98,4 +98,31 @@ describe("GoatNFT burn", function () {
     await nft.connect(user).burn(tokenId);
     await expect(nft.mint(user.address, 350, "reuse", "Boer", 2022)).to.not.be.reverted;
   });
+
+  it("reverts updateWeight when caller not owner", async function () {
+    const tx = await nft.mint(user.address, 400, "owner", "breed", 2022);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await expect(nft.updateWeight(tokenId, 450n)).to.be.revertedWith(
+      "Not token owner"
+    );
+  });
+
+  it("reverts burn when caller not owner", async function () {
+    const tx = await nft.mint(user.address, 550, "ownr", "breed", 2022);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).updateWeight(tokenId, 560n);
+    await expect(nft.burn(tokenId)).to.be.revertedWith("Not owner");
+  });
+
+  it("getGoatData cleared after burn", async function () {
+    const tx = await nft.mint(user.address, 600, "clr", "Boer", 2022);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).updateWeight(tokenId, 610n);
+    await nft.connect(user).burn(tokenId);
+    const data = await nft.getGoatData(tokenId);
+    expect(data.weight).to.equal(0n);
+    expect(data.birthYear).to.equal(0n);
+    expect(data.nfcId).to.equal("");
+    expect(data.breed).to.equal("");
+  });
 });

--- a/test/nftOwner.test.js
+++ b/test/nftOwner.test.js
@@ -18,4 +18,24 @@ describe("GoatNFT owner restrictions", function () {
         .mint(nonOwner.address, 50, "nfc", "breed", 2020)
     ).to.be.revertedWith("Not the owner");
   });
+
+  it("owner() returns deployer", async function () {
+    expect(await nft.owner()).to.equal(owner.address);
+  });
+
+  it("setBurnHook only owner", async function () {
+    const addr = nonOwner.address;
+    await expect(nft.connect(nonOwner).setBurnHook(addr)).to.be.revertedWith(
+      "Not the owner"
+    );
+    await expect(nft.setBurnHook(addr))
+      .to.emit(nft, "BurnHookUpdated")
+      .withArgs(ethers.ZeroAddress, addr);
+  });
+
+  it("allows owner to mint", async function () {
+    await expect(
+      nft.mint(nonOwner.address, 50, "nfc", "breed", 2020)
+    ).to.not.be.reverted;
+  });
 });

--- a/test/sapiNftBurn.test.js
+++ b/test/sapiNftBurn.test.js
@@ -38,4 +38,31 @@ describe("SapiNFT burn", function () {
       "Weight update too old"
     );
   });
+
+  it("reverts updateWeight when caller not owner", async function () {
+    const tx = await nft.mint(user.address, 700, "id1", "Brahman", 2021);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await expect(nft.updateWeight(tokenId, 710n)).to.be.revertedWith(
+      "Not token owner"
+    );
+  });
+
+  it("reverts burn when caller not owner", async function () {
+    const tx = await nft.mint(user.address, 650, "id2", "Brahman", 2021);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).updateWeight(tokenId, 655n);
+    await expect(nft.burn(tokenId)).to.be.revertedWith("Not owner");
+  });
+
+  it("getSapiData cleared after burn", async function () {
+    const tx = await nft.mint(user.address, 900, "id3", "Brahman", 2021);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).updateWeight(tokenId, 905n);
+    await nft.connect(user).burn(tokenId);
+    const data = await nft.getSapiData(tokenId);
+    expect(data.weight).to.equal(0n);
+    expect(data.birthYear).to.equal(0n);
+    expect(data.nfcId).to.equal("");
+    expect(data.breed).to.equal("");
+  });
 });

--- a/test/sapiNftOwner.test.js
+++ b/test/sapiNftOwner.test.js
@@ -16,4 +16,24 @@ describe("SapiNFT owner restrictions", function () {
       nft.connect(nonOwner).mint(nonOwner.address, 50, "nfc", "breed", 2020)
     ).to.be.revertedWith("Not the owner");
   });
+
+  it("owner() returns deployer", async function () {
+    expect(await nft.owner()).to.equal(owner.address);
+  });
+
+  it("setBurnHook only owner", async function () {
+    const addr = nonOwner.address;
+    await expect(nft.connect(nonOwner).setBurnHook(addr)).to.be.revertedWith(
+      "Not the owner"
+    );
+    await expect(nft.setBurnHook(addr))
+      .to.emit(nft, "BurnHookUpdated")
+      .withArgs(ethers.ZeroAddress, addr);
+  });
+
+  it("allows owner to mint", async function () {
+    await expect(
+      nft.mint(nonOwner.address, 50, "nfc", "breed", 2020)
+    ).to.not.be.reverted;
+  });
 });


### PR DESCRIPTION
## Summary
- extend GoatNFT owner tests for mint/burn access
- extend SapiNFT owner tests for mint/burn access
- ensure non-owners cannot update weight or burn
- verify data cleared after burn

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684795d6b6fc83259c0f95df14452635