### PR TITLE
codex/update-doc-mint-redeem

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Lineage ID otomatis diatur saat hook memanggil `mintSubtype()` sehingga mint man
 
 ```mermaid
 flowchart LR
-  MintMEAT["Mint MEAT with Native"] --> Subtype["Subtype Balance"]
+  MintMEAT["Mint MEAT via mintSubtype"] --> Subtype["Subtype Balance"]
   Subtype --> BarterEngine["BarterEngine"]
   Subtype --> RedeemEngine["RedeemEngine"]
   RedeemEngine --> Physical["Physical Meat Delivery"]
@@ -316,8 +316,7 @@ Setelah itu edit `frontend/.env.local` dan isi `NEXT_PUBLIC_GOAT_ADDRESS` serta 
 
 Struktur dan hubungan antar kontrak:
 - `GOAT` (`contracts/GOAT.sol`) mewarisi `ERC20` OpenZeppelin dan menambahkan fungsi staking, klaim, kompaun, serta konfigurasi reward. Token hanya dicetak melalui `GoatNFTWrapper` saat NFT dibungkus.
-- `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang menerima native token
-  untuk mint dan mengontrol deposit rate. Pesan baru `redeem_for_meat` membakar MEAT untuk menebus daging. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterEngine`.
+- `MEAT` (`contracts/MEAT.sol`) adalah token `ERC20` yang hanya dicetak lewat `mintSubtype()` oleh kontrak terotorisasi. Penebusan daging diproses melalui `RedeemEngine.redeem`. Perhitungan rasio barter menggunakan `RateHandler` yang dipanggil di dalam `BarterEngine`.
 - `BarterEngine` (`contracts/BarterEngine.sol`) memfasilitasi swap PRODUCT↔PRODUCT antar subtype MEAT. Hanya pertukaran PRODUCT↔PRODUCT yang diperbolehkan dan token GOAT **tidak** dapat ditukar. Engine ini menggunakan `balanceOfSubtypeWithLineage()` dari MEAT untuk memvalidasi asal-usul token sebelum swap dilakukan.
 -   Pengguna harus men-*approve* `BarterEngine` agar kontrak dapat membakar subtype miliknya.
 -   Fungsi `getCurrentBarterRate(fromSubtype, toSubtype)` menyediakan rasio swap terkini tanpa mengeksekusi transaksi.

--- a/frontend-flow.md
+++ b/frontend-flow.md
@@ -2,7 +2,7 @@
 
 Antarmuka web menyediakan langkah sederhana untuk berinteraksi dengan GOAT dan MEAT. Pengguna diharapkan menghubungkan dompet yang kompatibel dengan jaringan tempat kontrak dideploy.
 
-1. **Mint MEAT** – kirim mata uang native dari dompet langsung ke kontrak MEAT melalui UI. Frontend memantau event `MintedWithNative` dan memperbarui saldo MEAT.
+1. **Mint MEAT** – Hanya kontrak terotorisasi yang memanggil `mintSubtype` pada MEAT. Frontend memantau event `SubtypeMinted` dan memperbarui saldo.
 2. **Stake GOAT** – setelah memiliki GOAT, pengguna dapat melakukan staking berapa pun. UI menampilkan reward yang menunggu lewat `pendingReward` serta waktu berikutnya klaim tersedia.
 3. **Claim atau Compound** – setelah interval klaim terlewati, UI mengaktifkan tombol `claimReward` dan `compoundReward`. Opsi compound menambahkan reward kembali ke saldo staking.
 4. **Unstake** – pengguna dapat melakukan unstake untuk menarik pokok beserta reward.

--- a/integration-bridge.md
+++ b/integration-bridge.md
@@ -5,7 +5,7 @@ Integrasi antara smart contract dan aplikasi eksternal ditangani melalui backend
 1. **Skrip Deploy** – `scripts/deploy.js` mengompilasi dan mendepoy GOAT serta MEAT tanpa perlu memanggil `setMEATAddress` ataupun menautkan alamat apa pun.
 2. **Artefak ABI** – Hardhat menghasilkan ABI dan bytecode yang dapat diimpor layanan backend atau langsung digunakan frontend untuk membangun instance `ethers.Contract`.
 3. **Lapisan API** – Server Express opsional dapat menyediakan endpoint REST untuk memanggil fungsi kontrak seperti `stake`. Cara ini menjaga kunci privat di server sementara frontend menandatangani transaksi di sisi klien bila diperlukan.
-4. **Pemantauan Event** – Kedua lapisan memantau event penting (`MintedWithNative`, `Staked`, `Unstaked`, `EmergencyUnstaked`, dll.) agar UI tetap sinkron.
+4. **Pemantauan Event** – Kedua lapisan memantau event penting (`SubtypeMinted`, `Staked`, `Unstaked`, `EmergencyUnstaked`, dll.) agar UI tetap sinkron.
 
 ## Backend Setup
 


### PR DESCRIPTION
## Summary
- update contract structure section to remove native deposit mention
- switch diagrams and docs to `mintSubtype` + `RedeemEngine.redeem`
- adjust frontend and integration docs to watch `SubtypeMinted`

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684ba3b976e88325bbea0b9a3f619e3e