### PR TITLE
Optimize MEAT transfer tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Semua subtype direpresentasikan sebagai `bytes32`. MEAT selalu menerima paramete
 Kontrak MEAT kini menyimpan metadata `lineageID` untuk setiap kombinasi pengguna dan subtype. Pemilik kontrak dapat menetapkan nilai ini melalui `setSubtypeLineage(user, subtype, lineageID)`. Untuk membaca saldo sekaligus asal-usul token, gunakan `balanceOfSubtypeWithLineage(user, subtype)` yang mengembalikan `(balance, lineageID)`. Fungsi ini dipakai `BarterEngine` maupun `RedeemEngine` guna memverifikasi token sebelum dipertukarkan atau ditebus.
 Lineage ID otomatis diatur saat hook memanggil `mintSubtype()` sehingga mint manual tanpa lineage tidak diperbolehkan.
 
+Pengiriman MEAT kini menggunakan mekanisme round-robin antar subtype. Kontrak
+menyimpan indeks terakhir yang digunakan sehingga transfer berikutnya tidak
+perlu memindai seluruh daftar subtype milik pengirim. Pendekatan ini menjaga
+lineage sambil menghemat gas ketika pengguna memiliki banyak subtype.
+
 ### Token Lifecycle Flow
 
 ```mermaid

--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -29,6 +29,10 @@ contract MEAT is ERC20, Ownable {
 
     // List of owned subtypes per user for iteration
     mapping(address => bytes32[]) private _userSubtypes;
+    // Index of subtype in the list (+1) for quick lookup/removal
+    mapping(address => mapping(bytes32 => uint256)) private _userSubtypeIndex;
+    // Cursor to start iteration on transfers to avoid scanning from index 0
+    mapping(address => uint256) private _transferCursor;
 
     // Total supply per subtype
     mapping(bytes32 => uint256) public subtypeTotalSupply;
@@ -52,23 +56,35 @@ contract MEAT is ERC20, Ownable {
 
     // ----- internal helpers for subtype tracking -----
     function _addUserSubtype(address user, bytes32 subtype) internal {
-        bytes32[] storage list = _userSubtypes[user];
-        for (uint256 i = 0; i < list.length; i++) {
-            if (list[i] == subtype) {
-                return;
-            }
+        mapping(bytes32 => uint256) storage idxMap = _userSubtypeIndex[user];
+        if (idxMap[subtype] != 0) {
+            return;
         }
-        list.push(subtype);
+        _userSubtypes[user].push(subtype);
+        idxMap[subtype] = _userSubtypes[user].length; // store index + 1
     }
 
     function _removeUserSubtype(address user, bytes32 subtype) internal {
+        mapping(bytes32 => uint256) storage idxMap = _userSubtypeIndex[user];
+        uint256 idxPlus = idxMap[subtype];
+        if (idxPlus == 0) {
+            return;
+        }
+        uint256 idx = idxPlus - 1;
         bytes32[] storage list = _userSubtypes[user];
-        for (uint256 i = 0; i < list.length; i++) {
-            if (list[i] == subtype) {
-                list[i] = list[list.length - 1];
-                list.pop();
-                break;
-            }
+        uint256 lastIndex = list.length - 1;
+        if (idx != lastIndex) {
+            bytes32 lastSubtype = list[lastIndex];
+            list[idx] = lastSubtype;
+            idxMap[lastSubtype] = idx + 1;
+        }
+        list.pop();
+        delete idxMap[subtype];
+
+        if (_transferCursor[user] > lastIndex) {
+            _transferCursor[user] = 0;
+        } else if (_transferCursor[user] > idx) {
+            _transferCursor[user] -= 1;
         }
     }
 
@@ -228,14 +244,24 @@ contract MEAT is ERC20, Ownable {
 
         uint256 remaining = amount;
         bytes32[] storage list = _userSubtypes[from];
-        uint256 i = 0;
-        while (i < list.length && remaining > 0) {
-            bytes32 st = list[i];
+        uint256 idx = _transferCursor[from];
+        if (idx >= list.length) {
+            idx = 0;
+        }
+
+        while (remaining > 0 && list.length > 0) {
+            if (idx >= list.length) {
+                idx = 0;
+            }
+            bytes32 st = list[idx];
             SubtypeBalance storage sFrom = subtypeBalances[from][st];
             uint256 available = sFrom.balance;
             if (available == 0) {
-                list[i] = list[list.length - 1];
-                list.pop();
+                _removeUserSubtype(from, st);
+                list = _userSubtypes[from];
+                if (idx >= list.length) {
+                    idx = 0;
+                }
                 continue;
             }
 
@@ -243,10 +269,12 @@ contract MEAT is ERC20, Ownable {
             sFrom.balance = available - tAmt;
             if (sFrom.balance == 0) {
                 _removeUserSubtype(from, st);
-                // list may change, reload
                 list = _userSubtypes[from];
+                if (idx >= list.length) {
+                    idx = 0;
+                }
             } else {
-                i++;
+                idx++;
             }
 
             SubtypeBalance storage sTo = subtypeBalances[to][st];
@@ -263,6 +291,8 @@ contract MEAT is ERC20, Ownable {
             sTo.balance += tAmt;
             remaining -= tAmt;
         }
+
+        _transferCursor[from] = idx;
     }
 
     /// @notice Mengatur alamat kontrak rate handler untuk perhitungan swap (dipakai di BarterEngine, bukan di MEAT)

--- a/test/meatSubtype.test.js
+++ b/test/meatSubtype.test.js
@@ -133,4 +133,33 @@ describe("MEAT subtype functions", function () {
     expect(result[0]).to.equal(amount);
     expect(result[1]).to.equal(7n);
   });
+
+  it("transfers multiple subtypes correctly", async function () {
+    const goat = ethers.encodeBytes32String("GOATMEAT");
+    const beef = ethers.encodeBytes32String("BEEFMEAT");
+    const amtGoat = ethers.parseEther("10");
+    const amtBeef = ethers.parseEther("20");
+
+    await meat.connect(minter).mintSubtype(user.address, goat, amtGoat);
+    await meat.connect(minter).mintSubtype(user.address, beef, amtBeef);
+    await meat.setSubtypeLineage(user.address, goat, 1);
+    await meat.setSubtypeLineage(user.address, beef, 2);
+
+    const transferAmt = ethers.parseEther("15");
+    await meat.connect(user).transfer(other.address, transferAmt);
+
+    expect(await meat.getBalanceOfSubtype(user.address, goat)).to.equal(0n);
+    expect(await meat.getBalanceOfSubtype(user.address, beef)).to.equal(
+      amtBeef - (transferAmt - amtGoat)
+    );
+    expect(await meat.getBalanceOfSubtype(other.address, goat)).to.equal(amtGoat);
+    expect(await meat.getBalanceOfSubtype(other.address, beef)).to.equal(
+      transferAmt - amtGoat
+    );
+
+    const resGoat = await meat.balanceOfSubtypeWithLineage(other.address, goat);
+    const resBeef = await meat.balanceOfSubtypeWithLineage(other.address, beef);
+    expect(resGoat[1]).to.equal(1n);
+    expect(resBeef[1]).to.equal(2n);
+  });
 });


### PR DESCRIPTION
## Summary
- store subtype index and cursor to avoid scanning on token transfers
- implement round-robin transfer logic
- document new optimized transfer mechanism
- add test covering multi-subtype transfer

## Testing
- `npm install`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c316f1508832591207d6eb5145529