### PR TITLE
fix: prevent reentrancy in NFT burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Semua peristiwa tersebut tercatat on-chain sehingga pasokan GOAT dan MEAT selalu
 
 SapiNFT memodernisasi pencatatan sapi dengan pendekatan serupa. Token ini menyimpan `nfcId`, ras, tahun lahir, dan berat yang dapat diperbarui oleh pemilik agar valuasi tetap akurat. NFT dapat dipindahtangankan bebas sesuai standar ERC721. Saat sapi disembelih, NFT dibakar sehingga `SapiNFTBurnHook` otomatis mencetak `BEEFMEAT`. Token BEEFMEAT kemudian bisa ditebus menjadi daging fisik.
 
+Fungsi `burn` pada SapiNFT juga menghapus data dan memanggil `super.burn` terlebih dulu sebelum menghubungi `burnHook` agar tidak rentan terhadap *reentrancy*.
+
 Alurnya ringkas sebagai berikut:
 
 ```
@@ -327,7 +329,7 @@ Struktur dan hubungan antar kontrak:
   Metadata tiap token dikemas dalam struct `GoatData` (`nfcId`, `breed`,
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.
   Pemilik dapat memperbarui berat melalui `updateWeight` (memancarkan `WeightUpdated`); berat terakhir harus
-  masih valid (<=7 hari) saat dibakar. Fungsi `burn` kini hanya memicu `GoatNFTBurnHook` untuk mencetak `GOATMEAT`. Event `GoatBurned` tetap dipancarkan sebagai catatan berat dan rasio. Data dapat dibaca ulang melalui `getGoatData` dan dihapus setelah `burn`.
+  masih valid (<=7 hari) saat dibakar. Fungsi `burn` kini hanya memicu `GoatNFTBurnHook` untuk mencetak `GOATMEAT`. Event `GoatBurned` tetap dipancarkan sebagai catatan berat dan rasio. Data dapat dibaca ulang melalui `getGoatData` dan dihapus setelah `burn`. Untuk mencegah *reentrancy*, data NFT dibersihkan dan `super.burn` dipanggil **sebelum** meneruskan kontrol ke `burnHook`.
 - `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper` saat mencetak GOAT baru. `IGoatToken` dipakai oleh wrapper dan NFT untuk berinteraksi dengan kontrak GOAT.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test
   guna mensimulasikan kegagalan `transfer`.

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -101,18 +101,18 @@ contract GoatNFT is ERC721Burnable {
 
         bytes32 hash = keccak256(bytes(goatMetadata[tokenId].nfcId));
 
+        super.burn(tokenId);
+        delete goatValue[tokenId];
+        delete goatMetadata[tokenId];
+        delete lastWeightUpdateAt[tokenId];
+        delete nfcIdToTokenId[hash];
+
         // Memicu burnHook untuk mint GOATMEAT
         if (address(burnHook) != address(0)) {
             burnHook.onBurn(tokenOwner, currentWeight);
         }
 
         emit GoatBurned(tokenId, tokenOwner, currentWeight);
-
-        super.burn(tokenId);
-        delete goatValue[tokenId];
-        delete goatMetadata[tokenId];
-        delete lastWeightUpdateAt[tokenId];
-        delete nfcIdToTokenId[hash];
     }
 
     function getGoatData(uint256 tokenId) external view returns (GoatData memory) {

--- a/contracts/SapiNFT.sol
+++ b/contracts/SapiNFT.sol
@@ -84,17 +84,17 @@ contract SapiNFT is ERC721Burnable {
 
         bytes32 hash = keccak256(bytes(sapiMetadata[tokenId].nfcId));
 
-        if (address(burnHook) != address(0)) {
-            burnHook.onBurn(tokenOwner, currentWeight);
-        }
-
-        emit SapiBurned(tokenId, tokenOwner, currentWeight);
-
         super.burn(tokenId);
         delete sapiValue[tokenId];
         delete sapiMetadata[tokenId];
         delete lastWeightUpdateAt[tokenId];
         delete nfcIdToTokenId[hash];
+
+        if (address(burnHook) != address(0)) {
+            burnHook.onBurn(tokenOwner, currentWeight);
+        }
+
+        emit SapiBurned(tokenId, tokenOwner, currentWeight);
     }
 
     function getSapiData(uint256 tokenId) external view returns (SapiData memory) {

--- a/contracts/mocks/MaliciousGoatHook.sol
+++ b/contracts/mocks/MaliciousGoatHook.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IGoatNFT} from "../interfaces/IGoatNFT.sol";
+
+/// @title Malicious hook that attempts reentrancy during burn
+contract MaliciousGoatHook {
+    IGoatNFT public goatNFT;
+    uint256 public targetTokenId;
+
+    constructor(address nftAddress) {
+        goatNFT = IGoatNFT(nftAddress);
+    }
+
+    function setTargetTokenId(uint256 tokenId) external {
+        targetTokenId = tokenId;
+    }
+
+    function onBurn(address /*to*/, uint256 /*weight*/) external {
+        // attempt reentrant burn
+        if (targetTokenId != 0) {
+            try goatNFT.burn(targetTokenId) {
+                // no-op
+            } catch {}
+        }
+    }
+}

--- a/contracts/mocks/MaliciousSapiHook.sol
+++ b/contracts/mocks/MaliciousSapiHook.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {ISapiNFT} from "../interfaces/ISapiNFT.sol";
+
+/// @title Malicious hook that attempts reentrancy during burn of SapiNFT
+contract MaliciousSapiHook {
+    ISapiNFT public sapiNFT;
+    uint256 public targetTokenId;
+
+    constructor(address nftAddress) {
+        sapiNFT = ISapiNFT(nftAddress);
+    }
+
+    function setTargetTokenId(uint256 tokenId) external {
+        targetTokenId = tokenId;
+    }
+
+    function onBurn(address /*to*/, uint256 /*weight*/) external {
+        if (targetTokenId != 0) {
+            try sapiNFT.burn(targetTokenId) {
+            } catch {}
+        }
+    }
+}

--- a/test/nftReentrancy.test.js
+++ b/test/nftReentrancy.test.js
@@ -1,0 +1,59 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("NFT burn reentrancy protection", function () {
+  let owner, user, nft, sapi, goatHook, sapiHook;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const GoatNFT = await ethers.getContractFactory("GoatNFT");
+    nft = await GoatNFT.deploy();
+    await nft.waitForDeployment();
+
+    const SapiNFT = await ethers.getContractFactory("SapiNFT");
+    sapi = await SapiNFT.deploy();
+    await sapi.waitForDeployment();
+
+    const MaliciousGoat = await ethers.getContractFactory("MaliciousGoatHook");
+    goatHook = await MaliciousGoat.deploy(nft.target);
+    await goatHook.waitForDeployment();
+
+    const MaliciousSapi = await ethers.getContractFactory("MaliciousSapiHook");
+    sapiHook = await MaliciousSapi.deploy(sapi.target);
+    await sapiHook.waitForDeployment();
+
+    await nft.setBurnHook(goatHook.target);
+    await sapi.setBurnHook(sapiHook.target);
+  });
+
+  it("clears state before external hook (GoatNFT)", async function () {
+    const tx = await nft.mint(user.address, 500, "reent", "Boer", 2023);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await nft.connect(user).updateWeight(tokenId, 500n);
+
+    await nft.connect(user).approve(goatHook.target, tokenId);
+    await goatHook.setTargetTokenId(tokenId);
+
+    await expect(nft.connect(user).burn(tokenId))
+      .to.emit(nft, "GoatBurned")
+      .withArgs(tokenId, user.address, 500n);
+
+    await expect(nft.ownerOf(tokenId)).to.be.reverted;
+  });
+
+  it("clears state before external hook (SapiNFT)", async function () {
+    const tx = await sapi.mint(user.address, 700, "reentS", "Brahman", 2023);
+    const tokenId = (await tx.wait()).logs[0].args[2];
+    await sapi.connect(user).updateWeight(tokenId, 700n);
+
+    await sapi.connect(user).approve(sapiHook.target, tokenId);
+    await sapiHook.setTargetTokenId(tokenId);
+
+    await expect(sapi.connect(user).burn(tokenId))
+      .to.emit(sapi, "SapiBurned")
+      .withArgs(tokenId, user.address, 700n);
+
+    await expect(sapi.ownerOf(tokenId)).to.be.reverted;
+  });
+});


### PR DESCRIPTION
## Summary
- reorder state clearing in GoatNFT and SapiNFT burn
- add malicious hook contracts for reentrancy tests
- add unit tests confirming hooks cannot reenter
- document reentrancy mitigation

## Testing
- `npx hardhat test test/nftReentrancy.test.js`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684badc310c483258a27acdad097693c