### PR TITLE
codex/docs-redeem-weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ flowchart LR
 - Membakar `GoatNFT` menghasilkan GOATMEAT sesuai bobot ternak.
 - GOATMEAT dapat dipertukarkan dengan token produk lain melalui `RateHandler` (hanya untuk barter).
 - Pengguna harus memberikan *approval* pada `BarterEngine` sebelum menukar subtype melalui `barterProductToProduct`.
-- Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik. **1 MEAT setara 1 KG daging**. Sebelum memanggil `redeem`, berikan *approval* kepada `RedeemEngine` untuk jumlah yang akan dibakar.
+- Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik.
+  Jumlah daging dihitung dari konfigurasi `RedeemConfig.gramsPerTokenUnit`.
+  Nilai bawaan umumnya menyetarakan **1 MEAT (1e18 unit) dengan 1 kg**, namun
+  angka ini dapat diubah sesuai kebutuhan. Sebelum memanggil `redeem`, berikan
+  *approval* kepada `RedeemEngine` untuk jumlah yang akan dibakar.
 
 ### MEAT.sol — Subtype & Lineage Tracking
 

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -28,7 +28,12 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
    * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
    * MEAT selalu mengharapkan parameter subtype berupa `bytes32`; ubah ID numerik ke string sebelum di-encode. contoh: `bytes32 subtypeFromId = ethers.encodeBytes32String("99");`
 6. **Menebus MEAT**
-   * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain. Tiap token yang ditebus mewakili **satu kilogram daging** dari mitra distribusi kami. Diagram singkat jalur burn dan redemption dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow) di README.
+   * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain.
+     Berat daging dihitung memakai `RedeemConfig.gramsPerTokenUnit`.
+     Konfigurasi default sering menyamakan **1 MEAT (1e18 unit) dengan 1 kg**,
+     namun nilainya dapat diatur ulang. Diagram singkat jalur burn dan redemption
+     dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow)
+     di README.
    * Pengguna harus men-*approve* `RedeemEngine` sebelum memanggil `redeem`.
 
 Siklus ini memastikan setiap tahap partisipasi didukung oleh fungsi kontrak yang eksplisit dan alur token yang transparan.


### PR DESCRIPTION
## Summary
- clarify that the redemption weight comes from `RedeemConfig.gramsPerTokenUnit`
- note the default 1 MEAT (1e18 units) equals 1 kg in README
- update lifecycle docs with the same explanation

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684b666e39648325aa251c7a1da39b0f