### PR TITLE
Update script for ethers v6

### DIFF
--- a/scripts/updateCommodityRepresentation.js
+++ b/scripts/updateCommodityRepresentation.js
@@ -8,19 +8,19 @@ async function main() {
   const RateHandler = await ethers.getContractAt("RateHandler", rateHandlerAddress);
 
   // Example commodity data, adapt from lod_data.json
-  const commodityId = ethers.utils.formatBytes32String("KAMBING");
+  const commodityId = ethers.encodeBytes32String("KAMBING");
 
   const data = {
     nftAddress: "0xGoatNFTAddress", // set real NFT address
     tokenVirtualAddress: "0xGOATTokenAddress", // GOAT token
     tokenProductAddress: "0xMEATTokenAddress", // MEAT token (GOATMEAT subtype)
-    tokenProductSubtype: ethers.utils.formatBytes32String("GOATMEAT"),
+    tokenProductSubtype: ethers.encodeBytes32String("GOATMEAT"),
     isNftActive: true,
     isTokenVirtualActive: true,
     isTokenProductActive: true,
-    lodPerDayNft: ethers.utils.parseUnits("44.52", 18),
-    lodPerDayVirtual: ethers.utils.parseUnits("44.52", 18),
-    lodPerDayProduct: ethers.utils.parseUnits("44.52", 18),
+    lodPerDayNft: ethers.parseUnits("44.52", 18),
+    lodPerDayVirtual: ethers.parseUnits("44.52", 18),
+    lodPerDayProduct: ethers.parseUnits("44.52", 18),
     protein_g_per_kg: 270,
     fat_g_per_kg: 200,
     micronutrient_index_x1000: 900,


### PR DESCRIPTION
## Summary
- update `updateCommodityRepresentation.js` to use ethers v6 helpers
- run tests
- verify the script execution fails when executed without proper configuration

## Testing
- `yes | npx hardhat test`
- `node scripts/updateCommodityRepresentation.js` *(fails: HardhatEthersProvider.resolveName not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_684c23352b8c8325a9213ed17d4770f9