### PR TITLE
codex/ownable-upgrade

### DIFF
--- a/contracts/BarterEngine.sol
+++ b/contracts/BarterEngine.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.29;
 
 import { RateHandler } from "./RateHandler.sol";
 import { MEAT } from "./MEAT.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title BarterEngine v1
 /// @notice Enables PRODUCT↔PRODUCT swap based on RateHandler LOD parity.
 /// @dev Fully Reasoning Path FINAL Compliant. NO cross-layer swap allowed.
 /// @dev Subtype args are bytes32 generated via ethers.encodeBytes32String
-contract BarterEngine {
-    address private immutable _owner;
+contract BarterEngine is Ownable {
     RateHandler public rateHandler;
     MEAT public meatToken;
 
@@ -27,15 +27,9 @@ contract BarterEngine {
         uint256 amount
     );
 
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
-
-    constructor(address rateHandlerAddress, address meatAddress) {
+    constructor(address rateHandlerAddress, address meatAddress) Ownable(msg.sender) {
         require(rateHandlerAddress != address(0), "Invalid RateHandler address");
         require(meatAddress != address(0), "Invalid MEAT address");
-        _owner = msg.sender;
         rateHandler = RateHandler(rateHandlerAddress);
         meatToken = MEAT(payable(meatAddress));
     }
@@ -116,14 +110,12 @@ contract BarterEngine {
         meatToken.burnSubtype(address(this), subtype, balance);
 
         // Mint to owner → avoid reentrancy problems
-        meatToken.mintSubtype(_owner, subtype, balance);
+        meatToken.mintSubtype(owner(), subtype, balance);
 
-        emit MeatSubtypeWithdrawn(_owner, subtype, balance);
+        emit MeatSubtypeWithdrawn(owner(), subtype, balance);
     }
 
     /// @notice Returns owner
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }
 

--- a/contracts/GOAT.sol
+++ b/contracts/GOAT.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.29;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title Token GOAT - Guardian of Agricultural Trade (Capital Layer Token)
 /// @notice Token GOAT hanya dapat dicetak oleh GoatNFTWrapper (wrap) dan digunakan untuk staking / ROI.
 /// @dev Tidak ada path mintTo oleh MEAT. Tidak ada cross-layer leak. Reasoning Path FINAL Compliant.
 
-contract GOAT is ERC20 {
-    address private immutable _owner;
+contract GOAT is ERC20, Ownable {
 
     event RewardConfigChanged(
         uint256 oldRate,
@@ -35,14 +35,7 @@ contract GOAT is ERC20 {
 
     address public wrapperContract;
 
-    constructor() ERC20("Guardian of Agricultural Trade", "GOAT") {
-        _owner = msg.sender;
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
+    constructor() ERC20("Guardian of Agricultural Trade", "GOAT") Ownable(msg.sender) {}
 
     /// @notice Set wrapper contract (GoatNFTWrapper) — only this contract can mint/burn GOAT
     function setWrapperContract(address wrapperAddress) external onlyOwner {
@@ -170,8 +163,5 @@ contract GOAT is ERC20 {
         minClaimInterval = newMinClaimTime;
     }
 
-    /// @notice Mengembalikan alamat pemilik kontrak
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }

--- a/contracts/GoatNFT.sol
+++ b/contracts/GoatNFT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {GoatNFTBurnHook} from "./GoatNFTBurnHook.sol";
 
 /// @title GoatNFT - identitas kambing dalam bentuk token
@@ -12,7 +13,7 @@ import {GoatNFTBurnHook} from "./GoatNFTBurnHook.sol";
 /// - Mint: Menyimpan berat awal kambing.
 /// - UpdateWeight: Memperbarui berat terbaru.
 /// - Burn: Membutuhkan berat terbaru (valid), memicu burnHook untuk mint GOATMEAT, lalu membakar NFT.
-contract GoatNFT is ERC721Burnable {
+contract GoatNFT is ERC721Burnable, Ownable {
     uint256 public nextId;
     mapping(uint256 => uint256) public goatValue;
 
@@ -28,7 +29,6 @@ contract GoatNFT is ERC721Burnable {
     mapping(uint256 => uint256) public lastWeightUpdateAt;
     mapping(bytes32 => uint256) public nfcIdToTokenId;
 
-    address private immutable _owner;
     GoatNFTBurnHook public burnHook;
 
     /// @notice Jangka waktu validitas pembaruan berat dalam detik (7 hari)
@@ -36,14 +36,7 @@ contract GoatNFT is ERC721Burnable {
     /// @notice Jumlah digit desimal yang digunakan untuk berat
     uint256 public constant WEIGHT_DECIMALS = 1;
 
-    constructor() ERC721("Goat Identifier", "GOATNFT") {
-        _owner = msg.sender;
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
+    constructor() ERC721("Goat Identifier", "GOATNFT") Ownable(msg.sender) {}
 
     /// @notice Mengatur kontrak hook yang dipanggil saat NFT dibakar
     function setBurnHook(address hookAddress) external onlyOwner {
@@ -119,9 +112,7 @@ contract GoatNFT is ERC721Burnable {
         return goatMetadata[tokenId];
     }
 
-    function owner() external view returns (address) {
-        return _owner;
-    }
+
 
     /// @notice Dipancarkan ketika alamat kontrak hook diubah
     event BurnHookUpdated(address indexed oldAddress, address indexed newAddress);

--- a/contracts/GoatNFTBurnHook.sol
+++ b/contracts/GoatNFTBurnHook.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.29;
 
 import {IGoatNFT} from "./interfaces/IGoatNFT.sol";
 import {IMeat} from "./interfaces/IMeat.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title GoatNFTBurnHook
 /// @notice Mints GOATMEAT tokens when a GoatNFT is burned
-contract GoatNFTBurnHook {
+contract GoatNFTBurnHook is Ownable {
     IGoatNFT public goatNFT;
     IMeat public meatToken;
 
-    address private immutable _owner;
 
     bytes32 public constant GOATMEAT_SUBTYPE = keccak256("GOATMEAT");
     uint256 public constant SLAUGHTER_YIELD_BPS = 6000; // 60% of live weight
@@ -20,16 +20,10 @@ contract GoatNFTBurnHook {
     event NFTAddressUpdated(address indexed oldAddress, address indexed newAddress);
     event GoatMeatMinted(address indexed to, uint256 amount);
 
-    constructor(address nftAddress, address meatAddress) {
+    constructor(address nftAddress, address meatAddress) Ownable(msg.sender) {
         require(nftAddress != address(0) && meatAddress != address(0), "Invalid address");
-        _owner = msg.sender;
         goatNFT = IGoatNFT(nftAddress);
         meatToken = IMeat(meatAddress);
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
     }
 
     function setNFTAddress(address nftAddress) external onlyOwner {
@@ -57,8 +51,6 @@ contract GoatNFTBurnHook {
         emit GoatMeatMinted(to, meatAmount);
     }
 
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }
 

--- a/contracts/GoatNFTWrapper.sol
+++ b/contracts/GoatNFTWrapper.sol
@@ -6,14 +6,14 @@ import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IGoatNFT} from "./interfaces/IGoatNFT.sol";
 import {IGoatToken} from "./interfaces/IGoatToken.sol";
 import {SwapConfig} from "./SwapConfig.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title GoatNFTWrapper
 /// @notice Mengunci GoatNFT dan mencetak GOAT sebagai jaminan
-contract GoatNFTWrapper is ERC721Holder {
+contract GoatNFTWrapper is ERC721Holder, Ownable {
     IERC721 public immutable goatNFT;
     IGoatNFT public immutable goatValueFeed;
     IGoatToken public goatToken;
-    address private immutable _owner;
 
     uint256 public constant WEIGHT_DECIMALS = 1;
 
@@ -27,17 +27,11 @@ contract GoatNFTWrapper is ERC721Holder {
     event Wrapped(address indexed user, uint256 indexed tokenId, uint256 goatAmount);
     event Unwrapped(address indexed user, uint256 indexed tokenId, uint256 goatAmount);
 
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
-
-    constructor(address nftAddress, address goatAddress) {
+    constructor(address nftAddress, address goatAddress) Ownable(msg.sender) {
         require(nftAddress != address(0) && goatAddress != address(0), "Invalid address");
         goatNFT = IERC721(nftAddress);
         goatValueFeed = IGoatNFT(nftAddress);
         goatToken = IGoatToken(goatAddress);
-        _owner = msg.sender;
     }
 
     function _getRate() internal pure returns (uint256) {
@@ -71,7 +65,5 @@ contract GoatNFTWrapper is ERC721Holder {
         emit Unwrapped(msg.sender, tokenId, info.goatAmount);
     }
 
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.29;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { RateHandler } from "./RateHandler.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title Token MEAT - Market-Enabled Agricultural Token
 /// @notice Kontrak pintar untuk mint MEAT menggunakan native token dan PRODUCT subtype token.
 /// @dev Reasoning Path FINAL Compliant → NO awareness of GOAT token. NO swap GOAT ↔ MEAT allowed.
 
 /// @dev Subtype parameters expect bytes32 values from ethers.encodeBytes32String
-contract MEAT is ERC20 {
-    address private immutable _owner;
+contract MEAT is ERC20, Ownable {
 
     // Authorized addresses allowed to mint or burn subtype balances
     mapping(address => bool) public isMinter;
@@ -72,10 +72,7 @@ contract MEAT is ERC20 {
         }
     }
 
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
+
 
     modifier onlyMinter() {
         require(isMinter[msg.sender], "Not minter");
@@ -88,7 +85,7 @@ contract MEAT is ERC20 {
     }
 
     modifier onlyOwnerOrMinter() {
-        require(msg.sender == _owner || isMinter[msg.sender], "Not authorized");
+        require(msg.sender == owner() || isMinter[msg.sender], "Not authorized");
         _;
     }
 
@@ -96,13 +93,12 @@ contract MEAT is ERC20 {
     ///         and mints 1000 GOATMEAT via `mintSubtype` to the owner.
     /// @dev Initial supply is tracked through the `SubtypeMinted` event
     ///      emitted by `mintSubtype`.
-    constructor() ERC20("Market-Enabled Agricultural Token", "MEAT") {
-        _owner = msg.sender;
+    constructor() ERC20("Market-Enabled Agricultural Token", "MEAT") Ownable(msg.sender) {
 
-        isMinter[_owner] = true;
+        isMinter[owner()] = true;
 
         // Mint 1000 GOATMEAT to the owner via mintSubtype
-        mintSubtype(_owner, GOATMEAT_SUBTYPE, 1000 * 1e18);
+        mintSubtype(owner(), GOATMEAT_SUBTYPE, 1000 * 1e18);
     }
 
     /// @notice Menerima token native dan mencetak MEAT sesuai rate
@@ -128,9 +124,9 @@ contract MEAT is ERC20 {
     function withdrawNative() external onlyOwner {
         uint256 balance = address(this).balance;
         require(balance > 0, "No Native Token to withdraw");
-        (bool sent, ) = payable(_owner).call{value: balance}("");
+        (bool sent, ) = payable(owner()).call{value: balance}("");
         require(sent, "Native transfer failed");
-        emit NativeWithdrawn(_owner, balance);
+        emit NativeWithdrawn(owner(), balance);
     }
 
     function changeDepositRate(uint256 newRate) external onlyOwner {
@@ -277,8 +273,5 @@ contract MEAT is ERC20 {
         emit RateHandlerUpdated(old, rateHandlerAddress);
     }
 
-    /// @notice Mengembalikan alamat pemilik kontrak
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }

--- a/contracts/RateHandler.sol
+++ b/contracts/RateHandler.sol
@@ -5,8 +5,9 @@ pragma solidity ^0.8.29;
 /// @notice Computes PRODUCT↔PRODUCT swap parity based purely on LOD values.
 /// @dev No fallback, no deprecated mappings. LOD parity is fully transparent and governed.
 
-contract RateHandler {
-    address private _owner;
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract RateHandler is Ownable {
 
     struct CommodityRepresentation {
         address nftAddress;
@@ -28,17 +29,9 @@ contract RateHandler {
 
     mapping(bytes32 => CommodityRepresentation) public commodityRegistry;
 
-    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
     event CommodityRepresentationUpdated(bytes32 indexed commodityId);
 
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
-
-    constructor() {
-        _owner = msg.sender;
-    }
+    constructor() Ownable(msg.sender) {}
 
     /// @notice Register or update CommodityRepresentation.
     function setCommodityRepresentation(bytes32 commodityId, CommodityRepresentation calldata data) public onlyOwner {
@@ -103,17 +96,6 @@ contract RateHandler {
         return rate;
     }
 
-    /// @notice Transfer ownership.
-    function transferOwnership(address newOwner) external onlyOwner {
-        require(newOwner != address(0), "Invalid address");
-        address old = _owner;
-        _owner = newOwner;
-        emit OwnershipTransferred(old, newOwner);
-    }
-
-    /// @notice Return current owner.
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes transferOwnership() and owner()
 }
 

--- a/contracts/SapiNFT.sol
+++ b/contracts/SapiNFT.sol
@@ -3,11 +3,12 @@ pragma solidity ^0.8.29;
 
 import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {SapiNFTBurnHook} from "./SapiNFTBurnHook.sol";
 
 /// @title SapiNFT - identitas sapi dalam bentuk token
 /// @notice Menyimpan berat sapi hidup dan metadata terkait
-contract SapiNFT is ERC721Burnable {
+contract SapiNFT is ERC721Burnable, Ownable {
     uint256 public nextId;
     mapping(uint256 => uint256) public sapiValue;
 
@@ -23,20 +24,12 @@ contract SapiNFT is ERC721Burnable {
     mapping(uint256 => uint256) public lastWeightUpdateAt;
     mapping(bytes32 => uint256) public nfcIdToTokenId;
 
-    address private immutable _owner;
     SapiNFTBurnHook public burnHook;
 
     uint256 public constant WEIGHT_UPDATE_VALIDITY = 7 days;
     uint256 public constant WEIGHT_DECIMALS = 1;
 
-    constructor() ERC721("Sapi Identifier", "SAPINFT") {
-        _owner = msg.sender;
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
+    constructor() ERC721("Sapi Identifier", "SAPINFT") Ownable(msg.sender) {}
 
     function setBurnHook(address hookAddress) external onlyOwner {
         address old = address(burnHook);
@@ -101,9 +94,7 @@ contract SapiNFT is ERC721Burnable {
         return sapiMetadata[tokenId];
     }
 
-    function owner() external view returns (address) {
-        return _owner;
-    }
+
 
     event BurnHookUpdated(address indexed oldAddress, address indexed newAddress);
     event SapiBurned(uint256 indexed tokenId, address indexed user, uint256 weight);

--- a/contracts/SapiNFTBurnHook.sol
+++ b/contracts/SapiNFTBurnHook.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.29;
 
 import { ISapiNFT } from "./interfaces/ISapiNFT.sol";
 import { IMeat } from "./interfaces/IMeat.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title SapiNFTBurnHook
 /// @notice Mints BEEFMEAT tokens when a SapiNFT is burned
-contract SapiNFTBurnHook {
+contract SapiNFTBurnHook is Ownable {
     ISapiNFT public sapiNFT;
     IMeat public meatToken;
 
-    address private immutable _owner;
 
     bytes32 public constant BEEFMEAT_SUBTYPE = keccak256("BEEFMEAT");
     uint256 public constant SLAUGHTER_YIELD_BPS = 6500;
@@ -20,16 +20,10 @@ contract SapiNFTBurnHook {
     event NFTAddressUpdated(address indexed oldAddress, address indexed newAddress);
     event BeefMeatMinted(address indexed to, uint256 amount);
 
-    constructor(address nftAddress, address meatAddress) {
+    constructor(address nftAddress, address meatAddress) Ownable(msg.sender) {
         require(nftAddress != address(0) && meatAddress != address(0), "Invalid address");
-        _owner = msg.sender;
         sapiNFT = ISapiNFT(nftAddress);
         meatToken = IMeat(meatAddress);
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
     }
 
     function setNFTAddress(address nftAddress) external onlyOwner {
@@ -57,7 +51,5 @@ contract SapiNFTBurnHook {
         emit BeefMeatMinted(to, meatAmount);
     }
 
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }

--- a/contracts/SapiNFTWrapper.sol
+++ b/contracts/SapiNFTWrapper.sol
@@ -6,14 +6,14 @@ import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ISapiNFT} from "./interfaces/ISapiNFT.sol";
 import {IGoatToken} from "./interfaces/IGoatToken.sol";
 import {SwapConfig} from "./SwapConfig.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title SapiNFTWrapper
 /// @notice Mengunci SapiNFT dan mencetak GOAT sebagai jaminan (berdasarkan SAPI_WRAP_RATE)
-contract SapiNFTWrapper is ERC721Holder {
+contract SapiNFTWrapper is ERC721Holder, Ownable {
     IERC721 public immutable sapiNFT;
     ISapiNFT public immutable sapiValueFeed;
     IGoatToken public goatToken;
-    address private immutable _owner;
 
     uint256 public constant WEIGHT_DECIMALS = 1;
 
@@ -27,17 +27,11 @@ contract SapiNFTWrapper is ERC721Holder {
     event Wrapped(address indexed user, uint256 indexed tokenId, uint256 goatAmount);
     event Unwrapped(address indexed user, uint256 indexed tokenId, uint256 goatAmount);
 
-    modifier onlyOwner() {
-        require(msg.sender == _owner, "Not the owner");
-        _;
-    }
-
-    constructor(address nftAddress, address goatAddress) {
+    constructor(address nftAddress, address goatAddress) Ownable(msg.sender) {
         require(nftAddress != address(0) && goatAddress != address(0), "Invalid address");
         sapiNFT = IERC721(nftAddress);
         sapiValueFeed = ISapiNFT(nftAddress);
         goatToken = IGoatToken(goatAddress);
-        _owner = msg.sender;
     }
 
     function _getRate() internal pure returns (uint256) {
@@ -71,7 +65,5 @@ contract SapiNFTWrapper is ERC721Holder {
         emit Unwrapped(msg.sender, tokenId, info.goatAmount);
     }
 
-    function owner() external view returns (address) {
-        return _owner;
-    }
+    // Ownable already exposes owner() view
 }

--- a/test/barter.test.js
+++ b/test/barter.test.js
@@ -102,7 +102,8 @@ describe("BarterEngine", function () {
     await newHandler.waitForDeployment();
 
     await expect(barter.connect(user).setRateHandler(newHandler.target))
-      .to.be.revertedWith("Not the owner");
+      .to.be.revertedWithCustomError(barter, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
 
     await barter.setRateHandler(newHandler.target);
     expect(await barter.rateHandler()).to.equal(newHandler.target);
@@ -113,9 +114,10 @@ describe("BarterEngine", function () {
     const newMeat = await MEAT.deploy();
     await newMeat.waitForDeployment();
 
-    await expect(barter.connect(user).setMEAT(newMeat.target)).to.be.revertedWith(
-      "Not the owner"
-    );
+    await expect(barter.connect(user).setMEAT(newMeat.target)).to.be.revertedWithCustomError(
+      barter,
+      "OwnableUnauthorizedAccount"
+    ).withArgs(user.address);
 
     await barter.setMEAT(newMeat.target);
     expect(await barter.meatToken()).to.equal(newMeat.target);

--- a/test/goat-extra.test.js
+++ b/test/goat-extra.test.js
@@ -19,7 +19,9 @@ describe("GOAT extra", function () {
   it("setWrapperContract only owner", async function () {
     await expect(
       goat.connect(user).setWrapperContract(user.address)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(goat, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(goat.setWrapperContract(user.address))
       .to.emit(goat, "WrapperAddressUpdated")

--- a/test/goatMeatHook.test.js
+++ b/test/goatMeatHook.test.js
@@ -56,7 +56,9 @@ describe("GoatNFTBurnHook", function () {
 
     await expect(
       hook.connect(user).setNFTAddress(newNFT.target)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(hook, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(hook.setNFTAddress(newNFT.target))
       .to.emit(hook, "NFTAddressUpdated")
@@ -71,7 +73,9 @@ describe("GoatNFTBurnHook", function () {
 
     await expect(
       hook.connect(user).setMEATAddress(newMeat.target)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(hook, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(hook.setMEATAddress(newMeat.target))
       .to.emit(hook, "MeatAddressUpdated")

--- a/test/meat-functions.test.js
+++ b/test/meat-functions.test.js
@@ -26,9 +26,10 @@ describe("MEAT core functions", function () {
     const deposit = ethers.parseEther("1");
     await user.sendTransaction({ to: meat.target, value: deposit });
 
-    await expect(meat.connect(user).withdrawNative()).to.be.revertedWith(
-      "Not the owner"
-    );
+    await expect(meat.connect(user).withdrawNative()).to.be.revertedWithCustomError(
+      meat,
+      "OwnableUnauthorizedAccount"
+    ).withArgs(user.address);
 
     await expect(meat.withdrawNative())
       .to.emit(meat, "NativeWithdrawn")
@@ -71,9 +72,10 @@ describe("MEAT core functions", function () {
     const handler = await RateHandler.deploy();
     await handler.waitForDeployment();
 
-    await expect(meat.connect(user).setRateHandler(handler.target)).to.be.revertedWith(
-      "Not the owner"
-    );
+    await expect(meat.connect(user).setRateHandler(handler.target)).to.be.revertedWithCustomError(
+      meat,
+      "OwnableUnauthorizedAccount"
+    ).withArgs(user.address);
 
     await expect(meat.setRateHandler(handler.target))
       .to.emit(meat, "RateHandlerUpdated")

--- a/test/meatSubtype.test.js
+++ b/test/meatSubtype.test.js
@@ -81,7 +81,9 @@ describe("MEAT subtype functions", function () {
   it("setMinter onlyOwner and updates", async function () {
     await expect(
       meat.connect(user).setMinter(user.address, true)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(meat, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(meat.setMinter(user.address, true))
       .to.emit(meat, "MinterUpdated")
@@ -92,7 +94,9 @@ describe("MEAT subtype functions", function () {
   it("setBurner onlyOwner and updates", async function () {
     await expect(
       meat.connect(user).setBurner(user.address, true)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(meat, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(meat.setBurner(user.address, true))
       .to.emit(meat, "BurnerUpdated")

--- a/test/nftOwner.test.js
+++ b/test/nftOwner.test.js
@@ -16,7 +16,9 @@ describe("GoatNFT owner restrictions", function () {
       nft
         .connect(nonOwner)
         .mint(nonOwner.address, 50, "nfc", "breed", 2020)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount").withArgs(
+      nonOwner.address
+    );
   });
 
   it("owner() returns deployer", async function () {
@@ -25,9 +27,10 @@ describe("GoatNFT owner restrictions", function () {
 
   it("setBurnHook only owner", async function () {
     const addr = nonOwner.address;
-    await expect(nft.connect(nonOwner).setBurnHook(addr)).to.be.revertedWith(
-      "Not the owner"
-    );
+    await expect(nft.connect(nonOwner).setBurnHook(addr)).to.be.revertedWithCustomError(
+      nft,
+      "OwnableUnauthorizedAccount"
+    ).withArgs(nonOwner.address);
     await expect(nft.setBurnHook(addr))
       .to.emit(nft, "BurnHookUpdated")
       .withArgs(ethers.ZeroAddress, addr);

--- a/test/sapiMeatHook.test.js
+++ b/test/sapiMeatHook.test.js
@@ -54,7 +54,9 @@ describe("SapiNFTBurnHook", function () {
 
     await expect(
       hook.connect(user).setNFTAddress(newNFT.target)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(hook, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(hook.setNFTAddress(newNFT.target))
       .to.emit(hook, "NFTAddressUpdated")
@@ -69,7 +71,9 @@ describe("SapiNFTBurnHook", function () {
 
     await expect(
       hook.connect(user).setMEATAddress(newMeat.target)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(hook, "OwnableUnauthorizedAccount").withArgs(
+      user.address
+    );
 
     await expect(hook.setMEATAddress(newMeat.target))
       .to.emit(hook, "MeatAddressUpdated")

--- a/test/sapiNftOwner.test.js
+++ b/test/sapiNftOwner.test.js
@@ -14,7 +14,9 @@ describe("SapiNFT owner restrictions", function () {
   it("reverts when a non-owner calls mint", async function () {
     await expect(
       nft.connect(nonOwner).mint(nonOwner.address, 50, "nfc", "breed", 2020)
-    ).to.be.revertedWith("Not the owner");
+    ).to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount").withArgs(
+      nonOwner.address
+    );
   });
 
   it("owner() returns deployer", async function () {
@@ -23,9 +25,10 @@ describe("SapiNFT owner restrictions", function () {
 
   it("setBurnHook only owner", async function () {
     const addr = nonOwner.address;
-    await expect(nft.connect(nonOwner).setBurnHook(addr)).to.be.revertedWith(
-      "Not the owner"
-    );
+    await expect(nft.connect(nonOwner).setBurnHook(addr)).to.be.revertedWithCustomError(
+      nft,
+      "OwnableUnauthorizedAccount"
+    ).withArgs(nonOwner.address);
     await expect(nft.setBurnHook(addr))
       .to.emit(nft, "BurnHookUpdated")
       .withArgs(ethers.ZeroAddress, addr);


### PR DESCRIPTION
## Summary
- adopt OpenZeppelin Ownable across contracts
- update tests for new Ownable custom errors

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c2bb250f88325ba6bc55146567e31