### PR TITLE
codex emergency withdraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Struktur dan hubungan antar kontrak:
 - `BarterEngine` (`contracts/BarterEngine.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT. Engine ini menggunakan `balanceOfSubtypeWithLineage()` dari MEAT untuk memvalidasi asal-usul token sebelum swap dilakukan.
 -   Pengguna harus men-*approve* `BarterEngine` agar kontrak dapat membakar subtype miliknya.
 -   Fungsi `getCurrentBarterRate(fromSubtype, toSubtype)` menyediakan rasio swap terkini tanpa mengeksekusi transaksi.
--   Fungsi `emergencyWithdrawMEATSubtype` memungkinkan pemilik menarik saldo subtype yang tersangkut di dalam kontrak secara aman. Pilih `transferSubtype` jika tersedia, atau gunakan jalur `burn+mint` sebagai fallback.
+-   Fungsi `emergencyWithdrawMEATSubtype` memungkinkan pemilik menarik **seluruh** saldo subtype yang tersangkut di dalam kontrak secara aman melalui skema `burn+mint`.
 - `RedeemEngine` (`contracts/RedeemEngine.sol`) memproses penebusan MEAT dan memverifikasi lineage melalui `balanceOfSubtypeWithLineage()`. Tiap subtype memiliki `RedeemConfig` yang berisi berat (gram) per token dan status aktif.
 -   Sebelum menebus, berikan *approval* ke `RedeemEngine` untuk jumlah yang akan dibakar.
 - `GoatNFT` (`contracts/GoatNFT.sol`) menyimpan identitas kambing sebagai NFT.

--- a/contracts/BarterEngine.sol
+++ b/contracts/BarterEngine.sol
@@ -104,38 +104,21 @@ contract BarterEngine {
             );
     }
 
-    /// @notice Emergency withdraw stuck MEAT subtype from this contract
-    /// @param subtype Subtype to withdraw (bytes32 encoded string)
-    /// @param amount Amount of subtype to withdraw
-    /// @param useTransfer If true, call transferSubtype; otherwise burn+mint
-    function emergencyWithdrawMEATSubtype(
-        bytes32 subtype,
-        uint256 amount,
-        bool useTransfer
-    ) external onlyOwner {
+    /// @notice Owner emergency withdraw ALL balance of MEAT subtype (used in RedeemEngine or Barter)
+    /// @param subtype The MEAT subtype to withdraw
+    function emergencyWithdrawMEATSubtype(bytes32 subtype) external onlyOwner {
         require(subtype != bytes32(0), "Invalid subtype");
-        require(amount > 0, "Amount must be > 0");
 
         uint256 balance = meatToken.getBalanceOfSubtype(address(this), subtype);
-        require(balance >= amount, "Insufficient subtype balance");
+        require(balance > 0, "No subtype balance");
 
-        if (useTransfer) {
-            (bool success, ) = address(meatToken).call(
-                abi.encodeWithSignature(
-                    "transferSubtype(address,address,bytes32,uint256)",
-                    address(this),
-                    _owner,
-                    subtype,
-                    amount
-                )
-            );
-            require(success, "transferSubtype failed");
-        } else {
-            meatToken.burnSubtype(address(this), subtype, amount);
-            meatToken.mintSubtype(_owner, subtype, amount);
-        }
+        // Burn from this contract
+        meatToken.burnSubtype(address(this), subtype, balance);
 
-        emit MeatSubtypeWithdrawn(_owner, subtype, amount);
+        // Mint to owner → avoid reentrancy problems
+        meatToken.mintSubtype(_owner, subtype, balance);
+
+        emit MeatSubtypeWithdrawn(_owner, subtype, balance);
     }
 
     /// @notice Returns owner

--- a/contracts/RedeemEngine.sol
+++ b/contracts/RedeemEngine.sol
@@ -25,6 +25,12 @@ contract RedeemEngine is Ownable {
         uint256 grams
     );
 
+    event MeatSubtypeWithdrawn(
+        address indexed to,
+        bytes32 indexed subtype,
+        uint256 amount
+    );
+
     constructor(address meatAddress) Ownable(msg.sender) {
         require(meatAddress != address(0), "Invalid MEAT address");
         meat = MEAT(payable(meatAddress));
@@ -56,5 +62,22 @@ contract RedeemEngine is Ownable {
 
         uint256 grams = (amount * cfg.gramsPerTokenUnit) / 1e18;
         emit RedeemExecuted(msg.sender, subtype, lineageID, amount, grams);
+    }
+
+    /// @notice Owner emergency withdraw ALL balance of MEAT subtype (used in RedeemEngine or Barter)
+    /// @param subtype The MEAT subtype to withdraw
+    function emergencyWithdrawMEATSubtype(bytes32 subtype) external onlyOwner {
+        require(subtype != bytes32(0), "Invalid subtype");
+
+        uint256 balance = meat.getBalanceOfSubtype(address(this), subtype);
+        require(balance > 0, "No subtype balance");
+
+        // Burn from this contract
+        meat.burnSubtype(address(this), subtype, balance);
+
+        // Mint to owner → avoid reentrancy problems
+        meat.mintSubtype(owner(), subtype, balance);
+
+        emit MeatSubtypeWithdrawn(owner(), subtype, balance);
     }
 }

--- a/test/barter.test.js
+++ b/test/barter.test.js
@@ -131,4 +131,16 @@ describe("BarterEngine", function () {
     const current = await barter.getCurrentBarterRate(SUBTYPE_A, SUBTYPE_B);
     expect(current).to.equal(rate);
   });
+
+  it("owner can emergency withdraw subtype", async function () {
+    const stuck = ethers.parseEther("2");
+    await meat.mintSubtype(barter.target, SUBTYPE_A, stuck);
+
+    await expect(barter.emergencyWithdrawMEATSubtype(SUBTYPE_A))
+      .to.emit(barter, "MeatSubtypeWithdrawn")
+      .withArgs(owner.address, SUBTYPE_A, stuck);
+
+    expect(await meat.getBalanceOfSubtype(barter.target, SUBTYPE_A)).to.equal(0n);
+    expect(await meat.getBalanceOfSubtype(owner.address, SUBTYPE_A)).to.equal(stuck);
+  });
 });

--- a/test/redeemEngine.test.js
+++ b/test/redeemEngine.test.js
@@ -18,6 +18,7 @@ describe("RedeemEngine", function () {
     await engine.waitForDeployment();
 
     await meat.setMinter(owner.address, true);
+    await meat.setMinter(engine.target, true);
     await meat.setBurner(engine.target, true);
 
     await engine.setRedeemConfig(SUBTYPE, GRAMS_PER_TOKEN, true);
@@ -84,6 +85,20 @@ describe("RedeemEngine", function () {
     const cfg = await engine.redeemConfigs(SUBTYPE);
     expect(cfg.gramsPerTokenUnit).to.equal(500n);
     expect(cfg.isActive).to.equal(true);
+  });
+
+  it("owner can emergency withdraw subtype", async function () {
+    const stuck = ethers.parseEther("1");
+    await meat.mintSubtype(engine.target, SUBTYPE, stuck);
+
+    await expect(engine.emergencyWithdrawMEATSubtype(SUBTYPE))
+      .to.emit(engine, "MeatSubtypeWithdrawn")
+      .withArgs(owner.address, SUBTYPE, stuck);
+
+    expect(await meat.getBalanceOfSubtype(engine.target, SUBTYPE)).to.equal(0n);
+    expect(await meat.getBalanceOfSubtype(owner.address, SUBTYPE)).to.equal(
+      stuck
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add MeatSubtypeWithdrawn event and emergencyWithdrawMEATSubtype to RedeemEngine
- simplify BarterEngine emergency withdraw to burn+mint entire balance
- document new withdraw flow in README
- test emergency withdraw for RedeemEngine and BarterEngine

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684b77fe55b083258a4ed88ab56306ef