### PR TITLE
Add emergency subtype withdrawal

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Struktur dan hubungan antar kontrak:
   untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterEngine`.
 - `BarterEngine` (`contracts/BarterEngine.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT. Engine ini menggunakan `balanceOfSubtypeWithLineage()` dari MEAT untuk memvalidasi asal-usul token sebelum swap dilakukan.
 -   Pengguna harus men-*approve* `BarterEngine` agar kontrak dapat membakar subtype miliknya.
+-   Fungsi `emergencyWithdrawMEATSubtype` memungkinkan pemilik menarik saldo subtype yang tersangkut di dalam kontrak secara aman. Pilih `transferSubtype` jika tersedia, atau gunakan jalur `burn+mint` sebagai fallback.
 - `RedeemEngine` (`contracts/RedeemEngine.sol`) memproses penebusan MEAT dan memverifikasi lineage melalui `balanceOfSubtypeWithLineage()`. Tiap subtype memiliki `RedeemConfig` yang berisi berat (gram) per token dan status aktif.
 -   Sebelum menebus, berikan *approval* ke `RedeemEngine` untuk jumlah yang akan dibakar.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.

--- a/contracts/BarterEngine.sol
+++ b/contracts/BarterEngine.sol
@@ -21,6 +21,12 @@ contract BarterEngine {
         uint256 toAmount
     );
 
+    event MeatSubtypeWithdrawn(
+        address indexed to,
+        bytes32 indexed subtype,
+        uint256 amount
+    );
+
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
         _;
@@ -96,6 +102,40 @@ contract BarterEngine {
                 toSubtype,
                 "PRODUCT"
             );
+    }
+
+    /// @notice Emergency withdraw stuck MEAT subtype from this contract
+    /// @param subtype Subtype to withdraw (bytes32 encoded string)
+    /// @param amount Amount of subtype to withdraw
+    /// @param useTransfer If true, call transferSubtype; otherwise burn+mint
+    function emergencyWithdrawMEATSubtype(
+        bytes32 subtype,
+        uint256 amount,
+        bool useTransfer
+    ) external onlyOwner {
+        require(subtype != bytes32(0), "Invalid subtype");
+        require(amount > 0, "Amount must be > 0");
+
+        uint256 balance = meatToken.getBalanceOfSubtype(address(this), subtype);
+        require(balance >= amount, "Insufficient subtype balance");
+
+        if (useTransfer) {
+            (bool success, ) = address(meatToken).call(
+                abi.encodeWithSignature(
+                    "transferSubtype(address,address,bytes32,uint256)",
+                    address(this),
+                    _owner,
+                    subtype,
+                    amount
+                )
+            );
+            require(success, "transferSubtype failed");
+        } else {
+            meatToken.burnSubtype(address(this), subtype, amount);
+            meatToken.mintSubtype(_owner, subtype, amount);
+        }
+
+        emit MeatSubtypeWithdrawn(_owner, subtype, amount);
     }
 
     /// @notice Returns owner


### PR DESCRIPTION
## Summary
- add `emergencyWithdrawMEATSubtype` to `BarterEngine`
- document new emergency withdraw flow in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68484cca54b48325b8631ad6f54a9652