### PR TITLE
Add CosmWasm Sapi modules and barter engine

### DIFF
--- a/wasm-contracts/barterengine/Cargo.toml
+++ b/wasm-contracts/barterengine/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "barterengine"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+cw2 = "1.1"
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8"
+serde-json-wasm = "0.5"
+cw-storage-plus = "1.1"
+
+ratehandler = { path = "../ratehandler" }
+meat = { path = "../meat" }
+
+[dev-dependencies]
+cw-multi-test = "0.16"

--- a/wasm-contracts/barterengine/src/lib.rs
+++ b/wasm-contracts/barterengine/src/lib.rs
@@ -1,0 +1,100 @@
+use cosmwasm_std::{entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
+use cw2::set_contract_version;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RateResponse};
+use crate::state::{MEAT, OWNER, RATE_HANDLER};
+use ratehandler::{QueryMsg as RateQueryMsg, RateResponse as RateHandlerResponse};
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "barterengine";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    RATE_HANDLER.save(deps.storage, &deps.api.addr_validate(&msg.rate_handler)?)?;
+    MEAT.save(deps.storage, &deps.api.addr_validate(&msg.meat_contract)?)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let owner = OWNER.load(deps.storage)?;
+    if info.sender != owner {
+        return Err(StdError::generic_err("Not the owner"));
+    }
+    Ok(())
+}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::SetRateHandler { rate_handler } => execute_set_rate_handler(deps, info, rate_handler),
+        ExecuteMsg::SetMeat { meat } => execute_set_meat(deps, info, meat),
+        ExecuteMsg::BarterProductToProduct { from_subtype, to_subtype, from_amount } => {
+            execute_barter(deps, env, info, from_subtype, to_subtype, from_amount)
+        }
+        ExecuteMsg::EmergencyWithdraw { subtype: _ } => only_owner(deps, &info).map(|_| Response::new()),
+    }
+}
+
+fn execute_set_rate_handler(mut deps: DepsMut, info: MessageInfo, rate_handler: String) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&rate_handler)?;
+    RATE_HANDLER.save(deps.storage, &addr)?;
+    Ok(Response::new())
+}
+
+fn execute_set_meat(mut deps: DepsMut, info: MessageInfo, meat: String) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&meat)?;
+    MEAT.save(deps.storage, &addr)?;
+    Ok(Response::new())
+}
+
+fn execute_barter(deps: DepsMut, _env: Env, _info: MessageInfo, from_sub: String, to_sub: String, from_amount: u128) -> StdResult<Response> {
+    if from_sub == to_sub {
+        return Err(StdError::generic_err("Cannot swap same subtype"));
+    }
+    if from_amount == 0 {
+        return Err(StdError::generic_err("Amount must be > 0"));
+    }
+    let rate_handler = RATE_HANDLER.load(deps.storage)?;
+    let rate_resp: RateHandlerResponse = deps
+        .querier
+        .query_wasm_smart(rate_handler, &RateQueryMsg::GetRate {})?;
+    if rate_resp.rate.is_zero() {
+        return Err(StdError::generic_err("Invalid barter rate"));
+    }
+    let to_amount = Uint128::new(from_amount) * rate_resp.rate / Uint128::new(1_000_000_000_000_000_000u128);
+    Ok(Response::new()
+        .add_attribute("action", "barter")
+        .add_attribute("from", from_sub)
+        .add_attribute("to", to_sub)
+        .add_attribute("from_amount", from_amount.to_string())
+        .add_attribute("to_amount", to_amount))
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::GetRate { from_subtype: _, to_subtype: _ } => {
+            let addr = RATE_HANDLER.load(deps.storage)?;
+            let resp: RateHandlerResponse = deps
+                .querier
+                .query_wasm_smart(addr, &RateQueryMsg::GetRate {})?;
+            Ok(to_binary(&RateResponse { rate: resp.rate.u128() })?)
+        }
+        QueryMsg::Owner {} => {
+            let owner = OWNER.load(deps.storage)?;
+            Ok(to_binary(&owner.into_string())?)
+        }
+    }
+}

--- a/wasm-contracts/barterengine/src/msg.rs
+++ b/wasm-contracts/barterengine/src/msg.rs
@@ -1,0 +1,33 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub rate_handler: String,
+    pub meat_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    SetRateHandler { rate_handler: String },
+    SetMeat { meat: String },
+    BarterProductToProduct {
+        from_subtype: String,
+        to_subtype: String,
+        from_amount: u128,
+    },
+    EmergencyWithdraw { subtype: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    GetRate { from_subtype: String, to_subtype: String },
+    Owner {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RateResponse {
+    pub rate: u128,
+}

--- a/wasm-contracts/barterengine/src/state.rs
+++ b/wasm-contracts/barterengine/src/state.rs
@@ -1,0 +1,6 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const RATE_HANDLER: Item<Addr> = Item::new("rate_handler");
+pub const MEAT: Item<Addr> = Item::new("meat");

--- a/wasm-contracts/barterengine/tests/basic.rs
+++ b/wasm-contracts/barterengine/tests/basic.rs
@@ -1,0 +1,52 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use barterengine::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RateResponse};
+use barterengine::{execute, instantiate, query};
+use ratehandler::{execute as rate_execute, instantiate as rate_inst, query as rate_query, InstantiateMsg as RHInstantiate, ExecuteMsg as RHExecute};
+
+fn contract_engine() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+fn contract_rate() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(rate_execute, rate_inst, rate_query))
+}
+
+#[test]
+fn query_rate_forward() {
+    let mut app = App::default();
+    let rate_id = app.store_code(contract_rate());
+    let eng_id = app.store_code(contract_engine());
+
+    let rate_addr = app
+        .instantiate_contract(rate_id, Addr::unchecked("owner"), &RHInstantiate {}, &[], "rate", None)
+        .unwrap();
+    let eng_addr = app
+        .instantiate_contract(
+            eng_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg { rate_handler: rate_addr.to_string(), meat_contract: "meat".into() },
+            &[],
+            "engine",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        rate_addr.clone(),
+        &RHExecute::UpdateRate { new_rate: Uint128::new(200) },
+        &[],
+    )
+    .unwrap();
+
+    let rate: RateResponse = app
+        .wrap()
+        .query_wasm_smart(
+            eng_addr,
+            &QueryMsg::GetRate { from_subtype: "a".into(), to_subtype: "b".into() },
+        )
+        .unwrap();
+    assert_eq!(rate.rate, 200u128);
+}

--- a/wasm-contracts/build.sh
+++ b/wasm-contracts/build.sh
@@ -9,7 +9,7 @@ if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
   rustup target add wasm32-unknown-unknown
 fi
 
-for pkg in starter meat goatnft ratehandler goatnftwrapper goatnftburnhook; do
+for pkg in starter meat goatnft ratehandler goatnftwrapper goatnftburnhook sapinft sapinftwrapper sapinftburnhook barterengine; do
   cd "$DIR/$pkg"
   cargo build --release --target wasm32-unknown-unknown
   mkdir -p "$DIR/../artifacts"

--- a/wasm-contracts/sapinft/Cargo.toml
+++ b/wasm-contracts/sapinft/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sapinft"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+schemars = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+cw-storage-plus = "1.1"
+cw2 = "1.1"
+base64 = "0.21"
+serde-json-wasm = "0.5"
+cw721 = "0.18"
+
+[dev-dependencies]
+cw-multi-test = "0.16"
+starter = { path = "../starter" }

--- a/wasm-contracts/sapinft/src/lib.rs
+++ b/wasm-contracts/sapinft/src/lib.rs
@@ -1,0 +1,276 @@
+use base64::{engine::general_purpose, Engine as _};
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult, Uint128,
+};
+use cw2::set_contract_version;
+use serde_json_wasm;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, SapiDataResponse, SapiValueResponse};
+use crate::state::*;
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "sapinft";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    NEXT_ID.save(deps.storage, &0u64)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let owner = OWNER.load(deps.storage)?;
+    if info.sender != owner {
+        return Err(StdError::generic_err("Not the owner"));
+    }
+    Ok(())
+}
+
+fn handle_execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::Mint {
+            to,
+            nfc_id,
+            breed,
+            birth_year,
+            weight,
+        } => execute_mint(deps, env, info, to, weight, nfc_id, breed, birth_year),
+        ExecuteMsg::Burn { token_id } => execute_burn(deps, env, info, token_id),
+        ExecuteMsg::Approve { spender, token_id } => execute_approve(deps, info, spender, token_id),
+        ExecuteMsg::Transfer { to, token_id } => execute_transfer(deps, info, to, token_id),
+        ExecuteMsg::TransferFrom {
+            owner,
+            to,
+            token_id,
+        } => execute_transfer_from(deps, info, owner, to, token_id),
+        ExecuteMsg::UpdateWeight {
+            token_id,
+            new_weight,
+        } => execute_update_weight(deps, env, info, token_id, new_weight),
+    }
+}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    handle_execute(deps, env, info, msg)
+}
+
+fn execute_mint(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    to: String,
+    weight: u64,
+    nfc_id: String,
+    breed: String,
+    birth_year: u64,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    if weight == 0 {
+        return Err(StdError::generic_err("Weight must be > 0"));
+    }
+    if NFC_TO_TOKEN
+        .may_load(deps.storage, nfc_id.as_bytes())?
+        .is_some()
+    {
+        return Err(StdError::generic_err("NFC ID already used"));
+    }
+    let to_addr = deps.api.addr_validate(&to)?;
+    let id = NEXT_ID.load(deps.storage)? + 1;
+    NEXT_ID.save(deps.storage, &id)?;
+    OWNER_OF.save(deps.storage, id, &to_addr)?;
+    SAPI_VALUE.save(deps.storage, id, &Uint128::from(weight as u128))?;
+    let data = SapiData {
+        nfc_id: nfc_id.clone(),
+        breed,
+        birth_year,
+        weight,
+        minted_at: env.block.time.seconds(),
+    };
+    SAPI_METADATA.save(deps.storage, id, &data)?;
+    LAST_WEIGHT_UPDATE.save(deps.storage, id, &env.block.time.seconds())?;
+    NFC_TO_TOKEN.save(deps.storage, nfc_id.as_bytes(), &id)?;
+    Ok(Response::new().add_attribute("token_id", id.to_string()))
+}
+
+fn execute_burn(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: String,
+) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        let approved = APPROVALS.may_load(deps.storage, id)?;
+        match approved {
+            Some(addr) if addr == info.sender => {}
+            _ => return Err(StdError::generic_err("Unauthorized")),
+        }
+    }
+    let last_update = LAST_WEIGHT_UPDATE.load(deps.storage, id)?;
+    if env.block.time.seconds() - last_update > WEIGHT_UPDATE_VALIDITY {
+        return Err(StdError::generic_err("Weight update too old"));
+    }
+    let data = SAPI_METADATA.load(deps.storage, id)?;
+    OWNER_OF.remove(deps.storage, id);
+    SAPI_VALUE.remove(deps.storage, id);
+    SAPI_METADATA.remove(deps.storage, id);
+    APPROVALS.remove(deps.storage, id);
+    LAST_WEIGHT_UPDATE.remove(deps.storage, id);
+    NFC_TO_TOKEN.remove(deps.storage, data.nfc_id.as_bytes());
+    Ok(Response::new())
+}
+
+fn execute_approve(
+    deps: DepsMut,
+    info: MessageInfo,
+    spender: String,
+    token_id: String,
+) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        return Err(StdError::generic_err("Unauthorized"));
+    }
+    let spender_addr = deps.api.addr_validate(&spender)?;
+    APPROVALS.save(deps.storage, id, &spender_addr)?;
+    Ok(Response::new())
+}
+
+fn execute_transfer(
+    deps: DepsMut,
+    info: MessageInfo,
+    to: String,
+    token_id: String,
+) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        let approved = APPROVALS.may_load(deps.storage, id)?;
+        match approved {
+            Some(addr) if addr == info.sender => {}
+            _ => return Err(StdError::generic_err("Unauthorized")),
+        }
+    }
+    let to_addr = deps.api.addr_validate(&to)?;
+    OWNER_OF.save(deps.storage, id, &to_addr)?;
+    APPROVALS.remove(deps.storage, id);
+    Ok(Response::new())
+}
+
+fn execute_transfer_from(
+    deps: DepsMut,
+    info: MessageInfo,
+    owner: String,
+    to: String,
+    token_id: String,
+) -> StdResult<Response> {
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner_addr = deps.api.addr_validate(&owner)?;
+    let current_owner = OWNER_OF.load(deps.storage, id)?;
+    if current_owner != owner_addr {
+        return Err(StdError::generic_err("Owner mismatch"));
+    }
+    if owner_addr != info.sender {
+        let approved = APPROVALS.may_load(deps.storage, id)?;
+        match approved {
+            Some(addr) if addr == info.sender => {}
+            _ => return Err(StdError::generic_err("Unauthorized")),
+        }
+    }
+    let to_addr = deps.api.addr_validate(&to)?;
+    OWNER_OF.save(deps.storage, id, &to_addr)?;
+    APPROVALS.remove(deps.storage, id);
+    Ok(Response::new())
+}
+
+fn execute_update_weight(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: String,
+    new_weight: u64,
+) -> StdResult<Response> {
+    if new_weight == 0 {
+        return Err(StdError::generic_err("Weight must be > 0"));
+    }
+    let id: u64 = token_id
+        .parse()
+        .map_err(|_| StdError::generic_err("invalid id"))?;
+    let owner = OWNER_OF.load(deps.storage, id)?;
+    if owner != info.sender {
+        return Err(StdError::generic_err("Not token owner"));
+    }
+    SAPI_VALUE.save(deps.storage, id, &Uint128::from(new_weight as u128))?;
+    let mut data = SAPI_METADATA.load(deps.storage, id)?;
+    data.weight = new_weight;
+    SAPI_METADATA.save(deps.storage, id, &data)?;
+    LAST_WEIGHT_UPDATE.save(deps.storage, id, &env.block.time.seconds())?;
+    Ok(Response::new())
+}
+
+fn handle_query(deps: Deps, q: QueryMsg) -> StdResult<Binary> {
+    match q {
+        QueryMsg::SapiValue { token_id } => {
+            let value = SAPI_VALUE.load(deps.storage, token_id)?;
+            to_json_binary(&SapiValueResponse { value })
+        }
+        QueryMsg::SapiData { token_id } => {
+            let data = SAPI_METADATA.load(deps.storage, token_id)?;
+            to_json_binary(&SapiDataResponse {
+                nfc_id: data.nfc_id,
+                breed: data.breed,
+                birth_year: data.birth_year,
+                weight: data.weight,
+                minted_at: data.minted_at,
+            })
+        }
+        QueryMsg::Owner { token_id } => {
+            let owner = OWNER_OF.load(deps.storage, token_id)?;
+            to_json_binary(&owner.into_string())
+        }
+        QueryMsg::OwnerAddress {} => {
+            let owner = OWNER.load(deps.storage)?;
+            to_json_binary(&owner.into_string())
+        }
+    }
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: Binary) -> StdResult<Binary> {
+    if let Ok(q) = serde_json_wasm::from_slice::<QueryMsg>(&msg) {
+        return handle_query(deps, q);
+    }
+    if let Ok(s) = std::str::from_utf8(&msg) {
+        if let Ok(decoded) = general_purpose::STANDARD.decode(s) {
+            if let Ok(q) = serde_json_wasm::from_slice::<QueryMsg>(&decoded) {
+                return handle_query(deps, q);
+            }
+        }
+    }
+    Err(StdError::generic_err("invalid query"))
+}

--- a/wasm-contracts/sapinft/src/msg.rs
+++ b/wasm-contracts/sapinft/src/msg.rs
@@ -1,0 +1,61 @@
+use cosmwasm_std::Uint128;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Mint {
+        to: String,
+        nfc_id: String,
+        breed: String,
+        birth_year: u64,
+        weight: u64,
+    },
+    Burn {
+        token_id: String,
+    },
+    Approve {
+        spender: String,
+        token_id: String,
+    },
+    Transfer {
+        to: String,
+        token_id: String,
+    },
+    TransferFrom {
+        owner: String,
+        to: String,
+        token_id: String,
+    },
+    UpdateWeight {
+        token_id: String,
+        new_weight: u64,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    SapiValue { token_id: u64 },
+    SapiData { token_id: u64 },
+    Owner { token_id: u64 },
+    OwnerAddress {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct SapiValueResponse {
+    pub value: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct SapiDataResponse {
+    pub nfc_id: String,
+    pub breed: String,
+    pub birth_year: u64,
+    pub weight: u64,
+    pub minted_at: u64,
+}

--- a/wasm-contracts/sapinft/src/state.rs
+++ b/wasm-contracts/sapinft/src/state.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
+pub struct SapiData {
+    pub nfc_id: String,
+    pub breed: String,
+    pub birth_year: u64,
+    pub weight: u64,
+    pub minted_at: u64,
+}
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const NEXT_ID: Item<u64> = Item::new("next_id");
+pub const OWNER_OF: Map<u64, Addr> = Map::new("owner_of");
+pub const SAPI_VALUE: Map<u64, Uint128> = Map::new("sapi_value");
+pub const SAPI_METADATA: Map<u64, SapiData> = Map::new("sapi_metadata");
+pub const APPROVALS: Map<u64, Addr> = Map::new("approvals");
+
+/// Timestamp of the last weight update for each token
+pub const LAST_WEIGHT_UPDATE: Map<u64, u64> = Map::new("last_weight_update");
+
+/// Mapping from NFC id bytes to token id to ensure uniqueness
+pub const NFC_TO_TOKEN: Map<&[u8], u64> = Map::new("nfc_to_token");
+
+/// Weight update validity window (7 days)
+pub const WEIGHT_UPDATE_VALIDITY: u64 = 60 * 60 * 24 * 7;

--- a/wasm-contracts/sapinft/tests/burn.rs
+++ b/wasm-contracts/sapinft/tests/burn.rs
@@ -1,0 +1,60 @@
+use cosmwasm_std::{Addr, Empty};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use sapinft::msg::{ExecuteMsg as NftExecute, InstantiateMsg as NftInstantiate, QueryMsg as NftQuery};
+use sapinft::{execute, instantiate, query};
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+#[test]
+fn burn_nft_removes_owner() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &NftInstantiate {}, &[], "nft", None)
+        .unwrap();
+
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 10,
+            },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &NftExecute::Burn {
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res: Result<String, _> = app
+        .wrap()
+        .query_wasm_smart(nft_addr, &NftQuery::Owner { token_id });
+    assert!(res.is_err());
+}

--- a/wasm-contracts/sapinft/tests/transfer.rs
+++ b/wasm-contracts/sapinft/tests/transfer.rs
@@ -1,0 +1,171 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use sapinft::msg::{ExecuteMsg as NftExecute, InstantiateMsg as NftInstantiate, QueryMsg as NftQuery};
+use sapinft::{execute, instantiate, query};
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+fn mint_sample(app: &mut App, nft_addr: Addr) -> u64 {
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user1".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 5,
+            },
+            &[],
+        )
+        .unwrap();
+    resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap()
+}
+
+#[test]
+fn transfer_changes_owner_and_clears_approval() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &NftInstantiate {}, &[], "nft", None)
+        .unwrap();
+
+    let token_id = mint_sample(&mut app, nft_addr.clone());
+
+    app.execute_contract(
+        Addr::unchecked("user1"),
+        nft_addr.clone(),
+        &NftExecute::Approve {
+            spender: "spender".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user1"),
+        nft_addr.clone(),
+        &NftExecute::Transfer {
+            to: "user2".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("spender"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user1"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    app.execute_contract(
+        Addr::unchecked("user2"),
+        nft_addr.clone(),
+        &NftExecute::Burn {
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res: Result<String, _> = app
+        .wrap()
+        .query_wasm_smart(nft_addr.clone(), &NftQuery::Owner { token_id });
+    assert!(res.is_err());
+}
+
+#[test]
+fn transfer_from_by_approved() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &NftInstantiate {}, &[], "nft", None)
+        .unwrap();
+
+    let token_id = mint_sample(&mut app, nft_addr.clone());
+
+    app.execute_contract(
+        Addr::unchecked("user1"),
+        nft_addr.clone(),
+        &NftExecute::Approve {
+            spender: "spender".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("spender"),
+        nft_addr.clone(),
+        &NftExecute::TransferFrom {
+            owner: "user1".into(),
+            to: "user2".into(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user1"),
+            nft_addr.clone(),
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+
+    app.execute_contract(
+        Addr::unchecked("user2"),
+        nft_addr.clone(),
+        &NftExecute::Burn {
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res: Result<String, _> = app
+        .wrap()
+        .query_wasm_smart(nft_addr, &NftQuery::Owner { token_id });
+    assert!(res.is_err());
+}

--- a/wasm-contracts/sapinft/tests/weight.rs
+++ b/wasm-contracts/sapinft/tests/weight.rs
@@ -1,0 +1,118 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use sapinft::msg::{
+    ExecuteMsg as NftExecute, InstantiateMsg as NftInstantiate, QueryMsg as NftQuery,
+};
+use sapinft::state::WEIGHT_UPDATE_VALIDITY;
+use sapinft::{execute, instantiate, query};
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+fn mint_sample(app: &mut App, nft_addr: Addr) -> u64 {
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "user".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 5,
+            },
+            &[],
+        )
+        .unwrap();
+    resp.events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap()
+}
+
+#[test]
+fn duplicate_nfc_fails() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &NftInstantiate {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+
+    let _ = mint_sample(&mut app, nft_addr.clone());
+    let err = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &NftExecute::Mint {
+                to: "other".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 5,
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}
+
+#[test]
+fn burn_requires_recent_update() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &NftInstantiate {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+
+    let token_id = mint_sample(&mut app, nft_addr.clone());
+
+    app.update_block(|b| b.time = b.time.plus_seconds(WEIGHT_UPDATE_VALIDITY + 1));
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &NftExecute::UpdateWeight {
+            token_id: token_id.to_string(),
+            new_weight: 8,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.update_block(|b| b.time = b.time.plus_seconds(WEIGHT_UPDATE_VALIDITY + 1));
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            nft_addr,
+            &NftExecute::Burn {
+                token_id: token_id.to_string(),
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}

--- a/wasm-contracts/sapinftburnhook/Cargo.toml
+++ b/wasm-contracts/sapinftburnhook/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sapinftburnhook"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+cw2 = "1.1"
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8"
+cw-storage-plus = "1.1"
+
+[dev-dependencies]
+cw-multi-test = "0.16"

--- a/wasm-contracts/sapinftburnhook/src/lib.rs
+++ b/wasm-contracts/sapinftburnhook/src/lib.rs
@@ -1,0 +1,74 @@
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult,
+};
+use cw2::set_contract_version;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::state::{OWNER, SAPI_NFT};
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "sapinftburnhook";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+const SLAUGHTER_YIELD_BPS: u64 = 6500;
+const WEIGHT_DECIMALS: u32 = 1;
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    SAPI_NFT.save(deps.storage, &deps.api.addr_validate(&msg.nft_contract)?)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::OnBurn { to, weight } => execute_on_burn(deps, info, to, weight),
+    }
+}
+
+fn execute_on_burn(
+    deps: DepsMut,
+    info: MessageInfo,
+    to: String,
+    weight: u64,
+) -> StdResult<Response> {
+    let nft = SAPI_NFT.load(deps.storage)?;
+    if info.sender != nft {
+        return Err(StdError::generic_err("Unauthorized"));
+    }
+    if weight == 0 {
+        return Ok(Response::default());
+    }
+    let amount = weight as u128 * 1_000_000_000_000_000_000u128 * SLAUGHTER_YIELD_BPS as u128
+        / 10u128.pow(WEIGHT_DECIMALS)
+        / 10_000u128;
+    Ok(Response::new()
+        .add_attribute("action", "BeefMeatMinted")
+        .add_attribute("to", to)
+        .add_attribute("amount", amount.to_string()))
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Owner {} => {
+            let owner = OWNER.load(deps.storage)?;
+            Ok(to_json_binary(&owner.into_string())?)
+        }
+    }
+}

--- a/wasm-contracts/sapinftburnhook/src/msg.rs
+++ b/wasm-contracts/sapinftburnhook/src/msg.rs
@@ -1,0 +1,19 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub nft_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    OnBurn { to: String, weight: u64 },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Owner {},
+}

--- a/wasm-contracts/sapinftburnhook/src/state.rs
+++ b/wasm-contracts/sapinftburnhook/src/state.rs
@@ -1,0 +1,5 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const SAPI_NFT: Item<Addr> = Item::new("sapi_nft");

--- a/wasm-contracts/sapinftburnhook/tests/basic.rs
+++ b/wasm-contracts/sapinftburnhook/tests/basic.rs
@@ -1,0 +1,30 @@
+use cosmwasm_std::{Addr, Empty};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use sapinftburnhook::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use sapinftburnhook::{execute, instantiate, query};
+
+fn contract_hook() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+#[test]
+fn owner_query_works() {
+    let mut app = App::default();
+    let hook_id = app.store_code(contract_hook());
+    let hook_addr = app
+        .instantiate_contract(
+            hook_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg { nft_contract: "nft".into() },
+            &[],
+            "hook",
+            None,
+        )
+        .unwrap();
+    let owner: String = app
+        .wrap()
+        .query_wasm_smart(hook_addr, &QueryMsg::Owner {})
+        .unwrap();
+    assert_eq!(owner, "owner");
+}

--- a/wasm-contracts/sapinftwrapper/Cargo.toml
+++ b/wasm-contracts/sapinftwrapper/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sapinftwrapper"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+cw2 = "1.1"
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8"
+serde-json-wasm = "0.5"
+cw-storage-plus = "1.1"
+
+starter = { path = "../starter" }
+sapinft = { path = "../sapinft" }
+
+[dev-dependencies]
+cw-multi-test = "0.16"
+sapinftburnhook = { path = "../sapinftburnhook" }

--- a/wasm-contracts/sapinftwrapper/src/lib.rs
+++ b/wasm-contracts/sapinftwrapper/src/lib.rs
@@ -1,0 +1,153 @@
+use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg};
+use cw2::set_contract_version;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, WrappedResponse};
+use crate::state::{WrappedInfo, OWNER, SAPI_NFT, GOAT_TOKEN, WRAPPED};
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "sapinftwrapper";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+const SAPI_WRAP_RATE: u64 = 595;
+const WEIGHT_DECIMALS: u32 = 1;
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    SAPI_NFT.save(deps.storage, &deps.api.addr_validate(&msg.nft_contract)?)?;
+    GOAT_TOKEN.save(deps.storage, &deps.api.addr_validate(&msg.goat_contract)?)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::Wrap { token_id } => execute_wrap(deps, env, info, token_id),
+        ExecuteMsg::Unwrap { token_id } => execute_unwrap(deps, env, info, token_id),
+    }
+}
+
+fn execute_wrap(deps: DepsMut, env: Env, info: MessageInfo, token_id: u64) -> StdResult<Response> {
+    let nft = SAPI_NFT.load(deps.storage)?;
+    let goat = GOAT_TOKEN.load(deps.storage)?;
+
+    let owner_query = to_json_binary(&sapinft::msg::QueryMsg::Owner { token_id })?;
+    let owner: String = deps.querier.query_wasm_smart(nft.clone(), &owner_query)?;
+    if owner != info.sender {
+        return Err(StdError::generic_err("Not token owner"));
+    }
+
+    let value_query = to_json_binary(&sapinft::msg::QueryMsg::SapiValue { token_id })?;
+    let value: sapinft::msg::SapiValueResponse =
+        deps.querier.query_wasm_smart(nft.clone(), &value_query)?;
+
+    let goat_amount = Uint128::new(
+        value.value.u128() * 1_000_000_000_000_000_000u128
+            / SAPI_WRAP_RATE as u128
+            / 10u128.pow(WEIGHT_DECIMALS),
+    );
+
+    let transfer = WasmMsg::Execute {
+        contract_addr: nft.to_string(),
+        msg: to_json_binary(&sapinft::msg::ExecuteMsg::TransferFrom {
+            owner: info.sender.to_string(),
+            to: env.contract.address.to_string(),
+            token_id: token_id.to_string(),
+        })?,
+        funds: vec![],
+    };
+
+    let mint = WasmMsg::Execute {
+        contract_addr: goat.to_string(),
+        msg: to_json_binary(&starter::msg::ExecuteMsg::MintTo {
+            to: info.sender.to_string(),
+            amount: goat_amount,
+        })?,
+        funds: vec![],
+    };
+
+    WRAPPED.save(
+        deps.storage,
+        token_id,
+        &WrappedInfo {
+            owner: info.sender.clone(),
+            goat_amount,
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_message(transfer)
+        .add_message(mint)
+        .add_attribute("action", "Wrapped")
+        .add_attribute("user", info.sender)
+        .add_attribute("token_id", token_id.to_string())
+        .add_attribute("goat_amount", goat_amount))
+}
+
+fn execute_unwrap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    token_id: u64,
+) -> StdResult<Response> {
+    let nft = SAPI_NFT.load(deps.storage)?;
+    let goat = GOAT_TOKEN.load(deps.storage)?;
+    let info_wrapped = WRAPPED.load(deps.storage, token_id)?;
+    if info_wrapped.owner != info.sender {
+        return Err(StdError::generic_err("Not owner"));
+    }
+
+    let burn = WasmMsg::Execute {
+        contract_addr: goat.to_string(),
+        msg: to_json_binary(&starter::msg::ExecuteMsg::TransferFrom {
+            owner: info.sender.to_string(),
+            recipient: env.contract.address.to_string(),
+            amount: info_wrapped.goat_amount,
+        })?,
+        funds: vec![],
+    };
+
+    let transfer = WasmMsg::Execute {
+        contract_addr: nft.to_string(),
+        msg: to_json_binary(&sapinft::msg::ExecuteMsg::Transfer {
+            to: info.sender.to_string(),
+            token_id: token_id.to_string(),
+        })?,
+        funds: vec![],
+    };
+
+    WRAPPED.remove(deps.storage, token_id);
+
+    Ok(Response::new()
+        .add_message(burn)
+        .add_message(transfer)
+        .add_attribute("action", "Unwrapped")
+        .add_attribute("user", info.sender)
+        .add_attribute("token_id", token_id.to_string())
+        .add_attribute("goat_amount", info_wrapped.goat_amount))
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Wrapped { token_id } => {
+            let info = WRAPPED.load(deps.storage, token_id)?;
+            Ok(to_json_binary(&WrappedResponse {
+                owner: info.owner.into_string(),
+                goat_amount: info.goat_amount,
+            })?)
+        }
+        QueryMsg::Owner {} => {
+            let owner = OWNER.load(deps.storage)?;
+            Ok(to_json_binary(&owner.into_string())?)
+        }
+    }
+}

--- a/wasm-contracts/sapinftwrapper/src/msg.rs
+++ b/wasm-contracts/sapinftwrapper/src/msg.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::Uint128;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub nft_contract: String,
+    pub goat_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Wrap { token_id: u64 },
+    Unwrap { token_id: u64 },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Wrapped { token_id: u64 },
+    Owner {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct WrappedResponse {
+    pub owner: String,
+    pub goat_amount: Uint128,
+}

--- a/wasm-contracts/sapinftwrapper/src/state.rs
+++ b/wasm-contracts/sapinftwrapper/src/state.rs
@@ -1,0 +1,14 @@
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const SAPI_NFT: Item<Addr> = Item::new("sapi_nft");
+pub const GOAT_TOKEN: Item<Addr> = Item::new("goat_token");
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct WrappedInfo {
+    pub owner: Addr,
+    pub goat_amount: Uint128,
+}
+
+pub const WRAPPED: Map<u64, WrappedInfo> = Map::new("wrapped");

--- a/wasm-contracts/sapinftwrapper/tests/wrapper.rs
+++ b/wasm-contracts/sapinftwrapper/tests/wrapper.rs
@@ -1,0 +1,222 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use sapinft::msg as nft_msg;
+use sapinft::{execute as nft_execute, instantiate as nft_instantiate, query as nft_query};
+use sapinftburnhook::msg as hook_msg;
+use sapinftburnhook::{
+    execute as hook_execute, instantiate as hook_instantiate, query as hook_query,
+};
+use sapinftwrapper::msg as wrap_msg;
+use sapinftwrapper::{
+    execute as wrap_execute, instantiate as wrap_instantiate, query as wrap_query,
+};
+use starter::msg as goat_msg;
+use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
+
+fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        goat_execute,
+        goat_instantiate,
+        goat_query,
+    ))
+}
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        nft_execute,
+        nft_instantiate,
+        nft_query,
+    ))
+}
+
+fn contract_wrapper() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        wrap_execute,
+        wrap_instantiate,
+        wrap_query,
+    ))
+}
+
+fn contract_hook() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        hook_execute,
+        hook_instantiate,
+        hook_query,
+    ))
+}
+
+#[test]
+fn wrap_and_unwrap_flow() {
+    let mut app = App::default();
+    let goat_id = app.store_code(contract_goat());
+    let nft_id = app.store_code(contract_nft());
+    let wrap_id = app.store_code(contract_wrapper());
+    let hook_id = app.store_code(contract_hook());
+
+    let goat_addr = app
+        .instantiate_contract(
+            goat_id,
+            Addr::unchecked("owner"),
+            &goat_msg::InstantiateMsg {
+                meat_contract: "meat".into(),
+            },
+            &[],
+            "goat",
+            None,
+        )
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(
+            nft_id,
+            Addr::unchecked("owner"),
+            &nft_msg::InstantiateMsg {},
+            &[],
+            "nft",
+            None,
+        )
+        .unwrap();
+    let _hook_addr = app
+        .instantiate_contract(
+            hook_id,
+            Addr::unchecked("owner"),
+            &hook_msg::InstantiateMsg {
+                nft_contract: nft_addr.to_string(),
+            },
+            &[],
+            "hook",
+            None,
+        )
+        .unwrap();
+    let wrapper_addr = app
+        .instantiate_contract(
+            wrap_id,
+            Addr::unchecked("owner"),
+            &wrap_msg::InstantiateMsg {
+                nft_contract: nft_addr.to_string(),
+                goat_contract: goat_addr.to_string(),
+            },
+            &[],
+            "wrapper",
+            None,
+        )
+        .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        goat_addr.clone(),
+        &goat_msg::ExecuteMsg::SetMeatAddress { meat_address: wrapper_addr.to_string() },
+        &[],
+    ).unwrap();
+
+    // mint nft
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &nft_msg::ExecuteMsg::Mint {
+                to: "user".into(),
+                nfc_id: "nfc".into(),
+                breed: "breed".into(),
+                birth_year: 2024,
+                weight: 10,
+            },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp
+        .events
+        .iter()
+        .find(|e| e.ty == "wasm")
+        .unwrap()
+        .attributes
+        .iter()
+        .find(|a| a.key == "token_id")
+        .unwrap()
+        .value
+        .parse()
+        .unwrap();
+
+    // approve wrapper
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &nft_msg::ExecuteMsg::Approve {
+            spender: wrapper_addr.to_string(),
+            token_id: token_id.to_string(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    // wrap nft
+    let res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            wrapper_addr.clone(),
+            &wrap_msg::ExecuteMsg::Wrap { token_id },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "Wrapped")));
+
+    // approve goat burn
+    app.execute_contract(
+        Addr::unchecked("user"),
+        goat_addr.clone(),
+        &goat_msg::ExecuteMsg::Approve {
+            spender: wrapper_addr.to_string(),
+            amount: Uint128::new(117647058823529400),
+        },
+        &[],
+    )
+    .unwrap();
+    let res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            wrapper_addr.clone(),
+            &wrap_msg::ExecuteMsg::Unwrap { token_id },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "Unwrapped")));
+}
+
+#[test]
+fn burn_hook_emits_event() {
+    let mut app = App::default();
+    let hook_id = app.store_code(contract_hook());
+    let _nft_id = app.store_code(contract_nft());
+    let hook_addr = app
+        .instantiate_contract(
+            hook_id,
+            Addr::unchecked("owner"),
+            &hook_msg::InstantiateMsg {
+                nft_contract: "nft".into(),
+            },
+            &[],
+            "hook",
+            None,
+        )
+        .unwrap();
+    let res = app
+        .execute_contract(
+            Addr::unchecked("nft"),
+            hook_addr,
+            &hook_msg::ExecuteMsg::OnBurn {
+                to: "user".into(),
+                weight: 10,
+            },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "BeefMeatMinted")));
+}


### PR DESCRIPTION
## Summary
- implement new CosmWasm packages `sapinft`, `sapinftburnhook`, `sapinftwrapper`, and `barterengine`
- include unit tests for new modules
- extend build script to build the new contracts

## Testing
- `cargo test` for `sapinft`
- `cargo test` for `sapinftburnhook`
- `cargo test` for `sapinftwrapper`
- `cargo test` for `barterengine`
- `yes | npx hardhat test` *(fails: Hardhat non-local installation)*

------
https://chatgpt.com/codex/tasks/task_e_684c384adf948325bee9ee45c834c4dd