### PR TITLE
Add ownership tests for wrapper and burn hooks

### DIFF
--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -5,6 +5,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 - Setiap **GoatNFT** mencatat *ras*, *NFC tag*, *tahun lahir*, dan *berat* terkini.
 - Pemilik bebas memindahkan NFT dan memperbarui berat seiring pertumbuhan hewan.
 - Sebelum kambing disembelih, token dapat **dibakar** dengan berat terbaru yang mencetak `GOATMEAT` melalui `GoatNFTBurnHook`.
+- Pemilik hook dapat memperbarui alamat `GoatNFT` maupun `MEAT` melalui `setNFTAddress` dan `setMEATAddress` bila diperlukan.
 - GOAT diperoleh dengan mengunci NFT pada `GoatNFTWrapper` dan digunakan untuk staking.
 - MEAT pada akhirnya dibakar menggunakan `redeemForMeat` untuk menebus daging fisik.
 

--- a/test/goatMeatHook.test.js
+++ b/test/goatMeatHook.test.js
@@ -44,5 +44,39 @@ describe("GoatNFTBurnHook", function () {
       meatAmount
     );
   });
+
+  it("owner() returns deployer", async function () {
+    expect(await hook.owner()).to.equal(owner.address);
+  });
+
+  it("setNFTAddress only owner", async function () {
+    const GoatNFT = await ethers.getContractFactory("GoatNFT");
+    const newNFT = await GoatNFT.deploy();
+    await newNFT.waitForDeployment();
+
+    await expect(
+      hook.connect(user).setNFTAddress(newNFT.target)
+    ).to.be.revertedWith("Not the owner");
+
+    await expect(hook.setNFTAddress(newNFT.target))
+      .to.emit(hook, "NFTAddressUpdated")
+      .withArgs(nft.target, newNFT.target);
+    expect(await hook.goatNFT()).to.equal(newNFT.target);
+  });
+
+  it("setMEATAddress only owner", async function () {
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const newMeat = await MEAT.deploy();
+    await newMeat.waitForDeployment();
+
+    await expect(
+      hook.connect(user).setMEATAddress(newMeat.target)
+    ).to.be.revertedWith("Not the owner");
+
+    await expect(hook.setMEATAddress(newMeat.target))
+      .to.emit(hook, "MeatAddressUpdated")
+      .withArgs(meat.target, newMeat.target);
+    expect(await hook.meatToken()).to.equal(newMeat.target);
+  });
 });
 

--- a/test/sapiMeatHook.test.js
+++ b/test/sapiMeatHook.test.js
@@ -42,4 +42,38 @@ describe("SapiNFTBurnHook", function () {
 
     expect(await meat.getBalanceOfSubtype(user.address, subtype)).to.equal(meatAmount);
   });
+
+  it("owner() returns deployer", async function () {
+    expect(await hook.owner()).to.equal(owner.address);
+  });
+
+  it("setNFTAddress only owner", async function () {
+    const SapiNFT = await ethers.getContractFactory("SapiNFT");
+    const newNFT = await SapiNFT.deploy();
+    await newNFT.waitForDeployment();
+
+    await expect(
+      hook.connect(user).setNFTAddress(newNFT.target)
+    ).to.be.revertedWith("Not the owner");
+
+    await expect(hook.setNFTAddress(newNFT.target))
+      .to.emit(hook, "NFTAddressUpdated")
+      .withArgs(nft.target, newNFT.target);
+    expect(await hook.sapiNFT()).to.equal(newNFT.target);
+  });
+
+  it("setMEATAddress only owner", async function () {
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const newMeat = await MEAT.deploy();
+    await newMeat.waitForDeployment();
+
+    await expect(
+      hook.connect(user).setMEATAddress(newMeat.target)
+    ).to.be.revertedWith("Not the owner");
+
+    await expect(hook.setMEATAddress(newMeat.target))
+      .to.emit(hook, "MeatAddressUpdated")
+      .withArgs(meat.target, newMeat.target);
+    expect(await hook.meatToken()).to.equal(newMeat.target);
+  });
 });

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -56,5 +56,28 @@ describe("GoatNFTWrapper", function () {
     expect(await nft.ownerOf(tokenId)).to.equal(user.address);
     expect(await goat.balanceOf(user.address)).to.equal(0n);
   });
+
+  it("reverts wrap when caller not NFT owner", async function () {
+    const tx = await nft.mint(owner.address, 500, "tag", "Boer", 2020);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(owner).approve(wrapper.target, tokenId);
+
+    await expect(wrapper.connect(user).wrap(tokenId)).to.be.revertedWith(
+      "Not token owner"
+    );
+  });
+
+  it("reverts unwrap when caller not token owner", async function () {
+    const tx = await nft.mint(user.address, 600, "tag", "Boer", 2020);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).approve(wrapper.target, tokenId);
+    await wrapper.connect(user).wrap(tokenId);
+
+    await expect(wrapper.unwrap(tokenId)).to.be.revertedWith("Not owner");
+  });
+
+  it("owner() returns deployer", async function () {
+    expect(await wrapper.owner()).to.equal(owner.address);
+  });
 });
 


### PR DESCRIPTION
## Summary
- verify only NFT owners can wrap/unwrap
- cover owner() getter for wrapper and hooks
- test setNFTAddress/setMEATAddress on burn hooks
- document burn hook address configurability

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68479bbf1b388325a598e59f60b05bdc