### PR TITLE
codex/docs-bytes32-subtype-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Berikut gambaran umum alur penggunaan kedua token:
 3. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
 4. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
 5. **Subtype Registry** – Kontrak MEAT menyimpan saldo per subtype (contoh `GOATMEAT`, `DUCKMEAT`). Hak khusus `mintSubtype` dan `burnSubtype` dapat diberikan ke kontrak lain seperti hook pembakaran NFT untuk mencatat produksi daging spesifik.
+Subtypes disimpan sebagai nilai `bytes32` hasil `ethers.encodeBytes32String` dari nama produk. Contoh:
+`bytes32 goatMeatSubtype = ethers.encodeBytes32String("GOATMEAT");`
 6. **GoatNFTBurnHook** – Hook ini dipanggil saat NFT kambing dibakar dan otomatis mencetak `GOATMEAT` sesuai berat yang dilaporkan.
 7. **SapiNFTBurnHook** – Versi untuk sapi yang memicu pencetakan `BEEFMEAT` ketika `SapiNFT` dibakar.
 8. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya untuk keperluan staking. Membuka kembali NFT mengharuskan jumlah GOAT yang sama dibakar.
@@ -51,6 +53,8 @@ flowchart LR
 - Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**.
 
 ### MEAT.sol — Subtype & Lineage Tracking
+
+Semua subtype direpresentasikan sebagai `bytes32` yang dihasilkan dari nama produk. Gunakan `ethers.encodeBytes32String("GOATMEAT")` untuk mengonversi string ke format ini.
 
 Kontrak MEAT kini menyimpan metadata `lineageID` untuk setiap kombinasi pengguna dan subtype. Pemilik kontrak dapat menetapkan nilai ini melalui `setSubtypeLineage(user, subtype, lineageID)`. Untuk membaca saldo sekaligus asal-usul token, gunakan `balanceOfSubtypeWithLineage(user, subtype)` yang mengembalikan `(balance, lineageID)`. Fungsi ini dipakai `BarterEngine` maupun `RedeemEngine` guna memverifikasi token sebelum dipertukarkan atau ditebus.
 

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -24,6 +24,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
    * Setelah `minClaimInterval`, staker bisa mengambil reward atau menggabungkannya kembali ke stake. Untuk keluar sepenuhnya panggil `unstake` agar pokok dan reward diterima.
 5. **Barter Produk**
    * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine`.
+   * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
 6. **Menebus MEAT**
    * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
 

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -65,7 +65,7 @@ Jalankan untuk tiap komoditas dengan data dari `lod_data.json`, meliputi:
 - Alamat NFT
 - Alamat token virtual
 - Alamat token produk
-- Subtype produk (bila ada)
+- Subtype produk (bila ada) - gunakan `ethers.encodeBytes32String("GOATMEAT")` untuk nilainya
 - Seluruh parameter transparan
 - Nilai LOD per layer
 

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -25,7 +25,7 @@ Pemilik kontrak dapat memanggil `setCommodityRepresentation(bytes32 commodityId,
 - alamat NFT
 - alamat token virtual
 - alamat token produk
-- subtype produk (bytes32)
+- subtype produk (bytes32) - contoh: `ethers.encodeBytes32String("GOATMEAT")`
 - status aktif masing-masing layer
 - nilai `lodPerDay` untuk setiap layer
 - parameter transparan: `protein_g_per_kg`, `fat_g_per_kg`, `micronutrient_index_x1000`, `yield_per_cycle_kg`, `cycle_time_days`


### PR DESCRIPTION
## Summary
- clarify how subtype strings must be encoded to bytes32
- document the encoding example in governance guides and lifecycle docs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6847e16521c083258329d02ec6250504