### PR TITLE
codex/redeem-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Struktur dan hubungan antar kontrak:
   untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterEngine`.
 - `BarterEngine` (`contracts/BarterEngine.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT. Engine ini menggunakan `balanceOfSubtypeWithLineage()` dari MEAT untuk memvalidasi asal-usul token sebelum swap dilakukan.
 -   Pengguna harus men-*approve* `BarterEngine` agar kontrak dapat membakar subtype miliknya.
-- `RedeemEngine` (`contracts/RedeemEngine.sol`) memproses penebusan MEAT dan memverifikasi lineage melalui `balanceOfSubtypeWithLineage()` sebelum distribusi.
+- `RedeemEngine` (`contracts/RedeemEngine.sol`) memproses penebusan MEAT dan memverifikasi lineage melalui `balanceOfSubtypeWithLineage()`. Tiap subtype memiliki `RedeemConfig` yang berisi berat (gram) per token dan status aktif.
 -   Sebelum menebus, berikan *approval* ke `RedeemEngine` untuk jumlah yang akan dibakar.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.
   Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
@@ -443,11 +443,19 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 contract RedeemEngine is Ownable {
     MEAT public immutable meat;
 
+    struct RedeemConfig {
+        uint256 gramsPerTokenUnit;
+        bool isActive;
+    }
+
+    mapping(bytes32 => RedeemConfig) public redeemConfigs;
+
     event RedeemExecuted(
         address indexed user,
         bytes32 indexed subtype,
         uint256 lineageID,
-        uint256 amount
+        uint256 amount,
+        uint256 grams
     );
 
     constructor(address meatAddress) Ownable(msg.sender) {
@@ -455,14 +463,26 @@ contract RedeemEngine is Ownable {
         meat = MEAT(payable(meatAddress));
     }
 
+    function setRedeemConfig(bytes32 subtype, uint256 gramsPerTokenUnit, bool active) external onlyOwner {
+        require(subtype != bytes32(0), "Invalid subtype");
+        RedeemConfig storage cfg = redeemConfigs[subtype];
+        cfg.gramsPerTokenUnit = gramsPerTokenUnit;
+        cfg.isActive = active;
+    }
+
     function redeem(bytes32 subtype, uint256 amount) external {
         require(amount > 0, "Invalid amount");
+        RedeemConfig storage cfg = redeemConfigs[subtype];
+        require(cfg.isActive, "Redeem inactive");
+
         (uint256 balance, uint256 lineageID) =
             meat.balanceOfSubtypeWithLineage(msg.sender, subtype);
         require(balance >= amount, "Insufficient balance");
         require(lineageID != 0, "Lineage not set");
         meat.burnSubtype(msg.sender, subtype, amount);
-        emit RedeemExecuted(msg.sender, subtype, lineageID, amount);
+
+        uint256 grams = (amount * cfg.gramsPerTokenUnit) / 1e18;
+        emit RedeemExecuted(msg.sender, subtype, lineageID, amount, grams);
     }
 }
 ```

--- a/contracts/RedeemEngine.sol
+++ b/contracts/RedeemEngine.sol
@@ -10,11 +10,19 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 contract RedeemEngine is Ownable {
     MEAT public immutable meat;
 
+    struct RedeemConfig {
+        uint256 gramsPerTokenUnit;
+        bool isActive;
+    }
+
+    mapping(bytes32 => RedeemConfig) public redeemConfigs;
+
     event RedeemExecuted(
         address indexed user,
         bytes32 indexed subtype,
         uint256 lineageID,
-        uint256 amount
+        uint256 amount,
+        uint256 grams
     );
 
     constructor(address meatAddress) Ownable(msg.sender) {
@@ -22,14 +30,31 @@ contract RedeemEngine is Ownable {
         meat = MEAT(payable(meatAddress));
     }
 
+    /// @notice Configure grams redemption and activation state for a subtype
+    function setRedeemConfig(
+        bytes32 subtype,
+        uint256 gramsPerTokenUnit,
+        bool active
+    ) external onlyOwner {
+        require(subtype != bytes32(0), "Invalid subtype");
+        RedeemConfig storage cfg = redeemConfigs[subtype];
+        cfg.gramsPerTokenUnit = gramsPerTokenUnit;
+        cfg.isActive = active;
+    }
+
     /// Subtype parameter should be bytes32 via ethers.encodeBytes32String
-    /// @notice Redeem MEAT subtype after verifying lineage
+    /// @notice Redeem MEAT subtype after verifying lineage and config
     function redeem(bytes32 subtype, uint256 amount) external {
         require(amount > 0, "Invalid amount");
+        RedeemConfig storage cfg = redeemConfigs[subtype];
+        require(cfg.isActive, "Redeem inactive");
+
         (uint256 balance, uint256 lineageID) = meat.balanceOfSubtypeWithLineage(msg.sender, subtype);
         require(balance >= amount, "Insufficient balance");
         require(lineageID != 0, "Lineage not set");
         meat.burnSubtype(msg.sender, subtype, amount);
-        emit RedeemExecuted(msg.sender, subtype, lineageID, amount);
+
+        uint256 grams = (amount * cfg.gramsPerTokenUnit) / 1e18;
+        emit RedeemExecuted(msg.sender, subtype, lineageID, amount, grams);
     }
 }

--- a/test/redeemEngine.test.js
+++ b/test/redeemEngine.test.js
@@ -4,6 +4,7 @@ const { ethers } = require("hardhat");
 describe("RedeemEngine", function () {
   let owner, user, meat, engine;
   const SUBTYPE = ethers.encodeBytes32String("GOATMEAT");
+  const GRAMS_PER_TOKEN = 1000; // 1 token = 1000 grams
 
   beforeEach(async function () {
     [owner, user] = await ethers.getSigners();
@@ -19,6 +20,8 @@ describe("RedeemEngine", function () {
     await meat.setMinter(owner.address, true);
     await meat.setBurner(engine.target, true);
 
+    await engine.setRedeemConfig(SUBTYPE, GRAMS_PER_TOKEN, true);
+
     const amount = ethers.parseEther("5");
     await meat.mintSubtype(user.address, SUBTYPE, amount);
     await meat.setSubtypeLineage(user.address, SUBTYPE, 7);
@@ -29,9 +32,11 @@ describe("RedeemEngine", function () {
 
     await meat.connect(user).approve(engine.target, redeemAmount);
 
+    const expectedGrams = (redeemAmount * BigInt(GRAMS_PER_TOKEN)) / 10n ** 18n;
+
     await expect(engine.connect(user).redeem(SUBTYPE, redeemAmount))
       .to.emit(engine, "RedeemExecuted")
-      .withArgs(user.address, SUBTYPE, 7, redeemAmount);
+      .withArgs(user.address, SUBTYPE, 7, redeemAmount, expectedGrams);
 
     expect(await meat.getBalanceOfSubtype(user.address, SUBTYPE)).to.equal(
       ethers.parseEther("3")
@@ -50,10 +55,35 @@ describe("RedeemEngine", function () {
     await freshMeat.setMinter(owner.address, true);
     await freshMeat.setBurner(freshEngine.target, true);
     await freshMeat.mintSubtype(user.address, SUBTYPE, ethers.parseEther("1"));
+    await freshEngine.setRedeemConfig(SUBTYPE, GRAMS_PER_TOKEN, true);
 
     await expect(
       freshEngine.connect(user).redeem(SUBTYPE, ethers.parseEther("1"))
     ).to.be.revertedWith("Lineage not set");
+  });
+
+  it("reverts when subtype inactive", async function () {
+    await engine.setRedeemConfig(SUBTYPE, GRAMS_PER_TOKEN, false);
+
+    await meat.connect(user).approve(engine.target, ethers.parseEther("1"));
+
+    await expect(
+      engine.connect(user).redeem(SUBTYPE, ethers.parseEther("1"))
+    ).to.be.revertedWith("Redeem inactive");
+  });
+
+  it("only owner can set config", async function () {
+    await expect(
+      engine.connect(user).setRedeemConfig(SUBTYPE, 500, true)
+    )
+      .to.be.revertedWithCustomError(engine, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+
+    await engine.setRedeemConfig(SUBTYPE, 500, true);
+
+    const cfg = await engine.redeemConfigs(SUBTYPE);
+    expect(cfg.gramsPerTokenUnit).to.equal(500n);
+    expect(cfg.isActive).to.equal(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `RedeemConfig` struct and mapping to `RedeemEngine`
- allow owner to configure grams and active state
- calculate grams redeemed during `redeem`
- extend tests for new config logic
- document RedeemEngine behavior and sample code

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68482f39ea1483258bb774e93503017f