### PR TITLE
Rename BarterContract references

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ npx hardhat compile
 
 Folder `wasm-contracts/` menyimpan versi CosmWasm dari setiap kontrak.
 Kontrak Solidity yang **sudah** terporting meliputi `GOAT` (paket `starter`),
-`MEAT`, `GoatNFT`, dan `RateHandler`. Implementasi untuk `BarterContract`,
+`MEAT`, `GoatNFT`, dan `RateHandler`. Implementasi untuk `BarterEngine`,
 `GoatNFTWrapper`, `GoatNFTBurnHook`, serta varian `SapiNFT` masih *pending*.
 Saat ini fungsi wrapper dan burn hook digabungkan ke dalam `starter` dan akan
 dipisah ke paket terpisah ketika kontrak baru diimplementasikan. Seluruh pesan
@@ -303,7 +303,7 @@ Setelah itu edit `frontend/.env.local` dan isi `NEXT_PUBLIC_GOAT_ADDRESS` serta 
 Struktur dan hubungan antar kontrak:
 - `GOAT` (`contracts/GOAT.sol`) mewarisi `ERC20` OpenZeppelin dan menambahkan fungsi staking, klaim, kompaun, serta konfigurasi reward. Token hanya dicetak melalui `GoatNFTWrapper` saat NFT dibungkus.
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
-  untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterContract`.
+  untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterEngine`.
 - `BarterEngine` (`contracts/BarterEngine.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT. Engine ini menggunakan `balanceOfSubtypeWithLineage()` dari MEAT untuk memvalidasi asal-usul token sebelum swap dilakukan.
 - `RedeemEngine` (`contracts/RedeemEngine.sol`) memproses penebusan MEAT dan memverifikasi lineage melalui `balanceOfSubtypeWithLineage()` sebelum distribusi.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.

--- a/architecture.md
+++ b/architecture.md
@@ -9,8 +9,8 @@ Proyek ini berpusat pada dua kontrak ERC20—**GOAT** dan **MEAT**—yang didepl
 * **GoatNFT (`contracts/GoatNFT.sol`)** – menyimpan detail kambing on-chain dalam `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Setiap `nfcId` dipetakan ke token ID sehingga duplikasi ditolak saat mint. Pemilik dapat memanggil `updateWeight` untuk memperbarui berat (menerbitkan `WeightUpdated`). `burn` mensyaratkan pembaruan berat dalam 7 hari terakhir, memicu `GoatNFTBurnHook` dan `GoatBurned` sambil menghapus pemetaan NFC.
 * **GoatNFTBurnHook (`contracts/GoatNFTBurnHook.sol`)** – dipanggil oleh `GoatNFT` saat token dibakar untuk mencetak `GOATMEAT` berdasarkan bobot.
 * **GoatNFTWrapper (`contracts/GoatNFTWrapper.sol`)** – kontrak pembungkus yang mengunci GoatNFT dan mencetak GOAT setara. NFT dapat diambil kembali setelah jumlah GOAT yang sama dibakar.
-* **RateHandler (`contracts/RateHandler.sol`)** – menghitung paritas barter PRODUCT↔PRODUCT berdasarkan nilai LOD yang disimpan untuk setiap komoditas. Data diregistrasi melalui `setCommodityRepresentation` dan dipakai `BarterContract` saat swap.
-* **BarterContract (`contracts/BarterContract.sol`)** – kontrak swap yang membakar subtype MEAT asal lalu mencetak subtype tujuan berdasarkan rasio yang dihitung `RateHandler`.
+* **RateHandler (`contracts/RateHandler.sol`)** – menghitung paritas barter PRODUCT↔PRODUCT berdasarkan nilai LOD yang disimpan untuk setiap komoditas. Data diregistrasi melalui `setCommodityRepresentation` dan dipakai `BarterEngine` saat swap.
+* **BarterEngine (`contracts/BarterEngine.sol`)** – kontrak swap yang membakar subtype MEAT asal lalu mencetak subtype tujuan berdasarkan rasio yang dihitung `RateHandler`.
 * **Interface dan mock** – `IGOAT` mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper`, sedangkan `FailingGOAT` membantu pengujian dengan mensimulasikan kegagalan transfer.
 
 ## Backend

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -166,7 +166,7 @@ contract MEAT is ERC20 {
         return (s.balance, s.lineageID);
     }
 
-    /// @notice Mengatur alamat kontrak rate handler untuk perhitungan swap (dipakai di BarterContract, bukan di MEAT)
+    /// @notice Mengatur alamat kontrak rate handler untuk perhitungan swap (dipakai di BarterEngine, bukan di MEAT)
     function setRateHandler(address rateHandlerAddress) external onlyOwner {
         require(rateHandlerAddress != address(0), "Invalid address");
         address old = address(rateHandler);

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -23,7 +23,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 4. **Mengambil Reward**
    * Setelah `minClaimInterval`, staker bisa mengambil reward atau menggabungkannya kembali ke stake. Untuk keluar sepenuhnya panggil `unstake` agar pokok dan reward diterima.
 5. **Barter Produk**
-   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterContract`.
+   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine`.
 6. **Menebus MEAT**
    * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
 

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -56,7 +56,7 @@ wasmd tx wasm instantiate <code_id> '{"meat_contract":"cosmos1..."}' \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
-Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan akan dikonfigurasi di `BarterContract` untuk menentukan rasio barter. Setelah itu deploy `goatnftwrapper` dan `goatnftburnhook` dengan parameter alamat kontrak terkait:
+Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan akan dikonfigurasi di `BarterEngine` untuk menentukan rasio barter. Setelah itu deploy `goatnftwrapper` dan `goatnftburnhook` dengan parameter alamat kontrak terkait:
 ```bash
 # contoh instansiasi goatnftwrapper
 wasmd tx wasm instantiate <code_id_wrapper> '{"nft_contract":"<nft_addr>","goat_contract":"<goat_addr>"}' \

--- a/test/barter.test.js
+++ b/test/barter.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("BarterContract", function () {
+describe("BarterEngine", function () {
   let owner, user, handler, meat, barter;
   const SUBTYPE_A = ethers.encodeBytes32String("GOATMEAT");
   const SUBTYPE_B = ethers.encodeBytes32String("DUCKMEAT");
@@ -17,7 +17,7 @@ describe("BarterContract", function () {
     meat = await MEAT.deploy();
     await meat.waitForDeployment();
 
-    const Barter = await ethers.getContractFactory("BarterContract");
+    const Barter = await ethers.getContractFactory("BarterEngine");
     barter = await Barter.deploy(handler.target, meat.target);
     await barter.waitForDeployment();
 

--- a/test/barterGoatBeef.test.js
+++ b/test/barterGoatBeef.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("BarterContract GOAT<->BEEF", function () {
+describe("BarterEngine GOAT<->BEEF", function () {
   let owner, user, handler, meat, barter;
   const SUBTYPE_GOATMEAT = ethers.encodeBytes32String("GOATMEAT");
   const SUBTYPE_BEEFMEAT = ethers.encodeBytes32String("BEEFMEAT");
@@ -17,7 +17,7 @@ describe("BarterContract GOAT<->BEEF", function () {
     meat = await MEAT.deploy();
     await meat.waitForDeployment();
 
-    const Barter = await ethers.getContractFactory("BarterContract");
+    const Barter = await ethers.getContractFactory("BarterEngine");
     barter = await Barter.deploy(handler.target, meat.target);
     await barter.waitForDeployment();
 


### PR DESCRIPTION
## Summary
- update docs to refer to `BarterEngine`
- revise architecture overview
- fix code comments referencing the old name
- use `BarterEngine` factory in barter tests

## Testing
- `yes | npx hardhat test` *(fails: non-local installation of Hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_6847a714bcec83259fc79c4b7a7f8106