### PR TITLE
Update README and docs for CosmWasm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ npx hardhat compile
 ## Perbandingan Perilaku CosmWasm
 
 Folder `wasm-contracts/` menyimpan versi CosmWasm dari setiap kontrak.
-Kontrak Solidity yang **sudah** terporting meliputi `GOAT` (paket `starter`),
-`MEAT`, `GoatNFT`, `RateHandler`, dan `BarterEngine`. Paket `goatnftwrapper`
-serta `goatnftburnhook` kini berdiri sendiri dan telah disertakan di
-`wasm-contracts/`. Implementasi varian `SapiNFT` masih *pending*. Seluruh pesan
+Kontrak Solidity yang **sudah** terporting meliputi paket `starter`, `meat`,
+`goatnft`, `ratehandler`, `goatnftwrapper`, dan `goatnftburnhook`.
+Implementasi `BarterEngine` serta varian `SapiNFT` masih *pending*.
+Seluruh pesan
 CosmWasm tetap mengikuti fungsi di Solidity namun ada beberapa perbedaan tak
 terelakkan:
 

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -22,7 +22,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 4. **Mengambil Reward**
    * Setelah `minClaimInterval`, staker bisa mengambil reward atau menggabungkannya kembali ke stake. Untuk keluar sepenuhnya panggil `unstake` agar pokok dan reward diterima.
 5. **Barter Produk**
-   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine`.
+   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine` (port CosmWasm belum tersedia).
    * Sebelum barter, pengguna harus memberikan *approval* kepada `BarterEngine` untuk jumlah subtype yang akan dibakar.
    * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
    * MEAT selalu mengharapkan parameter subtype berupa `bytes32`; ubah ID numerik ke string sebelum di-encode. contoh: `bytes32 subtypeFromId = ethers.encodeBytes32String("99");`

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -56,7 +56,7 @@ wasmd tx wasm instantiate <code_id> '{"meat_contract":"cosmos1..."}' \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
-Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan akan dikonfigurasi di `BarterEngine` untuk menentukan rasio barter. Setelah itu deploy `goatnftwrapper` dan `goatnftburnhook` dengan parameter alamat kontrak terkait:
+Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan nantinya akan digunakan oleh `BarterEngine` untuk menentukan rasio barter setelah port CosmWasm-nya tersedia. Setelah itu deploy `goatnftwrapper` dan `goatnftburnhook` dengan parameter alamat kontrak terkait:
 ```bash
 # contoh instansiasi goatnftwrapper
 wasmd tx wasm instantiate <code_id_wrapper> '{"nft_contract":"<nft_addr>","goat_contract":"<goat_addr>"}' \

--- a/docs/whitepaper.html
+++ b/docs/whitepaper.html
@@ -50,7 +50,7 @@
     <ol>
         <li>Dibungkus menjadi GOAT untuk staking.</li>
         <li>Dibakar melalui hook yang mencetak subtype <em>MEAT</em> sesuai berat ternak.</li>
-        <li>Token MEAT dapat dibarter ke produk lain dengan <code>BarterEngine</code> atau ditebus melalui <code>RedeemEngine</code>.</li>
+        <li>Token MEAT dapat dibarter ke produk lain dengan <code>BarterEngine</code> atau ditebus melalui <code>RedeemEngine</code>. Port CosmWasm untuk <code>BarterEngine</code> masih dalam pengerjaan.</li>
     </ol>
 
     <h2>Governance dan LOD Engine</h2>

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -38,7 +38,7 @@ Berdasarkan [goat-meat-lifecycle.md](goat-meat-lifecycle.md), setiap `GoatNFT` d
 
 1. Dibungkus menjadi GOAT untuk staking.
 2. Dibakar melalui hook yang mencetak subtype *MEAT* sesuai berat ternak.
-3. Token MEAT dapat dibarter ke produk lain dengan `BarterEngine` atau ditebus melalui `RedeemEngine`.
+3. Token MEAT dapat dibarter ke produk lain dengan `BarterEngine` atau ditebus melalui `RedeemEngine`. Port CosmWasm untuk `BarterEngine` masih dalam pengerjaan.
 
 ## Governance dan LOD Engine
 White paper ini mengikuti panduan [governance-lod-engine.md](governance-lod-engine.md). LOD Engine menetapkan paritas komoditas melalui fungsi `setCommodityRepresentation`. Setiap pembaruan diwajibkan melewati pipeline governansi dan diuji dengan Hardhat.


### PR DESCRIPTION
## Summary
- clarify which CosmWasm packages exist
- mention that BarterEngine and SapiNFT ports are pending
- update wasm deployment guide about BarterEngine
- note pending BarterEngine port in lifecycle and whitepaper docs

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c35fef5c48325b1be3c1c9e11b67b