### PR TITLE
codex/docs-burn-yield

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Berikut langkah detail siklus kambing hingga daging tercatat di ledger:
  - Nilai `weight` disimpan dengan satu tempat desimal menggunakan `WEIGHT_DECIMALS = 1` sehingga `425` berarti **42.5 kg**.
 - NFT (standar ERC721) bebas dipindahtangankan ke pemilik baru.
 - Untuk memperoleh GOAT sebelum penyembelihan, pemilik mengunci NFT melalui `GoatNFTWrapper` yang mencetak GOAT berdasarkan berat terakhir.
-- Ketika kambing disembelih, pemilik membakar NFT; `GoatNFTBurnHook` mencetak `GOATMEAT` sejumlah `weight / rate` dari `RateHandler`.
-- GOAT digunakan untuk staking sementara GOATMEAT dipertukarkan antar produk melalui `RateHandler`.
+- Ketika kambing disembelih, pemilik membakar NFT; `GoatNFTBurnHook` mencetak `GOATMEAT` sebesar 60% dari berat hidup (konstanta `SLAUGHTER_YIELD_BPS`).
+- GOAT digunakan untuk staking sementara GOATMEAT dipertukarkan antar produk. `RateHandler` hanya dipakai pada tahap barter.
 - MEAT kemudian ditebus sebagai daging nyata sehingga seluruh riwayat ternak tersimpan on-chain.
 
 ```mermaid
@@ -51,7 +51,7 @@ flowchart LR
 
 - Membungkus `GoatNFT` mencetak GOAT yang bisa langsung di-stake.
 - Membakar `GoatNFT` menghasilkan GOATMEAT sesuai bobot ternak.
-- GOATMEAT dapat dipertukarkan dengan token produk lain melalui `RateHandler`.
+- GOATMEAT dapat dipertukarkan dengan token produk lain melalui `RateHandler` (hanya untuk barter).
 - Pengguna harus memberikan *approval* pada `BarterEngine` sebelum menukar subtype melalui `barterProductToProduct`.
 - Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**. Sebelum memanggil `redeem`, berikan *approval* kepada `RedeemEngine` untuk jumlah yang akan dibakar.
 

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -4,7 +4,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 
 - Setiap **GoatNFT** mencatat *ras*, *NFC tag*, *tahun lahir*, dan *berat* terkini.
 - Pemilik bebas memindahkan NFT dan memperbarui berat seiring pertumbuhan hewan.
-- Sebelum kambing disembelih, token dapat **dibakar** dengan berat terbaru yang mencetak `GOATMEAT` melalui `GoatNFTBurnHook`.
+- Sebelum kambing disembelih, token dapat **dibakar** dengan berat terbaru yang mencetak `GOATMEAT` sebesar 60% dari berat hidup melalui `GoatNFTBurnHook`.
 - Pemilik hook dapat memperbarui alamat `GoatNFT` maupun `MEAT` melalui `setNFTAddress` dan `setMEATAddress` bila diperlukan.
 - GOAT diperoleh dengan mengunci NFT pada `GoatNFTWrapper` dan digunakan untuk staking.
 - MEAT pada akhirnya dibakar menggunakan `redeemForMeat` untuk menebus daging fisik.


### PR DESCRIPTION
## Summary
- clarify constant yield in GoatNFTBurnHook
- explain RateHandler is only used for barter operations
- adjust goat lifecycle doc accordingly

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684aade877988325a00524d066724b8b