### PR TITLE
codex/add-sapi-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Semua fungsi MEAT mengharapkan parameter subtype dalam bentuk `bytes32`. Gunakan
 7. **SapiNFTBurnHook** – Versi untuk sapi yang memicu pencetakan `BEEFMEAT` ketika `SapiNFT` dibakar.
 8. **GoatNFTWrapper** – Kontrak ini mengunci GoatNFT dan mencetak GOAT sesuai beratnya untuk keperluan staking. Membuka kembali NFT mengharuskan jumlah GOAT yang sama dibakar.
    *GOAT sepenuhnya dicetak oleh `GoatNFTWrapper`; kontrak lain tidak memiliki izin mint.*
+9. **SapiNFTWrapper** – Kontrak pembungkus untuk SapiNFT yang mencetak GOAT berdasarkan berat sapi.
 
 ## Burn & Redeem Flow
 

--- a/contract-map.md
+++ b/contract-map.md
@@ -24,6 +24,9 @@ flowchart TD
 * **IGoatToken** dipakai GoatNFTWrapper dan GoatNFT untuk berinteraksi dengan kontrak GOAT.
 * **RateHandler** mengendalikan rasio swap terkini untuk barter produk.
 * **RedeemEngine** memproses penebusan MEAT dan memverifikasi lineage sebelum pembakaran.
+* **SapiNFT** menyimpan identitas sapi ERC721 dan metadata di `sapiMetadata`.
+* **SapiNFTBurnHook** mencetak `BEEFMEAT` setiap kali SapiNFT dibakar.
+* **SapiNFTWrapper** mengunci SapiNFT dan mencetak GOAT hingga NFT dibuka kembali.
 
 Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontrak utama beserta perannya.
 
@@ -34,6 +37,9 @@ Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontra
 | GoatNFT | Identitas kambing ERC721 yang menyimpan metadata di `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Berat dapat diperbarui via `updateWeight` dan harus segar saat dibakar. Fungsi `burn` memicu `GoatNFTBurnHook` serta event `GoatBurned`. |
 | GoatNFTBurnHook | Kontrak hook yang mencetak `GOATMEAT` setiap kali GoatNFT dibakar. |
 | GoatNFTWrapper | Mengunci GoatNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. |
+| SapiNFT | Identitas sapi ERC721 yang menyimpan metadata di `sapiMetadata` sebagai `SapiData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Berat dapat diperbarui via `updateWeight` dan harus segar saat dibakar. Fungsi `burn` memicu `SapiNFTBurnHook` serta event `SapiBurned`. |
+| SapiNFTBurnHook | Kontrak hook yang mencetak `BEEFMEAT` setiap kali SapiNFT dibakar. |
+| SapiNFTWrapper | Mengunci SapiNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. |
 | IGOAT | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper. |
 | IGoatToken | Antarmuka pencetakan GOAT yang digunakan GoatNFTWrapper dan GoatNFT. |
 | RedeemEngine | Memverifikasi lineage dan membakar subtype MEAT saat penebusan. |

--- a/contracts/SapiNFTWrapper.sol
+++ b/contracts/SapiNFTWrapper.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ISapiNFT} from "./interfaces/ISapiNFT.sol";
+import {IGoatToken} from "./interfaces/IGoatToken.sol";
+import {SwapConfig} from "./SwapConfig.sol";
+
+/// @title SapiNFTWrapper
+/// @notice Mengunci SapiNFT dan mencetak GOAT sebagai jaminan (berdasarkan SAPI_WRAP_RATE)
+contract SapiNFTWrapper is ERC721Holder {
+    IERC721 public immutable sapiNFT;
+    ISapiNFT public immutable sapiValueFeed;
+    IGoatToken public goatToken;
+    address private immutable _owner;
+
+    uint256 public constant WEIGHT_DECIMALS = 1;
+
+    struct WrappedInfo {
+        address owner;
+        uint256 goatAmount;
+    }
+
+    mapping(uint256 => WrappedInfo) public wrapped;
+
+    event Wrapped(address indexed user, uint256 indexed tokenId, uint256 goatAmount);
+    event Unwrapped(address indexed user, uint256 indexed tokenId, uint256 goatAmount);
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Not the owner");
+        _;
+    }
+
+    constructor(address nftAddress, address goatAddress) {
+        require(nftAddress != address(0) && goatAddress != address(0), "Invalid address");
+        sapiNFT = IERC721(nftAddress);
+        sapiValueFeed = ISapiNFT(nftAddress);
+        goatToken = IGoatToken(goatAddress);
+        _owner = msg.sender;
+    }
+
+    function _getRate() internal pure returns (uint256) {
+        return SwapConfig.SAPI_WRAP_RATE;
+    }
+
+    function wrap(uint256 tokenId) external {
+        require(sapiNFT.ownerOf(tokenId) == msg.sender, "Not token owner");
+        sapiNFT.safeTransferFrom(msg.sender, address(this), tokenId);
+
+        uint256 weight = sapiValueFeed.sapiValue(tokenId);
+        require(weight > 0, "Invalid weight");
+
+        uint256 rate = _getRate();
+        uint256 goatAmount = (weight * 1e18) / rate / (10 ** WEIGHT_DECIMALS);
+
+        goatToken.mint(msg.sender, goatAmount);
+        wrapped[tokenId] = WrappedInfo(msg.sender, goatAmount);
+
+        emit Wrapped(msg.sender, tokenId, goatAmount);
+    }
+
+    function unwrap(uint256 tokenId) external {
+        WrappedInfo memory info = wrapped[tokenId];
+        require(info.owner == msg.sender, "Not owner");
+
+        goatToken.burnFrom(msg.sender, info.goatAmount);
+        delete wrapped[tokenId];
+
+        sapiNFT.safeTransferFrom(address(this), msg.sender, tokenId);
+        emit Unwrapped(msg.sender, tokenId, info.goatAmount);
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}

--- a/test/sapiWrapper.test.js
+++ b/test/sapiWrapper.test.js
@@ -1,0 +1,80 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("SapiNFTWrapper", function () {
+  let owner, user, goat, nft, wrapper, swapRate;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const GOAT = await ethers.getContractFactory("GOAT");
+    goat = await GOAT.deploy();
+    await goat.waitForDeployment();
+
+    const SapiNFT = await ethers.getContractFactory("SapiNFT");
+    nft = await SapiNFT.deploy();
+    await nft.waitForDeployment();
+
+    const Wrapper = await ethers.getContractFactory("SapiNFTWrapper");
+    wrapper = await Wrapper.deploy(nft.target, goat.target);
+    await wrapper.waitForDeployment();
+
+    await goat.setWrapperContract(wrapper.target);
+
+    swapRate = 595n;
+  });
+
+  it("wraps NFT and mints GOAT", async function () {
+    const tx = await nft.mint(user.address, 500, "wrapS", "Brahman", 2021);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+
+    await nft.connect(user).approve(wrapper.target, tokenId);
+
+    const expected = (500n * 10n ** 18n) / swapRate / 10n;
+    await expect(wrapper.connect(user).wrap(tokenId))
+      .to.emit(wrapper, "Wrapped")
+      .withArgs(user.address, tokenId, expected);
+
+    expect(await nft.ownerOf(tokenId)).to.equal(wrapper.target);
+    expect(await goat.balanceOf(user.address)).to.equal(expected);
+  });
+
+  it("unwraps and burns GOAT", async function () {
+    const tx = await nft.mint(user.address, 600, "unwrapS", "Brahman", 2021);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).approve(wrapper.target, tokenId);
+
+    const amount = (600n * 10n ** 18n) / swapRate / 10n;
+    await wrapper.connect(user).wrap(tokenId);
+
+    await expect(wrapper.connect(user).unwrap(tokenId))
+      .to.emit(wrapper, "Unwrapped")
+      .withArgs(user.address, tokenId, amount);
+
+    expect(await nft.ownerOf(tokenId)).to.equal(user.address);
+    expect(await goat.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("reverts wrap when caller not NFT owner", async function () {
+    const tx = await nft.mint(owner.address, 500, "tag", "Brahman", 2020);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(owner).approve(wrapper.target, tokenId);
+
+    await expect(wrapper.connect(user).wrap(tokenId)).to.be.revertedWith(
+      "Not token owner"
+    );
+  });
+
+  it("reverts unwrap when caller not token owner", async function () {
+    const tx = await nft.mint(user.address, 650, "tag2", "Brahman", 2020);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).approve(wrapper.target, tokenId);
+    await wrapper.connect(user).wrap(tokenId);
+
+    await expect(wrapper.unwrap(tokenId)).to.be.revertedWith("Not owner");
+  });
+
+  it("owner() returns deployer", async function () {
+    expect(await wrapper.owner()).to.equal(owner.address);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `SapiNFTWrapper` contract to wrap SapiNFT and mint GOAT
- test wrapper logic for SapiNFT
- document new wrapper contract in README and contract map

## Testing
- `yes | npx hardhat test` *(fails: Hardhat installation required)*

------
https://chatgpt.com/codex/tasks/task_e_684b684682788325acf684d259f6641a