### PR TITLE
Update docs for hook addresses and lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ flowchart LR
 Semua subtype direpresentasikan sebagai `bytes32`. MEAT selalu menerima parameter subtype dalam bentuk ini, jadi gunakan `ethers.encodeBytes32String("GOATMEAT")` atau konversi ID numerik ke string dahulu.
 `bytes32 subtypeFromId = ethers.encodeBytes32String(String(123));`
 
-Kontrak MEAT kini menyimpan metadata `lineageID` untuk setiap kombinasi pengguna dan subtype. Pemilik kontrak dapat menetapkan nilai ini melalui `setSubtypeLineage(user, subtype, lineageID)`. Untuk membaca saldo sekaligus asal-usul token, gunakan `balanceOfSubtypeWithLineage(user, subtype)` yang mengembalikan `(balance, lineageID)`. Fungsi ini dipakai `BarterEngine` maupun `RedeemEngine` guna memverifikasi token sebelum dipertukarkan atau ditebus.
+Kontrak MEAT kini menyimpan metadata `lineageID` untuk setiap kombinasi pengguna dan subtype. Pemilik kontrak atau minter yang diizinkan dapat menetapkan nilai ini melalui `setSubtypeLineage(user, subtype, lineageID)`. Untuk membaca saldo sekaligus asal-usul token, gunakan `balanceOfSubtypeWithLineage(user, subtype)` yang mengembalikan `(balance, lineageID)`. Fungsi ini dipakai `BarterEngine` maupun `RedeemEngine` guna memverifikasi token sebelum dipertukarkan atau ditebus.
 Lineage ID otomatis diatur saat hook memanggil `mintSubtype()` sehingga mint manual tanpa lineage tidak diperbolehkan.
 
 Pengiriman MEAT kini menggunakan mekanisme round-robin antar subtype. Kontrak

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -5,7 +5,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 - Setiap **GoatNFT** mencatat *ras*, *NFC tag*, *tahun lahir*, dan *berat* terkini.
 - Pemilik bebas memindahkan NFT dan memperbarui berat seiring pertumbuhan hewan.
 - Sebelum kambing disembelih, token dapat **dibakar** dengan berat terbaru yang mencetak `GOATMEAT` sebesar 60% dari berat hidup melalui `GoatNFTBurnHook`.
-- Pemilik hook dapat memperbarui alamat `GoatNFT` maupun `MEAT` melalui `setNFTAddress` dan `setMEATAddress` bila diperlukan.
+- Alamat `GoatNFT` dan `MEAT` ditetapkan di konstruktor. Fungsi `setNFTAddress` maupun `setMEATAddress` hanya dipakai pemilik bila perlu mengganti kontrak.
 - GOAT diperoleh dengan mengunci NFT pada `GoatNFTWrapper` dan digunakan untuk staking.
 - MEAT pada akhirnya dibakar melalui `RedeemEngine.redeem` untuk menebus daging fisik.
 


### PR DESCRIPTION
## Summary
- clarify that lineage updates can be done by owner or authorized minters
- note that burn hook addresses are set in constructor and changed only if needed

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c33f1c7a08325a53c3d8c56cd5502