### PR TITLE
codex/redeemengine-cosmwasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ npx hardhat compile
 Folder `wasm-contracts/` menyimpan versi CosmWasm dari setiap kontrak.
 Kontrak Solidity yang **sudah** terporting meliputi paket `starter`, `meat`,
 `goatnft`, `sapinft`, `ratehandler`, `goatnftwrapper`, `sapinftwrapper`,
-`goatnftburnhook`, `sapinftburnhook`, dan `barterengine`.
+`goatnftburnhook`, `sapinftburnhook`, `barterengine`, dan `redeemengine`.
 Seluruh pesan
 CosmWasm tetap mengikuti fungsi di Solidity namun ada beberapa perbedaan tak
 terelakkan:

--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -12,6 +12,7 @@ Proyek ini menyertakan implementasi CosmWasm untuk seluruh kontrak inti di direk
 - `sapinftwrapper` – membungkus SapiNFT untuk mencetak GOAT
 - `sapinftburnhook` – hook saat SapiNFT dibakar dan mencetak `BEEFMEAT`
 - `barterengine` – modul barter produk antar subtype menggunakan `RateHandler`
+- `redeemengine` – memproses penebusan MEAT menjadi barang fisik
 
 Paket-paket ini mencerminkan kontrak Solidity di `contracts/`. Sebagian besar fungsi memiliki pesan execute yang setara, namun terdapat beberapa perbedaan penting:
 
@@ -89,6 +90,13 @@ wasmd tx wasm instantiate <code_id_sapi_hook> '{"nft_contract":"<sapi_nft_addr>"
 # contoh instansiasi barterengine
 wasmd tx wasm instantiate <code_id_barter> '{"meat_contract":"<meat_addr>","rate_handler":"<rate_addr>"}' \
   --from wallet --label "barter" \
+  --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
+  --chain-id testing-1 --node https://rpc.testnet.cosmos.network
+```
+
+# contoh instansiasi redeemengine
+wasmd tx wasm instantiate <code_id_redeem> '{"meat_contract":"<meat_addr>"}' \
+  --from wallet --label "redeem" \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 ```

--- a/wasm-contracts/build.sh
+++ b/wasm-contracts/build.sh
@@ -9,7 +9,7 @@ if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
   rustup target add wasm32-unknown-unknown
 fi
 
-for pkg in starter meat goatnft ratehandler goatnftwrapper goatnftburnhook sapinft sapinftwrapper sapinftburnhook barterengine; do
+for pkg in starter meat goatnft ratehandler goatnftwrapper goatnftburnhook sapinft sapinftwrapper sapinftburnhook barterengine redeemengine; do
   cd "$DIR/$pkg"
   cargo build --release --target wasm32-unknown-unknown
   mkdir -p "$DIR/../artifacts"

--- a/wasm-contracts/redeemengine/Cargo.toml
+++ b/wasm-contracts/redeemengine/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "redeemengine"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-std = "1.3"
+cw2 = "1.1"
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8"
+cw-storage-plus = "1.1"
+meat = { path = "../meat" }
+
+[dev-dependencies]
+cw-multi-test = "0.16"
+starter = { path = "../starter" }

--- a/wasm-contracts/redeemengine/src/lib.rs
+++ b/wasm-contracts/redeemengine/src/lib.rs
@@ -1,0 +1,162 @@
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult, Uint128, WasmMsg,
+};
+use cw2::set_contract_version;
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RedeemConfigResponse};
+use crate::state::{RedeemConfig, CONFIGS, MEAT, OWNER};
+
+pub mod msg;
+pub mod state;
+
+const CONTRACT_NAME: &str = "redeemengine";
+const CONTRACT_VERSION: &str = "0.1.0";
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    OWNER.save(deps.storage, &info.sender)?;
+    MEAT.save(deps.storage, &deps.api.addr_validate(&msg.meat_contract)?)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let owner = OWNER.load(deps.storage)?;
+    if info.sender != owner {
+        return Err(StdError::generic_err("Not the owner"));
+    }
+    Ok(())
+}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::SetRedeemConfig {
+            subtype,
+            grams_per_token_unit,
+            active,
+        } => execute_set_config(deps, info, subtype, grams_per_token_unit, active),
+        ExecuteMsg::Redeem { subtype, amount } => {
+            execute_redeem(deps, env.clone(), info, subtype, amount)
+        }
+        ExecuteMsg::EmergencyWithdraw { subtype } => execute_withdraw(deps, env, info, subtype),
+    }
+}
+
+fn execute_set_config(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    subtype: String,
+    grams: u128,
+    active: bool,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    if subtype.is_empty() {
+        return Err(StdError::generic_err("Invalid subtype"));
+    }
+    CONFIGS.save(
+        deps.storage,
+        subtype.as_bytes(),
+        &RedeemConfig {
+            grams_per_token_unit: grams,
+            is_active: active,
+        },
+    )?;
+    Ok(Response::new())
+}
+
+fn execute_redeem(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    subtype: String,
+    amount: u128,
+) -> StdResult<Response> {
+    if amount == 0 {
+        return Err(StdError::generic_err("Invalid amount"));
+    }
+    let cfg = CONFIGS.load(deps.storage, subtype.as_bytes())?;
+    if !cfg.is_active {
+        return Err(StdError::generic_err("Redeem inactive"));
+    }
+    let meat = MEAT.load(deps.storage)?;
+    let transfer = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::TransferFrom {
+            owner: info.sender.to_string(),
+            recipient: env.contract.address.to_string(),
+            amount: Uint128::new(amount),
+        })?,
+        funds: vec![],
+    };
+    let burn = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::RedeemForMeat {
+            amount: Uint128::new(amount),
+        })?,
+        funds: vec![],
+    };
+    let grams = amount * cfg.grams_per_token_unit / 1_000_000_000_000_000_000u128;
+    Ok(Response::new()
+        .add_message(transfer)
+        .add_message(burn)
+        .add_attribute("action", "redeem")
+        .add_attribute("user", info.sender)
+        .add_attribute("subtype", subtype)
+        .add_attribute("amount", amount.to_string())
+        .add_attribute("grams", grams.to_string()))
+}
+
+fn execute_withdraw(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    _subtype: String,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let meat = MEAT.load(deps.storage)?;
+    let bal: meat::msg::BalanceResponse = deps.querier.query_wasm_smart(
+        meat.clone(),
+        &meat::msg::QueryMsg::Balance {
+            address: env.contract.address.to_string(),
+        },
+    )?;
+    if bal.balance.is_zero() {
+        return Err(StdError::generic_err("No balance"));
+    }
+    let transfer = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::Transfer {
+            recipient: info.sender.to_string(),
+            amount: bal.balance,
+        })?,
+        funds: vec![],
+    };
+    Ok(Response::new()
+        .add_message(transfer)
+        .add_attribute("action", "emergency_withdraw")
+        .add_attribute("amount", bal.balance))
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::RedeemConfig { subtype } => {
+            let cfg = CONFIGS.load(deps.storage, subtype.as_bytes())?;
+            to_json_binary(&RedeemConfigResponse {
+                grams_per_token_unit: cfg.grams_per_token_unit,
+                is_active: cfg.is_active,
+            })
+        }
+        QueryMsg::Owner {} => {
+            let owner = OWNER.load(deps.storage)?;
+            to_json_binary(&owner.into_string())
+        }
+    }
+}

--- a/wasm-contracts/redeemengine/src/msg.rs
+++ b/wasm-contracts/redeemengine/src/msg.rs
@@ -1,0 +1,37 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub meat_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    SetRedeemConfig {
+        subtype: String,
+        grams_per_token_unit: u128,
+        active: bool,
+    },
+    Redeem {
+        subtype: String,
+        amount: u128,
+    },
+    EmergencyWithdraw {
+        subtype: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    RedeemConfig { subtype: String },
+    Owner {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RedeemConfigResponse {
+    pub grams_per_token_unit: u128,
+    pub is_active: bool,
+}

--- a/wasm-contracts/redeemengine/src/state.rs
+++ b/wasm-contracts/redeemengine/src/state.rs
@@ -1,0 +1,14 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::{Item, Map};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RedeemConfig {
+    pub grams_per_token_unit: u128,
+    pub is_active: bool,
+}
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const MEAT: Item<Addr> = Item::new("meat");
+pub const CONFIGS: Map<&[u8], RedeemConfig> = Map::new("configs");

--- a/wasm-contracts/redeemengine/tests/basic.rs
+++ b/wasm-contracts/redeemengine/tests/basic.rs
@@ -1,0 +1,125 @@
+use cosmwasm_std::{coin, Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use meat::msg::{ExecuteMsg as MeatExec, InstantiateMsg as MeatInstantiate};
+use meat::{execute as meat_execute, instantiate as meat_init, query as meat_query};
+use redeemengine::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RedeemConfigResponse};
+use redeemengine::{execute, instantiate, query};
+use starter::{execute as goat_execute, instantiate as goat_init, query as goat_query};
+
+fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(goat_execute, goat_init, goat_query))
+}
+
+fn contract_meat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(meat_execute, meat_init, meat_query))
+}
+
+fn contract_engine() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+#[test]
+fn redeem_burns_meat() {
+    let mut app = App::new(|router, _, storage| {
+        router
+            .bank
+            .init_balance(storage, &Addr::unchecked("user"), vec![coin(1000, "ucosm")])
+            .unwrap();
+    });
+    let goat_id = app.store_code(contract_goat());
+    let meat_id = app.store_code(contract_meat());
+    let eng_id = app.store_code(contract_engine());
+
+    let goat_addr = app
+        .instantiate_contract(
+            goat_id,
+            Addr::unchecked("owner"),
+            &starter::msg::InstantiateMsg {
+                meat_contract: "meat".into(),
+            },
+            &[],
+            "goat",
+            None,
+        )
+        .unwrap();
+
+    let meat_addr = app
+        .instantiate_contract(
+            meat_id,
+            Addr::unchecked("owner"),
+            &MeatInstantiate {
+                goat_contract: goat_addr.to_string(),
+            },
+            &[],
+            "meat",
+            None,
+        )
+        .unwrap();
+
+    let eng_addr = app
+        .instantiate_contract(
+            eng_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg {
+                meat_contract: meat_addr.to_string(),
+            },
+            &[],
+            "engine",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        meat_addr.clone(),
+        &MeatExec::MintWithNative {},
+        &[coin(1000, "ucosm")],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        eng_addr.clone(),
+        &ExecuteMsg::SetRedeemConfig {
+            subtype: "GOATMEAT".into(),
+            grams_per_token_unit: 100,
+            active: true,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        meat_addr.clone(),
+        &MeatExec::Approve {
+            spender: eng_addr.to_string(),
+            amount: Uint128::new(50),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        eng_addr.clone(),
+        &ExecuteMsg::Redeem {
+            subtype: "GOATMEAT".into(),
+            amount: 50,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let bal: meat::msg::BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            meat_addr,
+            &meat::msg::QueryMsg::Balance {
+                address: "user".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(bal.balance, Uint128::new(50));
+}


### PR DESCRIPTION
## Summary
- add `redeemengine` CosmWasm contract with tests
- update build script and docs for new contract
- document RedeemEngine in README and deployment guide

## Testing
- `cargo test --manifest-path wasm-contracts/sapinft/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/sapinftburnhook/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/sapinftwrapper/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/barterengine/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/redeemengine/Cargo.toml`
- `yes | npx hardhat test` *(fails: non-local hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_684c3da3497c8325aef81f82d4d7d6da