### PR TITLE
Add event emission for commodity updates

### DIFF
--- a/contracts/RateHandler.sol
+++ b/contracts/RateHandler.sol
@@ -29,6 +29,7 @@ contract RateHandler {
     mapping(bytes32 => CommodityRepresentation) public commodityRegistry;
 
     event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+    event CommodityRepresentationUpdated(bytes32 indexed commodityId);
 
     modifier onlyOwner() {
         require(msg.sender == _owner, "Not the owner");
@@ -57,6 +58,7 @@ contract RateHandler {
         c.micronutrient_index_x1000 = data.micronutrient_index_x1000;
         c.yield_per_cycle_kg = data.yield_per_cycle_kg;
         c.cycle_time_days = data.cycle_time_days;
+        emit CommodityRepresentationUpdated(commodityId);
     }
 
     /// @notice Get LOD per layer for given commodity.

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -15,6 +15,7 @@ Setiap komoditas direpresentasikan sebagai:
 LOD per hari untuk tiap layer disimpan on-chain.
 Semua nilai tersebut kini hanya dimuat melalui fungsi `setCommodityRepresentation` pada `RateHandler`.
 Tidak ada fallback atau referensi ke `SwapConfig` maupun mapping lama lainnya.
+Panggilan fungsi tersebut memunculkan event `CommodityRepresentationUpdated(commodityId)` untuk menandai pembaruan data di blockchain.
 
 Lihat diagram *Canonical Reasoning Path* pada [architecture.md](../architecture.md#token-layer-separation--lod-engine-enforcement) bagian 4 untuk pemahaman menyeluruh mengenai pemisahan layer dan aturan swap.
 

--- a/test/rateHandler.test.js
+++ b/test/rateHandler.test.js
@@ -44,7 +44,9 @@ describe("RateHandler integration", function () {
       yield_per_cycle_kg: 1,
       cycle_time_days: 1,
     };
-    await handler.setCommodityRepresentation(wheat, data);
+    await expect(handler.setCommodityRepresentation(wheat, data))
+      .to.emit(handler, "CommodityRepresentationUpdated")
+      .withArgs(wheat);
     expect(
       await handler["getLODPerDay(bytes32,string)"](wheat, "NFT")
     ).to.equal(2n);
@@ -168,8 +170,9 @@ describe("RateHandler - LOD Engine v1.0", function () {
       cycle_time_days: 365,
     };
 
-    const tx = await rateHandler.setCommodityRepresentation(commodityId, data);
-    await tx.wait();
+    await expect(rateHandler.setCommodityRepresentation(commodityId, data))
+      .to.emit(rateHandler, "CommodityRepresentationUpdated")
+      .withArgs(commodityId);
   });
 
   it("returns correct LOD for NFT layer", async function () {


### PR DESCRIPTION
## Summary
- emit `CommodityRepresentationUpdated` when calling `setCommodityRepresentation`
- document the new event in governance documentation
- expect the event in `rateHandler` tests

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684bd30d90688325ab6c0ef8ce0d7b1c