### PR TITLE
codex/lineage-barter-validation

### DIFF
--- a/contracts/BarterContract.sol
+++ b/contracts/BarterContract.sol
@@ -69,6 +69,11 @@ contract BarterContract {
         uint256 toAmount = (fromAmount * rate) / 1e18;
         require(toAmount > 0, "Resulting toAmount too low");
 
+        (uint256 balance, uint256 lineageID) =
+            meatToken.balanceOfSubtypeWithLineage(msg.sender, fromSubtype);
+        require(balance >= fromAmount, "Insufficient subtype balance");
+        require(lineageID != 0, "Invalid lineage");
+
         meatToken.burnSubtype(msg.sender, fromSubtype, fromAmount);
         meatToken.mintSubtype(msg.sender, toSubtype, toAmount);
 

--- a/test/barter.test.js
+++ b/test/barter.test.js
@@ -69,6 +69,7 @@ describe("BarterContract", function () {
 
   it("barters between product subtypes", async function () {
     const fromAmount = ethers.parseEther("2");
+    await meat.setSubtypeLineage(user.address, SUBTYPE_A, 1);
     await meat.connect(user).approve(barter.target, fromAmount);
 
     const rate = await handler.computeBarterRate(SUBTYPE_A, "PRODUCT", SUBTYPE_B, "PRODUCT");
@@ -80,5 +81,11 @@ describe("BarterContract", function () {
 
     expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE_A)).to.equal(ethers.parseEther("8"));
     expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE_B)).to.equal(expected);
+  });
+
+  it("reverts when lineage not set", async function () {
+    const fromAmount = ethers.parseEther("1");
+    await expect(barter.connect(user).barterProductToProduct(SUBTYPE_A, SUBTYPE_B, fromAmount))
+      .to.be.revertedWith("Invalid lineage");
   });
 });

--- a/test/barterGoatBeef.test.js
+++ b/test/barterGoatBeef.test.js
@@ -69,6 +69,7 @@ describe("BarterContract GOAT<->BEEF", function () {
 
   it("barters GOATMEAT to BEEFMEAT correctly", async function () {
     const fromAmount = ethers.parseEther("2");
+    await meat.setSubtypeLineage(user.address, SUBTYPE_GOATMEAT, 1);
     await meat.connect(user).approve(barter.target, fromAmount);
 
     const rate = await handler.computeBarterRate(
@@ -93,5 +94,16 @@ describe("BarterContract GOAT<->BEEF", function () {
       ethers.parseEther("8")
     );
     expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE_BEEFMEAT)).to.equal(expected);
+  });
+
+  it("reverts when lineage missing", async function () {
+    const fromAmount = ethers.parseEther("1");
+    await expect(
+      barter.connect(user).barterProductToProduct(
+        SUBTYPE_GOATMEAT,
+        SUBTYPE_BEEFMEAT,
+        fromAmount
+      )
+    ).to.be.revertedWith("Invalid lineage");
   });
 });


### PR DESCRIPTION
## Summary
- validate product lineage on barter
- test lineage requirements in barter flows

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68479e5f67348325be2b5dfa8093a60b