### PR TITLE
codex/reentrancy-guard-withdraw

### DIFF
--- a/contracts/MEAT.sol
+++ b/contracts/MEAT.sol
@@ -4,13 +4,14 @@ pragma solidity ^0.8.29;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { RateHandler } from "./RateHandler.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title Token MEAT - Market-Enabled Agricultural Token
 /// @notice Kontrak pintar untuk mint MEAT menggunakan native token dan PRODUCT subtype token.
 /// @dev Reasoning Path FINAL Compliant → NO awareness of GOAT token. NO swap GOAT ↔ MEAT allowed.
 
 /// @dev Subtype parameters expect bytes32 values from ethers.encodeBytes32String
-contract MEAT is ERC20, Ownable {
+contract MEAT is ERC20, Ownable, ReentrancyGuard {
 
     // Authorized addresses allowed to mint or burn subtype balances
     mapping(address => bool) public isMinter;
@@ -137,7 +138,7 @@ contract MEAT is ERC20, Ownable {
         emit MintedWithNative(msg.sender, msg.value, meatAmount);
     }
 
-    function withdrawNative() external onlyOwner {
+    function withdrawNative() external onlyOwner nonReentrant {
         uint256 balance = address(this).balance;
         require(balance > 0, "No Native Token to withdraw");
         (bool sent, ) = payable(owner()).call{value: balance}("");

--- a/contracts/mocks/ReentrantWithdrawer.sol
+++ b/contracts/mocks/ReentrantWithdrawer.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import { MEAT } from "../MEAT.sol";
+
+/// @title Contract that attempts to reenter MEAT.withdrawNative
+contract ReentrantWithdrawer {
+    MEAT public meat;
+    bool public attackInProgress;
+
+    constructor(address meatAddr) {
+        meat = MEAT(payable(meatAddr));
+    }
+
+    receive() external payable {
+        if (attackInProgress) {
+            attackInProgress = false;
+            // attempt reentrant call
+            meat.withdrawNative();
+        }
+    }
+
+    function attackWithdraw() external {
+        attackInProgress = true;
+        meat.withdrawNative();
+    }
+}

--- a/test/meat-functions.test.js
+++ b/test/meat-functions.test.js
@@ -38,6 +38,23 @@ describe("MEAT core functions", function () {
     expect(await ethers.provider.getBalance(meat.target)).to.equal(0n);
   });
 
+  it("prevents reentrancy during withdrawNative", async function () {
+    const deposit = ethers.parseEther("1");
+    await user.sendTransaction({ to: meat.target, value: deposit });
+
+    const Reentrant = await ethers.getContractFactory("ReentrantWithdrawer");
+    const attacker = await Reentrant.deploy(meat.target);
+    await attacker.waitForDeployment();
+
+    await meat.transferOwnership(attacker.target);
+
+    await expect(attacker.attackWithdraw()).to.be.revertedWith(
+      "Native transfer failed"
+    );
+
+    expect(await ethers.provider.getBalance(meat.target)).to.equal(deposit);
+  });
+
   it("changeDepositRate updates rate and affects minting", async function () {
     expect(await meat.DepositRate()).to.equal(100n);
 


### PR DESCRIPTION
## Summary
- secure `withdrawNative` with `ReentrancyGuard`
- add `ReentrantWithdrawer` mock contract
- test reentrant withdraw attempts

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c32beffb8832589308c786b354a38