### PR TITLE
Add events for minter/burner updates

### DIFF
--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -41,6 +41,8 @@ contract MEAT is ERC20 {
     event SubtypeMinted(address indexed to, bytes32 indexed subtype, uint256 amount);
     event SubtypeBurned(address indexed from, bytes32 indexed subtype, uint256 amount);
     event SubtypeLineageUpdated(address indexed user, bytes32 indexed subtype, uint256 lineageID);
+    event MinterUpdated(address indexed account, bool status);
+    event BurnerUpdated(address indexed account, bool status);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
@@ -113,11 +115,13 @@ contract MEAT is ERC20 {
     /// @notice Menetapkan atau mencabut hak minter untuk alamat tertentu
     function setMinter(address account, bool status) external onlyOwner {
         isMinter[account] = status;
+        emit MinterUpdated(account, status);
     }
 
     /// @notice Menetapkan atau mencabut hak burner untuk alamat tertentu
     function setBurner(address account, bool status) external onlyOwner {
         isBurner[account] = status;
+        emit BurnerUpdated(account, status);
     }
 
     function mintSubtype(address to, bytes32 subtype, uint256 amount) public onlyMinter {

--- a/test/meatSubtype.test.js
+++ b/test/meatSubtype.test.js
@@ -72,7 +72,9 @@ describe("MEAT subtype functions", function () {
       meat.connect(user).setMinter(user.address, true)
     ).to.be.revertedWith("Not the owner");
 
-    await meat.setMinter(user.address, true);
+    await expect(meat.setMinter(user.address, true))
+      .to.emit(meat, "MinterUpdated")
+      .withArgs(user.address, true);
     expect(await meat.isMinter(user.address)).to.equal(true);
   });
 
@@ -81,7 +83,9 @@ describe("MEAT subtype functions", function () {
       meat.connect(user).setBurner(user.address, true)
     ).to.be.revertedWith("Not the owner");
 
-    await meat.setBurner(user.address, true);
+    await expect(meat.setBurner(user.address, true))
+      .to.emit(meat, "BurnerUpdated")
+      .withArgs(user.address, true);
     expect(await meat.isBurner(user.address)).to.equal(true);
   });
 


### PR DESCRIPTION
## Summary
- add `MinterUpdated` and `BurnerUpdated` events in MEAT token
- emit new events when setting minters and burners
- test event emission in meatSubtype unit tests

## Testing
- `yes | npx hardhat test` *(fails: Hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847df7bc330832586de6b779fe16560