### PR TITLE
codex/docs-bytes32-clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Berikut gambaran umum alur penggunaan kedua token:
 5. **Subtype Registry** – Kontrak MEAT menyimpan saldo per subtype (contoh `GOATMEAT`, `DUCKMEAT`). Hak khusus `mintSubtype` dan `burnSubtype` dapat diberikan ke kontrak lain seperti hook pembakaran NFT untuk mencatat produksi daging spesifik.
 Subtypes disimpan sebagai nilai `bytes32` hasil `ethers.encodeBytes32String` dari nama produk. Contoh:
 `bytes32 goatMeatSubtype = ethers.encodeBytes32String("GOATMEAT");`
+Semua fungsi MEAT mengharapkan parameter subtype dalam bentuk `bytes32`. Gunakan `ethers.encodeBytes32String` untuk mengubah nama produk atau ID numerik menjadi string terlebih dulu sebelum dikonversi.
+`bytes32 numericSubtype = ethers.encodeBytes32String("42");`
 6. **GoatNFTBurnHook** – Hook ini dipanggil saat NFT kambing dibakar dan otomatis mencetak `GOATMEAT` sesuai berat yang dilaporkan.
 7. **SapiNFTBurnHook** – Versi untuk sapi yang memicu pencetakan `BEEFMEAT` ketika `SapiNFT` dibakar.
 8. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya untuk keperluan staking. Membuka kembali NFT mengharuskan jumlah GOAT yang sama dibakar.
@@ -55,7 +57,8 @@ flowchart LR
 
 ### MEAT.sol — Subtype & Lineage Tracking
 
-Semua subtype direpresentasikan sebagai `bytes32` yang dihasilkan dari nama produk. Gunakan `ethers.encodeBytes32String("GOATMEAT")` untuk mengonversi string ke format ini.
+Semua subtype direpresentasikan sebagai `bytes32`. MEAT selalu menerima parameter subtype dalam bentuk ini, jadi gunakan `ethers.encodeBytes32String("GOATMEAT")` atau konversi ID numerik ke string dahulu.
+`bytes32 subtypeFromId = ethers.encodeBytes32String(String(123));`
 
 Kontrak MEAT kini menyimpan metadata `lineageID` untuk setiap kombinasi pengguna dan subtype. Pemilik kontrak dapat menetapkan nilai ini melalui `setSubtypeLineage(user, subtype, lineageID)`. Untuk membaca saldo sekaligus asal-usul token, gunakan `balanceOfSubtypeWithLineage(user, subtype)` yang mengembalikan `(balance, lineageID)`. Fungsi ini dipakai `BarterEngine` maupun `RedeemEngine` guna memverifikasi token sebelum dipertukarkan atau ditebus.
 

--- a/contracts/BarterEngine.sol
+++ b/contracts/BarterEngine.sol
@@ -7,6 +7,7 @@ import { MEAT } from "./MEAT.sol";
 /// @title BarterEngine v1
 /// @notice Enables PRODUCT↔PRODUCT swap based on RateHandler LOD parity.
 /// @dev Fully Reasoning Path FINAL Compliant. NO cross-layer swap allowed.
+/// @dev Subtype args are bytes32 generated via ethers.encodeBytes32String
 contract BarterEngine {
     address private immutable _owner;
     RateHandler public rateHandler;
@@ -48,6 +49,7 @@ contract BarterEngine {
     /// @notice PRODUCT↔PRODUCT swap
     /// @param fromSubtype Subtype of MEAT being burned
     /// @param toSubtype Subtype of MEAT being minted
+    /// Subtype parameters must be bytes32 from ethers.encodeBytes32String
     /// @param fromAmount Amount of fromSubtype to burn
     function barterProductToProduct(
         bytes32 fromSubtype,

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -8,6 +8,7 @@ import { RateHandler } from "./RateHandler.sol";
 /// @notice Kontrak pintar untuk mint MEAT menggunakan native token dan PRODUCT subtype token.
 /// @dev Reasoning Path FINAL Compliant → NO awareness of GOAT token. NO swap GOAT ↔ MEAT allowed.
 
+/// @dev Subtype parameters expect bytes32 values from ethers.encodeBytes32String
 contract MEAT is ERC20 {
     address private immutable _owner;
 
@@ -21,6 +22,7 @@ contract MEAT is ERC20 {
     }
 
     // Balance per user per subtype with lineage info
+    // Subtype values must be bytes32 generated via ethers.encodeBytes32String
     mapping(address => mapping(bytes32 => SubtypeBalance)) public subtypeBalances;
 
     // Total supply per subtype

--- a/contracts/RedeemEngine.sol
+++ b/contracts/RedeemEngine.sol
@@ -6,6 +6,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title RedeemEngine
 /// @notice Processes MEAT redemption with lineage verification
+/// @dev Subtype arguments must use ethers.encodeBytes32String
 contract RedeemEngine is Ownable {
     MEAT public immutable meat;
 
@@ -21,6 +22,7 @@ contract RedeemEngine is Ownable {
         meat = MEAT(payable(meatAddress));
     }
 
+    /// Subtype parameter should be bytes32 via ethers.encodeBytes32String
     /// @notice Redeem MEAT subtype after verifying lineage
     function redeem(bytes32 subtype, uint256 amount) external {
         require(amount > 0, "Invalid amount");

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -26,6 +26,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
    * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine`.
    * Sebelum barter, pengguna harus memberikan *approval* kepada `BarterEngine` untuk jumlah subtype yang akan dibakar.
    * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
+   * MEAT selalu mengharapkan parameter subtype berupa `bytes32`; ubah ID numerik ke string sebelum di-encode. contoh: `bytes32 subtypeFromId = ethers.encodeBytes32String("99");`
 6. **Menebus MEAT**
    * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
    * Pengguna harus men-*approve* `RedeemEngine` sebelum memanggil `redeem`.

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -25,7 +25,7 @@ Pemilik kontrak dapat memanggil `setCommodityRepresentation(bytes32 commodityId,
 - alamat NFT
 - alamat token virtual
 - alamat token produk
-- subtype produk (bytes32) - contoh: `ethers.encodeBytes32String("GOATMEAT")`
+- subtype produk (bytes32) - contoh: `ethers.encodeBytes32String("GOATMEAT")` MEAT selalu mengharapkan parameter subtype berbentuk `bytes32`; ID numerik harus diubah ke string sebelum di-encode.
 - status aktif masing-masing layer
 - nilai `lodPerDay` untuk setiap layer
 - parameter transparan: `protein_g_per_kg`, `fat_g_per_kg`, `micronutrient_index_x1000`, `yield_per_cycle_kg`, `cycle_time_days`


### PR DESCRIPTION
## Summary
- document that MEAT subtype params are passed as `bytes32`
- add example of encoding numeric IDs using `ethers.encodeBytes32String`
- note byte32 encoding requirements in BarterEngine and RedeemEngine

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68480b058bd8832581592752798fbd0f