### PR TITLE
Add RedeemEngine contract and unit tests

### DIFF
--- a/contract-map.md
+++ b/contract-map.md
@@ -23,6 +23,7 @@ flowchart TD
 * **IGOAT** mendefinisikan fungsi `mintTo` yang memungkinkan GoatNFTWrapper mencetak GOAT.
 * **IGoatToken** dipakai GoatNFTWrapper dan GoatNFT untuk berinteraksi dengan kontrak GOAT.
 * **RateHandler** mengendalikan rasio swap terkini untuk barter produk.
+* **RedeemEngine** memproses penebusan MEAT dan memverifikasi lineage sebelum pembakaran.
 
 Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontrak utama beserta perannya.
 
@@ -35,4 +36,5 @@ Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontra
 | GoatNFTWrapper | Mengunci GoatNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. |
 | IGOAT | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper. |
 | IGoatToken | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper dan GoatNFT. |
+| RedeemEngine | Memverifikasi lineage dan membakar subtype MEAT saat penebusan. |
 

--- a/contracts/RedeemEngine.sol
+++ b/contracts/RedeemEngine.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import { MEAT } from "./MEAT.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title RedeemEngine
+/// @notice Processes MEAT redemption with lineage verification
+contract RedeemEngine is Ownable {
+    MEAT public immutable meat;
+
+    event RedeemExecuted(
+        address indexed user,
+        bytes32 indexed subtype,
+        uint256 lineageID,
+        uint256 amount
+    );
+
+    constructor(address meatAddress) Ownable(msg.sender) {
+        require(meatAddress != address(0), "Invalid MEAT address");
+        meat = MEAT(payable(meatAddress));
+    }
+
+    /// @notice Redeem MEAT subtype after verifying lineage
+    function redeem(bytes32 subtype, uint256 amount) external {
+        require(amount > 0, "Invalid amount");
+        (uint256 balance, uint256 lineageID) = meat.balanceOfSubtypeWithLineage(msg.sender, subtype);
+        require(balance >= amount, "Insufficient balance");
+        require(lineageID != 0, "Lineage not set");
+        meat.burnSubtype(msg.sender, subtype, amount);
+        emit RedeemExecuted(msg.sender, subtype, lineageID, amount);
+    }
+}

--- a/test/redeemEngine.test.js
+++ b/test/redeemEngine.test.js
@@ -1,0 +1,57 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("RedeemEngine", function () {
+  let owner, user, meat, engine;
+  const SUBTYPE = ethers.encodeBytes32String("GOATMEAT");
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const MEAT = await ethers.getContractFactory("MEAT");
+    meat = await MEAT.deploy();
+    await meat.waitForDeployment();
+
+    const Engine = await ethers.getContractFactory("RedeemEngine");
+    engine = await Engine.deploy(meat.target);
+    await engine.waitForDeployment();
+
+    await meat.setMinter(owner.address, true);
+    await meat.setBurner(engine.target, true);
+
+    const amount = ethers.parseEther("5");
+    await meat.mintSubtype(user.address, SUBTYPE, amount);
+    await meat.setSubtypeLineage(user.address, SUBTYPE, 7);
+  });
+
+  it("redeems MEAT with lineage check", async function () {
+    const redeemAmount = ethers.parseEther("2");
+
+    await expect(engine.connect(user).redeem(SUBTYPE, redeemAmount))
+      .to.emit(engine, "RedeemExecuted")
+      .withArgs(user.address, SUBTYPE, 7, redeemAmount);
+
+    expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE)).to.equal(
+      ethers.parseEther("3")
+    );
+  });
+
+  it("reverts when lineage not set", async function () {
+    const MEAT = await ethers.getContractFactory("MEAT");
+    const freshMeat = await MEAT.deploy();
+    await freshMeat.waitForDeployment();
+
+    const Engine = await ethers.getContractFactory("RedeemEngine");
+    const freshEngine = await Engine.deploy(freshMeat.target);
+    await freshEngine.waitForDeployment();
+
+    await freshMeat.setMinter(owner.address, true);
+    await freshMeat.setBurner(freshEngine.target, true);
+    await freshMeat.mintSubtype(user.address, SUBTYPE, ethers.parseEther("1"));
+
+    await expect(
+      freshEngine.connect(user).redeem(SUBTYPE, ethers.parseEther("1"))
+    ).to.be.revertedWith("Lineage not set");
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement `RedeemEngine` smart contract for MEAT redemption
- document the new engine in `contract-map.md`
- test redemption flow and lineage checks

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6847a1c947e48325b9b97c58120a25a2