### PR TITLE
docs: update CosmWasm guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ npx hardhat compile
 
 Folder `wasm-contracts/` menyimpan versi CosmWasm dari setiap kontrak.
 Kontrak Solidity yang **sudah** terporting meliputi paket `starter`, `meat`,
-`goatnft`, `ratehandler`, `goatnftwrapper`, dan `goatnftburnhook`.
-Implementasi `BarterEngine` serta varian `SapiNFT` masih *pending*.
+`goatnft`, `sapinft`, `ratehandler`, `goatnftwrapper`, `sapinftwrapper`,
+`goatnftburnhook`, `sapinftburnhook`, dan `barterengine`.
 Seluruh pesan
 CosmWasm tetap mengikuti fungsi di Solidity namun ada beberapa perbedaan tak
 terelakkan:

--- a/docs/goat-meat-lifecycle.md
+++ b/docs/goat-meat-lifecycle.md
@@ -22,7 +22,7 @@ Kedua token membentuk loop tertutup yang memungkinkan nilai masuk melalui MEAT d
 4. **Mengambil Reward**
    * Setelah `minClaimInterval`, staker bisa mengambil reward atau menggabungkannya kembali ke stake. Untuk keluar sepenuhnya panggil `unstake` agar pokok dan reward diterima.
 5. **Barter Produk**
-   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine` (port CosmWasm belum tersedia).
+   * GOATMEAT dapat ditukar dengan token produk lain menggunakan `RateHandler` yang diakses oleh `BarterEngine` pada CosmWasm.
    * Sebelum barter, pengguna harus memberikan *approval* kepada `BarterEngine` untuk jumlah subtype yang akan dibakar.
    * Subtype seperti `GOATMEAT` harus di-encode ke `bytes32` misal `ethers.encodeBytes32String("GOATMEAT")`.
    * MEAT selalu mengharapkan parameter subtype berupa `bytes32`; ubah ID numerik ke string sebelum di-encode. contoh: `bytes32 subtypeFromId = ethers.encodeBytes32String("99");`

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -7,7 +7,11 @@ Proyek ini menyertakan implementasi CosmWasm untuk seluruh kontrak inti di direk
 - `goatnft` – kontrak NFT sederhana tempat setiap token menyimpan nilai berat yang dapat ditebus menjadi GOAT
 - `ratehandler` – utilitas kecil yang menyimpan rasio konversi terbaru dan memungkinkan pemilik memperbarui atau menonaktifkannya
 - `goatnftwrapper` – membungkus GoatNFT untuk mencetak GOAT, NFT dikunci hingga pengguna melakukan `unwrap`
-- `goatnftburnhook` – hook sederhana yang dipanggil saat NFT dibakar dan mencatat jumlah GOATMEAT yang seharusnya dicetak
+- `goatnftburnhook` – hook saat GoatNFT dibakar dan mencetak `GOATMEAT`
+- `sapinft` – NFT sapi yang menyimpan berat dan dapat dibakar menjadi `BEEFMEAT`
+- `sapinftwrapper` – membungkus SapiNFT untuk mencetak GOAT
+- `sapinftburnhook` – hook saat SapiNFT dibakar dan mencetak `BEEFMEAT`
+- `barterengine` – modul barter produk antar subtype menggunakan `RateHandler`
 
 Paket-paket ini mencerminkan kontrak Solidity di `contracts/`. Sebagian besar fungsi memiliki pesan execute yang setara, namun terdapat beberapa perbedaan penting:
 
@@ -56,17 +60,35 @@ wasmd tx wasm instantiate <code_id> '{"meat_contract":"cosmos1..."}' \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```
-Instansiasi `meat`, `goatnft`, dan `ratehandler` dengan perintah serupa. `ratehandler` tidak memerlukan parameter dan nantinya akan digunakan oleh `BarterEngine` untuk menentukan rasio barter setelah port CosmWasm-nya tersedia. Setelah itu deploy `goatnftwrapper` dan `goatnftburnhook` dengan parameter alamat kontrak terkait:
+Instansiasi `meat`, `goatnft`, `sapinft`, dan `ratehandler` dengan perintah serupa. `ratehandler` digunakan oleh `BarterEngine` untuk menentukan rasio barter. Setelah itu deploy `goatnftwrapper`, `sapinftwrapper`, `goatnftburnhook`, `sapinftburnhook`, dan `barterengine` dengan parameter alamat kontrak terkait:
 ```bash
 # contoh instansiasi goatnftwrapper
 wasmd tx wasm instantiate <code_id_wrapper> '{"nft_contract":"<nft_addr>","goat_contract":"<goat_addr>"}' \
-  --from wallet --label "wrapper" \
+  --from wallet --label "goat-wrapper" \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 
-# contoh instansiasi burn hook
+# contoh instansiasi sapinftwrapper
+wasmd tx wasm instantiate <code_id_sapi_wrapper> '{"nft_contract":"<sapi_nft_addr>","goat_contract":"<goat_addr>"}' \
+  --from wallet --label "sapi-wrapper" \
+  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+
+# contoh instansiasi burn hook kambing
 wasmd tx wasm instantiate <code_id_hook> '{"nft_contract":"<nft_addr>"}' \
-  --from wallet --label "burnhook" \
+  --from wallet --label "goat-burnhook" \
+  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+
+# contoh instansiasi burn hook sapi
+wasmd tx wasm instantiate <code_id_sapi_hook> '{"nft_contract":"<sapi_nft_addr>"}' \
+  --from wallet --label "sapi-burnhook" \
+  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+
+# contoh instansiasi barterengine
+wasmd tx wasm instantiate <code_id_barter> '{"meat_contract":"<meat_addr>","rate_handler":"<rate_addr>"}' \
+  --from wallet --label "barter" \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -38,7 +38,7 @@ Berdasarkan [goat-meat-lifecycle.md](goat-meat-lifecycle.md), setiap `GoatNFT` d
 
 1. Dibungkus menjadi GOAT untuk staking.
 2. Dibakar melalui hook yang mencetak subtype *MEAT* sesuai berat ternak.
-3. Token MEAT dapat dibarter ke produk lain dengan `BarterEngine` atau ditebus melalui `RedeemEngine`. Port CosmWasm untuk `BarterEngine` masih dalam pengerjaan.
+3. Token MEAT dapat dibarter ke produk lain dengan `BarterEngine` pada CosmWasm atau ditebus melalui `RedeemEngine`.
 
 ## Governance dan LOD Engine
 White paper ini mengikuti panduan [governance-lod-engine.md](governance-lod-engine.md). LOD Engine menetapkan paritas komoditas melalui fungsi `setCommodityRepresentation`. Setiap pembaruan diwajibkan melewati pipeline governansi dan diuji dengan Hardhat.


### PR DESCRIPTION
## Summary
- list SapiNFT and BarterEngine packages in the CosmWasm docs
- explain how to deploy CosmWasm BarterEngine and SapiNFT contracts
- document BarterEngine usage in lifecycle and whitepaper

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c3c1a4588832584717939cc7deb5a