### PR TITLE
codex/docs-ratehandler-lod-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ agar perilaku ekonomi konsisten di EVM maupun Cosmos.
  - **GOAT_WRAP_RATE** – konstanta di `SwapConfig` yang dipakai `GoatNFTWrapper` untuk menghitung jumlah GOAT dari berat NFT. Nilai default `85`.
  - **SAPI_WRAP_RATE** – konstanta di `SwapConfig` yang digunakan `SapiNFTWrapper` untuk menentukan jumlah token virtual sapi dari berat NFT. Nilai default `595`.
    `SwapConfig` kini hanya menyimpan dua konstanta ini.
- - **RateHandler LOD Parity** – Fungsi `computeBarterRate` tidak lagi memakai `SwapConfig` dan sepenuhnya menghitung rasio barter berdasarkan nilai LOD masing-masing komoditas.
+- **RateHandler LOD Parity** – Fungsi `computeBarterRate` tidak lagi memakai `SwapConfig` dan sepenuhnya menghitung rasio barter berdasarkan nilai LOD masing-masing komoditas.
+- **Set LOD via CommodityRepresentation** – `RateHandler` mendapatkan semua data LOD melalui `setCommodityRepresentation` tanpa fallback ke konfigurasi lain.
 - **rewardRate** – tingkat imbal hasil tahunan di kontrak GOAT (dalam skala
   `1e18`). Nilai ini dikombinasikan dengan `rewardInterval` untuk menghitung
   reward harian pengguna.

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -13,6 +13,8 @@ Setiap komoditas direpresentasikan sebagai:
 - **Token produk** → Produk olahan (subtype MEAT, JMC, dll)
 
 LOD per hari untuk tiap layer disimpan on-chain.
+Semua nilai tersebut kini hanya dimuat melalui fungsi `setCommodityRepresentation` pada `RateHandler`.
+Tidak ada fallback atau referensi ke `SwapConfig` maupun mapping lama lainnya.
 
 Lihat diagram *Canonical Reasoning Path* pada [architecture.md](../architecture.md#token-layer-separation--lod-engine-enforcement) bagian 4 untuk pemahaman menyeluruh mengenai pemisahan layer dan aturan swap.
 
@@ -100,6 +102,7 @@ LOD v1.1 → lod_data_v1_1_202507XX.json
 ✅ Governance mengontrol pembaruan parameter secara transparan.
 ✅ Riwayat LOD harus versi.
 ✅ Unit Test **WAJIB** lulus sebelum mengirim pembaruan on-chain.
+✅ `RateHandler` hanya mengambil data melalui `setCommodityRepresentation` tanpa fallback ke `SwapConfig`.
 
 ---
 

--- a/docs/lod-governance.md
+++ b/docs/lod-governance.md
@@ -1,6 +1,6 @@
 # Level of Decay (LOD)
 
-`LOD` menentukan penurunan nilai barter komoditas setiap hari. Data dasar tersimpan pada `lod_data_base.json` dan diolah oleh skrip `compute_lod.py` menjadi `lod_data.json`. Nilai pada berkas keluaran tersebut dapat dimuat on-chain melalui fungsi `setCommodityRepresentation` pada `RateHandler`.
+`LOD` menentukan penurunan nilai barter komoditas setiap hari. Data dasar tersimpan pada `lod_data_base.json` dan diolah oleh skrip `compute_lod.py` menjadi `lod_data.json`. Nilai pada berkas keluaran tersebut dimuat on-chain hanya melalui fungsi `setCommodityRepresentation` pada `RateHandler`. Tidak ada mekanisme fallback maupun ketergantungan `SwapConfig`.
 
 ```json
 [


### PR DESCRIPTION
## Summary
- clarify `setCommodityRepresentation` is only source for LOD values in RateHandler

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684b9da93c188325b8c25b29fff878a0