### PR TITLE
codex/update-docs-mint-redeem

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 Repositori ini berisi dua token ERC20:
 
 - **GOAT** (Guardian of Agricultural Trade) mendukung proses staking. Token GOAT dicetak saat `GoatNFT` dikunci melalui `GoatNFTWrapper`. Pemegang dapat melakukan staking guna memperoleh imbal hasil tahunan tinggi.
-- **MEAT** (Market-Enabled Agricultural Token) memungkinkan pengguna mencetak token dengan mata uang native dan menjadi gerbang utama bagi ekosistem.
+- **MEAT** (Market-Enabled Agricultural Token) dicetak hanya melalui `mintSubtype()` oleh kontrak terotorisasi dan menjadi gerbang utama bagi ekosistem.
 
 ## Cara Kerja Token
 
 Berikut gambaran umum alur penggunaan kedua token:
 
-1. **Mint MEAT** – MEAT dapat dicetak dengan mengirim token native ke kontrak `MEAT` yang diproses otomatis oleh `receive()` sesuai `DepositRate`, atau melalui `mintSubtype` oleh minter terotorisasi seperti hook pembakaran NFT. Saat kontrak dideploy, suplai awal juga dicetak ke alamat pemilik. Versi CosmWasm menggunakan pesan `mint_with_native` untuk cara pertama.
-   *MEAT dapat dicetak lewat deposit token native maupun `mintSubtype` oleh kontrak terotorisasi.*
+1. **Mint MEAT** – MEAT hanya dicetak melalui `mintSubtype()` oleh kontrak yang telah diberi otorisasi seperti hook pembakaran NFT. Saat kontrak dideploy, suplai awal dikirim ke alamat pemilik.
+   *MEAT hanya dicetak oleh kontrak terotorisasi.*
 2. **Stake GOAT** – Pemegang GOAT dapat memanggil `stake(amount)` pada kontrak GOAT untuk mulai memperoleh reward. Besarnya reward dihitung linier berdasarkan `rewardRate` dengan periode akrual `rewardInterval`.
    *Memanggil `stake()` lagi akan mengatur ulang `lastStakedTime` dan membuang reward yang belum diambil, jadi sebaiknya `claimReward` terlebih dahulu sebelum menambah stake.*
 3. **Claim atau Compound** – Setelah melewati `minClaimInterval`, pengguna dapat mencairkan reward melalui `claimReward` atau melakukan `compoundReward` agar hasilnya otomatis ditambahkan ke saldo staking.
-4. **Redeem MEAT** – Panggil `redeemForMeat(amount)` untuk membakar token MEAT dan men-trigger distribusi daging secara off-chain. Fungsi ini mengurangi saldo MEAT dan memancarkan event `MeatRedeemed`.
+4. **Redeem MEAT** – Panggil `RedeemEngine.redeem(subtype, amount)` untuk membakar MEAT setelah verifikasi lineage. Event `RedeemExecuted` mencatat jumlah dan asal token.
 5. **Subtype Registry** – Kontrak MEAT menyimpan saldo per subtype (contoh `GOATMEAT`, `DUCKMEAT`). Hak khusus `mintSubtype` dan `burnSubtype` dapat diberikan ke kontrak lain seperti hook pembakaran NFT untuk mencatat produksi daging spesifik.
 Subtypes disimpan sebagai nilai `bytes32` hasil `ethers.encodeBytes32String` dari nama produk. Contoh:
 `bytes32 goatMeatSubtype = ethers.encodeBytes32String("GOATMEAT");`
@@ -54,11 +54,10 @@ flowchart LR
 - Membakar `GoatNFT` menghasilkan GOATMEAT sesuai bobot ternak.
 - GOATMEAT dapat dipertukarkan dengan token produk lain melalui `RateHandler` (hanya untuk barter).
 - Pengguna harus memberikan *approval* pada `BarterEngine` sebelum menukar subtype melalui `barterProductToProduct`.
-- Pemegang MEAT menukarkan tokennya lewat `redeemForMeat` untuk menerima daging fisik.
-  Jumlah daging dihitung dari konfigurasi `RedeemConfig.gramsPerTokenUnit`.
-  Nilai bawaan umumnya menyetarakan **1 MEAT (1e18 unit) dengan 1 kg**, namun
-  angka ini dapat diubah sesuai kebutuhan. Sebelum memanggil `redeem`, berikan
-  *approval* kepada `RedeemEngine` untuk jumlah yang akan dibakar.
+- Pemegang MEAT menukarkan tokennya dengan memanggil `RedeemEngine.redeem(subtype, amount)`.
+  Fungsi ini memverifikasi `lineageID` melalui `balanceOfSubtypeWithLineage` dan
+  menghitung berat berdasarkan `RedeemConfig.gramsPerTokenUnit`.
+  Sebelum memanggil `redeem`, berikan *approval* kepada `RedeemEngine` untuk jumlah yang akan dibakar.
 
 ### MEAT.sol — Subtype & Lineage Tracking
 
@@ -184,12 +183,7 @@ serta `goatnftburnhook` kini berdiri sendiri dan telah disertakan di
 CosmWasm tetap mengikuti fungsi di Solidity namun ada beberapa perbedaan tak
 terelakkan:
 
- - **MEAT**: Pada `MEAT.sol` pengguna cukup mengirim native token dan fungsi
-   `receive()` otomatis mencetak token. CosmWasm tidak menyediakan mekanisme
-   auto‑mint saat menerima dana tanpa pesan sehingga pengguna **harus** memanggil
-   `mint_with_native` sambil menyertakan koin. Versi CosmWasm hanya menyediakan
-   pesan `redeem_for_meat` dan tidak memiliki fitur swap GOAT↔MEAT maupun
-   konfigurasi `ratehandler`.
+- **MEAT**: Baik versi Solidity maupun CosmWasm hanya mencetak token melalui `mintSubtype()` yang dipanggil kontrak lain. Fitur auto-mint dengan token native telah dihapus.
 - **GOAT**: Kontrak `starter` mereplikasi logika staking, klaim, kompaun dan
   pembakaran NFT. Event Solidity diterjemahkan menjadi atribut di response
   CosmWasm, sedangkan cara perhitungan reward sama persis.
@@ -206,9 +200,6 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
  - **SAPI_WRAP_RATE** – konstanta di `SwapConfig` yang digunakan `SapiNFTWrapper` untuk menentukan jumlah token virtual sapi dari berat NFT. Nilai default `595`.
    `SwapConfig` kini hanya menyimpan dua konstanta ini.
  - **RateHandler LOD Parity** – Fungsi `computeBarterRate` tidak lagi memakai `SwapConfig` dan sepenuhnya menghitung rasio barter berdasarkan nilai LOD masing-masing komoditas.
-- **DepositRate** – rasio pencetakan MEAT ketika menerima native token. Nilai
-  dihitung per `DEPOSIT_DIVISOR` (1000) unit native token sehingga `100` berarti
-  100 MEAT untuk 1000 unit native (0.1 MEAT per 1 unit).
 - **rewardRate** – tingkat imbal hasil tahunan di kontrak GOAT (dalam skala
   `1e18`). Nilai ini dikombinasikan dengan `rewardInterval` untuk menghitung
   reward harian pengguna.
@@ -247,10 +238,6 @@ di [docs/lod-governance.md](docs/lod-governance.md).
 - `OwnershipTransferred(oldOwner, newOwner)` dicatat ketika kepemilikan RateHandler dialihkan ke alamat baru.
 
 MEAT juga memunculkan event utama berikut:
-
-- `MintedWithNative(user, nativeReceived, meatMinted)` dicatat ketika kontrak
-  menerima native token dan mencetak MEAT. Pada versi CosmWasm event ini
-  dipicu saat `mint_with_native` dipanggil.
 - `SubtypeMinted(to, subtype, amount)` dicatat ketika minter terotorisasi
   mencetak MEAT untuk subtype tertentu.
 - `SubtypeBurned(from, subtype, amount)` dicatat ketika burner terotorisasi

--- a/architecture.md
+++ b/architecture.md
@@ -5,7 +5,7 @@ Proyek ini berpusat pada dua kontrak ERC20—**GOAT** dan **MEAT**—yang didepl
 ## Lapisan On-Chain
 
 * **GOAT (`contracts/GOAT.sol`)** – menyediakan staking dengan reward berbasis waktu dan kontrol konfigurasi. Suplai GOAT dicetak melalui `GoatNFTWrapper`.
-* **MEAT (`contracts/MEAT.sol`)** – mencetak token saat menerima mata uang native (menggunakan `DepositRate` per 1000 unit), mengendalikan deposit rate, serta dapat menarik saldo native yang terkumpul.
+* **MEAT (`contracts/MEAT.sol`)** – token ERC20 yang dicetak melalui `mintSubtype()` oleh kontrak terotorisasi. Kontrak ini menyimpan saldo per subtype dan mendukung pembakaran.
 * **GoatNFT (`contracts/GoatNFT.sol`)** – menyimpan detail kambing on-chain dalam `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Setiap `nfcId` dipetakan ke token ID sehingga duplikasi ditolak saat mint. Pemilik dapat memanggil `updateWeight` untuk memperbarui berat (menerbitkan `WeightUpdated`). `burn` mensyaratkan pembaruan berat dalam 7 hari terakhir, memicu `GoatNFTBurnHook` dan `GoatBurned` sambil menghapus pemetaan NFC.
 * **GoatNFTBurnHook (`contracts/GoatNFTBurnHook.sol`)** – dipanggil oleh `GoatNFT` saat token dibakar untuk mencetak `GOATMEAT` berdasarkan bobot.
 * **GoatNFTWrapper (`contracts/GoatNFTWrapper.sol`)** – kontrak pembungkus yang mengunci GoatNFT dan mencetak GOAT setara. NFT dapat diambil kembali setelah jumlah GOAT yang sama dibakar.

--- a/contract-map.md
+++ b/contract-map.md
@@ -9,7 +9,7 @@ flowchart TD
   Hook[BurnHook]
   RateHandler[RateHandler]
 
-  UserWallet -- "native token" --> MEAT
+  UserWallet -- "approval" --> MEAT
   GoatNFT -- burn --> Hook
   Hook --> MEAT
   MEAT -->|withdraw| UserWallet
@@ -17,7 +17,7 @@ flowchart TD
   RateHandler --> MEAT
 ```
 
-* **MEAT** berperan sebagai gerbang: menerima koin native, mencetak MEAT, dan mengontrol rasio deposit. Pemilik dapat menarik saldo native yang terkumpul.
+* **MEAT** berperan sebagai gerbang: token dicetak melalui `mintSubtype` oleh kontrak terotorisasi.
 * **GOAT** menerima suplai dari GoatNFTWrapper yang mencetak token saat NFT dibungkus. Reward serta parameter konfigurasi dapat diatur pemilik.
 * **FailingGOAT** hanya untuk pengujian; menerapkan antarmuka yang sama namun memungkinkan simulasi kegagalan transfer.
 * **IGOAT** mendefinisikan fungsi `mintTo` yang memungkinkan GoatNFTWrapper mencetak GOAT.
@@ -33,7 +33,7 @@ Kontrak GOAT dan MEAT dimiliki alamat yang sama. Tabel di bawah merangkum kontra
 | Kontrak | Deskripsi |
 |---------|-----------|
 | GOAT | Token ERC20 untuk staking yang dicetak oleh GoatNFTWrapper saat NFT dibungkus. |
-| MEAT | Token ERC20 yang dicetak dengan deposit native. |
+| MEAT | Token ERC20 yang dicetak melalui `mintSubtype` oleh kontrak terotorisasi. |
 | GoatNFT | Identitas kambing ERC721 yang menyimpan metadata di `goatMetadata` sebagai `GoatData` (`nfcId`, `breed`, `birthYear`, `weight`, `mintedAt`). Berat dapat diperbarui via `updateWeight` dan harus segar saat dibakar. Fungsi `burn` memicu `GoatNFTBurnHook` serta event `GoatBurned`. |
 | GoatNFTBurnHook | Kontrak hook yang mencetak `GOATMEAT` setiap kali GoatNFT dibakar. |
 | GoatNFTWrapper | Mengunci GoatNFT dan mencetak GOAT setara hingga NFT dibuka kembali dengan membakar GOAT. |

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -7,11 +7,10 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 - Sebelum kambing disembelih, token dapat **dibakar** dengan berat terbaru yang mencetak `GOATMEAT` sebesar 60% dari berat hidup melalui `GoatNFTBurnHook`.
 - Pemilik hook dapat memperbarui alamat `GoatNFT` maupun `MEAT` melalui `setNFTAddress` dan `setMEATAddress` bila diperlukan.
 - GOAT diperoleh dengan mengunci NFT pada `GoatNFTWrapper` dan digunakan untuk staking.
-- MEAT pada akhirnya dibakar menggunakan `redeemForMeat` untuk menebus daging fisik.
+- MEAT pada akhirnya dibakar melalui `RedeemEngine.redeem` untuk menebus daging fisik.
 
 1. **Mencetak MEAT**
-   * Pengguna mengirim mata uang native ke kontrak MEAT. Fungsi `receive()` mencetak MEAT ke pengirim berdasarkan `DepositRate`, dihitung per 1000 unit (default `100`, artinya 100 MEAT per 1000 native).
-   * Kontrak memancarkan `MintedWithNative(user, nativeReceived, meatMinted)` yang mencatat siapa mencetak dan berapa jumlah token native diterima.
+   * Token hanya dicetak melalui `mintSubtype` oleh kontrak terotorisasi seperti `GoatNFTBurnHook`.
 2. **GoatNFT**
    * [GoatNFT](contracts/GoatNFT.sol) mewakili kambing hidup dan menyimpan beratnya di `goatValue`.
    * Pemilik dapat memperbarui berat kapan saja (event `WeightUpdated`). Berat memakai satu desimal (`WEIGHT_DECIMALS = 1`) sehingga `425` berarti **42.5 kg**.
@@ -28,12 +27,11 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
    * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
    * MEAT selalu mengharapkan parameter subtype berupa `bytes32`; ubah ID numerik ke string sebelum di-encode. contoh: `bytes32 subtypeFromId = ethers.encodeBytes32String("99");`
 6. **Menebus MEAT**
-   * Pemegang membakar MEAT mereka melalui `redeemForMeat(amount)` yang memicu `MeatRedeemed` untuk pemrosesan off-chain.
-     Berat daging dihitung memakai `RedeemConfig.gramsPerTokenUnit`.
-     Konfigurasi default sering menyamakan **1 MEAT (1e18 unit) dengan 1 kg**,
-     namun nilainya dapat diatur ulang. Diagram singkat jalur burn dan redemption
-     dapat dilihat pada bagian [Burn & Redeem Flow](README.md#burn--redeem-flow)
-     di README.
+   * Panggil `RedeemEngine.redeem(subtype, amount)` untuk membakar MEAT setelah verifikasi lineage.
+     Berat daging dihitung memakai `RedeemConfig.gramsPerTokenUnit` dan hasilnya
+     dicatat dalam event `RedeemExecuted`.
+     Konfigurasi default menyetarakan **1 MEAT (1e18 unit) dengan 1 kg**, tetapi
+     nilainya dapat diubah. Lihat diagram [Burn & Redeem Flow](README.md#burn--redeem-flow).
    * Pengguna harus men-*approve* `RedeemEngine` sebelum memanggil `redeem`.
 
 Siklus ini memastikan setiap tahap partisipasi didukung oleh fungsi kontrak yang eksplisit dan alur token yang transparan.

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -3,7 +3,7 @@
 Proyek ini menyertakan implementasi CosmWasm untuk seluruh kontrak inti di direktori `wasm-contracts/`:
 
 - `starter` – token GOAT dengan logika staking
-- `meat` – token MEAT yang mendukung pencetakan menggunakan native token dan perintah `redeem_for_meat`. Fitur swap GOAT↔MEAT dan konfigurasi `ratehandler` tidak disertakan.
+- `meat` – token MEAT. Pencetakan dilakukan via pesan `mint_subtype` oleh kontrak terotorisasi dan penebusan menggunakan `redeem` pada `RedeemEngine`.
 - `goatnft` – kontrak NFT sederhana tempat setiap token menyimpan nilai berat yang dapat ditebus menjadi GOAT
 - `ratehandler` – utilitas kecil yang menyimpan rasio konversi terbaru dan memungkinkan pemilik memperbarui atau menonaktifkannya
 - `goatnftwrapper` – membungkus GoatNFT untuk mencetak GOAT, NFT dikunci hingga pengguna melakukan `unwrap`
@@ -11,7 +11,7 @@ Proyek ini menyertakan implementasi CosmWasm untuk seluruh kontrak inti di direk
 
 Paket-paket ini mencerminkan kontrak Solidity di `contracts/`. Sebagian besar fungsi memiliki pesan execute yang setara, namun terdapat beberapa perbedaan penting:
 
-- **MEAT** tidak dapat mencetak otomatis ketika menerima token native tanpa pesan. Pengguna **harus** memanggil `mint_with_native` dan menyertakan dana.
+- **MEAT** tidak memiliki fungsi auto-mint. Token dicetak melalui pesan `mint_subtype` yang dipanggil kontrak lain.
 - **starter** menerapkan staking GOAT dan penebusan NFT sama seperti `GOAT.sol`, hanya saja event menjadi atribut log.
 - **goatnft** menyimpan metadata kambing dan berat mirip dengan `GoatNFT.sol` dengan sedikit perbedaan penamaan. Pemilik dapat memanggil `update_weight` untuk memperbarui berat. Pembakaran membutuhkan pembaruan terakhir dalam rentang `WEIGHT_UPDATE_VALIDITY` (7 hari).
 
@@ -71,20 +71,8 @@ wasmd tx wasm instantiate <code_id_hook> '{"nft_contract":"<nft_addr>"}' \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
 
-### Mencetak MEAT
 
-Panggil entri `mint_with_native` sambil mengirim koin native untuk mencetak MEAT. Contoh:
-
-```bash
-wasmd tx wasm execute <meat_address> '{"mint_with_native":{}}' \
-  --amount 1000000uatom --from wallet \
-  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
-  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
-```
-
-Mengirim koin tanpa pesan ini **tidak** akan mencetak token; koin hanya tersimpan di kontrak sampai ditarik pemilik.
-
-Setelah `goatnft` dideploy, pemilik dapat langsung memanggil `burn` pada kontrak NFT untuk menandai penyembelihan. Fungsi ini akan memicu `GoatNFTBurnHook` yang mencetak `GOATMEAT` sesuai berat terakhir.
+Setelah `goatnft` dideploy, pemilik dapat langsung memanggil `burn` pada kontrak NFT untuk menandai penyembelihan. Fungsi ini memicu `GoatNFTBurnHook` yang menjalankan `mint_subtype` pada kontrak MEAT dan mencetak `GOATMEAT` sesuai berat terakhir.
 
 ```bash
 wasmd tx wasm execute <nft_address> '{"burn":{"token_id":1}}' \

--- a/user-journey.md
+++ b/user-journey.md
@@ -3,7 +3,7 @@
 Dokumen ini menggambarkan pengalaman umum bagi peserta baru di ekosistem GOAT/MEAT.
 
 1. **Mendapatkan MEAT**
-   * Pengguna membuka aplikasi web, menghubungkan dompet, lalu mengirim sejumlah kecil token native ke kontrak MEAT. Kontrak akan mencetak MEAT sesuai `DepositRate` saat ini.
+   * Pengguna memperoleh MEAT ketika kontrak terotorisasi memanggil `mintSubtype` setelah aksi tertentu, misalnya pembakaran NFT melalui hook.
 2. **Staking untuk Reward**
    * Pengguna membungkus GoatNFT melalui `GoatNFTWrapper` untuk memperoleh GOAT.
    * GOAT tersebut kemudian di-stake dan UI menampilkan hitungan mundur hingga klaim diperbolehkan (`minClaimInterval`).


### PR DESCRIPTION
## Summary
- update README to explain mint only via `mintSubtype`
- document lineage-verified redeem using `RedeemEngine.redeem`
- revise lifecycle and deployment docs to remove native token mint flow
- adjust architecture map and user journey to match new minting rules

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684b873cd2888325b805870e22b8ad95