### PR TITLE
codex/allowance-check-burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ flowchart LR
 - Membungkus `GoatNFT` mencetak GOAT yang bisa langsung di-stake.
 - Membakar `GoatNFT` menghasilkan GOATMEAT sesuai bobot ternak.
 - GOATMEAT dapat dipertukarkan dengan token produk lain melalui `RateHandler`.
-- Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**.
+- Pengguna harus memberikan *approval* pada `BarterEngine` sebelum menukar subtype melalui `barterProductToProduct`.
+- Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**. Sebelum memanggil `redeem`, berikan *approval* kepada `RedeemEngine` untuk jumlah yang akan dibakar.
 
 ### MEAT.sol — Subtype & Lineage Tracking
 
@@ -309,7 +310,9 @@ Struktur dan hubungan antar kontrak:
 - `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
   untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterEngine`.
 - `BarterEngine` (`contracts/BarterEngine.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT. Engine ini menggunakan `balanceOfSubtypeWithLineage()` dari MEAT untuk memvalidasi asal-usul token sebelum swap dilakukan.
+-   Pengguna harus men-*approve* `BarterEngine` agar kontrak dapat membakar subtype miliknya.
 - `RedeemEngine` (`contracts/RedeemEngine.sol`) memproses penebusan MEAT dan memverifikasi lineage melalui `balanceOfSubtypeWithLineage()` sebelum distribusi.
+-   Sebelum menebus, berikan *approval* ke `RedeemEngine` untuk jumlah yang akan dibakar.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
   Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -146,6 +146,10 @@ contract MEAT is ERC20 {
         s.balance -= amount;
         subtypeTotalSupply[subtype] -= amount;
 
+        if (msg.sender != from) {
+            _spendAllowance(from, msg.sender, amount);
+        }
+
         _burn(from, amount);
 
         emit SubtypeBurned(from, subtype, amount);

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -24,9 +24,11 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
    * Setelah `minClaimInterval`, staker bisa mengambil reward atau menggabungkannya kembali ke stake. Untuk keluar sepenuhnya panggil `unstake` agar pokok dan reward diterima.
 5. **Barter Produk**
    * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine`.
+   * Sebelum barter, pengguna harus memberikan *approval* kepada `BarterEngine` untuk jumlah subtype yang akan dibakar.
    * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
 6. **Menebus MEAT**
    * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
+   * Pengguna harus men-*approve* `RedeemEngine` sebelum memanggil `redeem`.
 
 Siklus ini memastikan setiap tahap partisipasi didukung oleh fungsi kontrak yang eksplisit dan alur token yang transparan.
 

--- a/test/meatSubtype.test.js
+++ b/test/meatSubtype.test.js
@@ -31,6 +31,8 @@ describe("MEAT subtype functions", function () {
     expect(await meat.getTotalSupplyOfSubtype(subtype)).to.equal(amount);
     expect(await meat.balanceOf(user.address)).to.equal(amount);
 
+    await meat.connect(user).approve(burner.address, amount);
+
     await expect(
       meat.connect(burner).burnSubtype(user.address, subtype, amount)
     )

--- a/test/redeemEngine.test.js
+++ b/test/redeemEngine.test.js
@@ -27,6 +27,8 @@ describe("RedeemEngine", function () {
   it("redeems MEAT with lineage check", async function () {
     const redeemAmount = ethers.parseEther("2");
 
+    await meat.connect(user).approve(engine.target, redeemAmount);
+
     await expect(engine.connect(user).redeem(SUBTYPE, redeemAmount))
       .to.emit(engine, "RedeemExecuted")
       .withArgs(user.address, SUBTYPE, 7, redeemAmount);


### PR DESCRIPTION
## Summary
- enforce allowance when `burnSubtype` is called by third-party contracts
- document approval requirement for BarterEngine and RedeemEngine
- update lifecycle docs with approval steps
- adjust subtype and redeem engine tests to approve before burning

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6848019692c48325b3c60bdde9eda54b