### PR TITLE
codex/add-initial-supply-test

### DIFF
--- a/test/meatSubtype.test.js
+++ b/test/meatSubtype.test.js
@@ -15,6 +15,15 @@ describe("MEAT subtype functions", function () {
     await meat.setBurner(burner.address, true);
   });
 
+  it("initializes with owner as minter and 1000 GOATMEAT", async function () {
+    const subtype = ethers.keccak256(ethers.toUtf8Bytes("GOATMEAT"));
+    const expected = ethers.parseEther("1000");
+
+    expect(await meat.isMinter(owner.address)).to.equal(true);
+    expect(await meat.getBalanceOfSubtype(owner.address, subtype)).to.equal(expected);
+    expect(await meat.totalSupply()).to.equal(expected);
+  });
+
   it("mints and burns subtype tokens", async function () {
     const subtype = ethers.encodeBytes32String("GOATMEAT");
     const amount = ethers.parseEther("10");


### PR DESCRIPTION
## Summary
- add regression test for MEAT initial subtype supply

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684b99157c9083258d85afb049fe3974