### PR TITLE
Add MEAT subtype management

### DIFF
--- a/wasm-contracts/meat/src/lib.rs
+++ b/wasm-contracts/meat/src/lib.rs
@@ -1,11 +1,13 @@
 use cosmwasm_std::{
-    entry_point, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, StdResult, Uint128,
+    entry_point, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult, Uint128,
 };
 use cw2::set_contract_version;
 
-
-use crate::msg::{AllowanceResponse, BalanceResponse, ExecuteMsg, InstantiateMsg, QueryMsg, TokenInfoResponse};
+use crate::msg::{
+    AllowanceResponse, BalanceResponse, BalanceSubtypeWithLineageResponse, ExecuteMsg,
+    InstantiateMsg, QueryMsg, TokenInfoResponse,
+};
 use crate::state::*;
 
 pub mod msg;
@@ -13,6 +15,7 @@ pub mod state;
 
 const CONTRACT_NAME: &str = "meat";
 const CONTRACT_VERSION: &str = "0.1.0";
+const GOATMEAT_SUBTYPE: &[u8] = b"GOATMEAT";
 
 fn add_balance(
     store: &mut dyn cosmwasm_std::Storage,
@@ -35,21 +38,107 @@ fn sub_balance(
     BALANCES.save(store, addr, &(bal - amount))
 }
 
+fn add_user_subtype(
+    store: &mut dyn cosmwasm_std::Storage,
+    addr: &Addr,
+    st: &[u8],
+) -> StdResult<()> {
+    let mut list = USER_SUBTYPES.may_load(store, addr)?.unwrap_or_default();
+    if !list.iter().any(|x| x.as_slice() == st) {
+        list.push(st.to_vec());
+        USER_SUBTYPES.save(store, addr, &list)?;
+    }
+    Ok(())
+}
+
+fn remove_user_subtype(
+    store: &mut dyn cosmwasm_std::Storage,
+    addr: &Addr,
+    st: &[u8],
+) -> StdResult<()> {
+    let mut list = USER_SUBTYPES.may_load(store, addr)?.unwrap_or_default();
+    if let Some(pos) = list.iter().position(|x| x.as_slice() == st) {
+        list.remove(pos);
+        USER_SUBTYPES.save(store, addr, &list)?;
+    }
+    Ok(())
+}
+
+fn mint_subtype_internal(
+    store: &mut dyn cosmwasm_std::Storage,
+    to: &Addr,
+    subtype: &[u8],
+    amount: Uint128,
+) -> StdResult<()> {
+    add_balance(store, to, amount)?;
+    let mut total = TOTAL_SUPPLY.load(store)? + amount;
+    TOTAL_SUPPLY.save(store, &total)?;
+
+    let mut sub_bal = SUBTYPE_BALANCES
+        .may_load(store, (to, subtype))?
+        .unwrap_or_default();
+    if sub_bal.is_zero() {
+        add_user_subtype(store, to, subtype)?;
+    }
+    sub_bal += amount;
+    SUBTYPE_BALANCES.save(store, (to, subtype), &sub_bal)?;
+
+    let mut sub_total = SUBTYPE_TOTAL_SUPPLY
+        .may_load(store, subtype)?
+        .unwrap_or_default();
+    sub_total += amount;
+    SUBTYPE_TOTAL_SUPPLY.save(store, subtype, &sub_total)?;
+    Ok(())
+}
+
+fn burn_subtype_internal(
+    store: &mut dyn cosmwasm_std::Storage,
+    from: &Addr,
+    subtype: &[u8],
+    amount: Uint128,
+) -> StdResult<()> {
+    sub_balance(store, from, amount)?;
+    let mut total = TOTAL_SUPPLY.load(store)?;
+    total -= amount;
+    TOTAL_SUPPLY.save(store, &total)?;
+
+    let mut sub_bal = SUBTYPE_BALANCES
+        .may_load(store, (from, subtype))?
+        .unwrap_or_default();
+    if sub_bal < amount {
+        return Err(StdError::generic_err("Insufficient subtype balance"));
+    }
+    sub_bal -= amount;
+    if sub_bal.is_zero() {
+        remove_user_subtype(store, from, subtype)?;
+    }
+    SUBTYPE_BALANCES.save(store, (from, subtype), &sub_bal)?;
+
+    let mut sub_total = SUBTYPE_TOTAL_SUPPLY
+        .may_load(store, subtype)?
+        .unwrap_or_default();
+    sub_total -= amount;
+    SUBTYPE_TOTAL_SUPPLY.save(store, subtype, &sub_total)?;
+    Ok(())
+}
 
 #[entry_point]
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    msg: InstantiateMsg,
+    _msg: InstantiateMsg,
 ) -> StdResult<Response> {
     let owner = info.sender.clone();
     OWNER.save(deps.storage, &owner)?;
-    let goat_addr = deps.api.addr_validate(&msg.goat_contract)?;
-    GOAT_CONTRACT.save(deps.storage, &goat_addr)?;
-    let init = Uint128::new(INITIAL_SUPPLY);
-    BALANCES.save(deps.storage, &owner, &init)?;
-    TOTAL_SUPPLY.save(deps.storage, &init)?;
+    MINTERS.save(deps.storage, &owner, &true)?;
+    TOTAL_SUPPLY.save(deps.storage, &Uint128::zero())?;
+    mint_subtype_internal(
+        deps.storage,
+        &owner,
+        GOATMEAT_SUBTYPE,
+        Uint128::new(INITIAL_SUPPLY),
+    )?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
@@ -60,6 +149,34 @@ fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
         return Err(StdError::generic_err("Not the owner"));
     }
     Ok(())
+}
+
+fn only_minter(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let is = MINTERS
+        .may_load(deps.storage, &info.sender)?
+        .unwrap_or(false);
+    if !is {
+        return Err(StdError::generic_err("Not minter"));
+    }
+    Ok(())
+}
+
+fn only_burner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let is = BURNERS
+        .may_load(deps.storage, &info.sender)?
+        .unwrap_or(false);
+    if !is {
+        return Err(StdError::generic_err("Not burner"));
+    }
+    Ok(())
+}
+
+fn only_owner_or_minter(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let owner = OWNER.load(deps.storage)?;
+    if info.sender == owner {
+        return Ok(());
+    }
+    only_minter(deps, info)
 }
 
 #[entry_point]
@@ -75,7 +192,27 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             amount,
         } => execute_transfer_from(deps, info, owner, recipient, amount),
         ExecuteMsg::RedeemForMeat { amount } => execute_redeem_for_meat(deps, info, amount),
-        ExecuteMsg::SetGoatAddress { goat_address } => execute_set_goat(deps, info, goat_address),
+        ExecuteMsg::MintSubtype {
+            to,
+            subtype,
+            amount,
+        } => execute_mint_subtype(deps, info, to, subtype, amount),
+        ExecuteMsg::BurnSubtype {
+            from,
+            subtype,
+            amount,
+        } => execute_burn_subtype(deps, info, from, subtype, amount),
+        ExecuteMsg::SetMinter { account, status } => {
+            execute_set_minter(deps, info, account, status)
+        }
+        ExecuteMsg::SetBurner { account, status } => {
+            execute_set_burner(deps, info, account, status)
+        }
+        ExecuteMsg::SetSubtypeLineage {
+            user,
+            subtype,
+            lineage_id,
+        } => execute_set_lineage(deps, info, user, subtype, lineage_id),
     }
 }
 
@@ -124,6 +261,92 @@ fn execute_transfer_from(
     Ok(Response::new())
 }
 
+fn execute_mint_subtype(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    to: String,
+    subtype: String,
+    amount: Uint128,
+) -> StdResult<Response> {
+    only_minter(deps.branch(), &info)?;
+    if amount.is_zero() || subtype.is_empty() {
+        return Err(StdError::generic_err("Invalid params"));
+    }
+    let to_addr = deps.api.addr_validate(&to)?;
+    mint_subtype_internal(deps.storage, &to_addr, subtype.as_bytes(), amount)?;
+    Ok(Response::new()
+        .add_attribute("action", "SubtypeMinted")
+        .add_attribute("to", to)
+        .add_attribute("subtype", subtype)
+        .add_attribute("amount", amount))
+}
+
+fn execute_burn_subtype(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    from: String,
+    subtype: String,
+    amount: Uint128,
+) -> StdResult<Response> {
+    only_burner(deps.branch(), &info)?;
+    if amount.is_zero() || subtype.is_empty() {
+        return Err(StdError::generic_err("Invalid params"));
+    }
+    let from_addr = deps.api.addr_validate(&from)?;
+    burn_subtype_internal(deps.storage, &from_addr, subtype.as_bytes(), amount)?;
+    Ok(Response::new()
+        .add_attribute("action", "SubtypeBurned")
+        .add_attribute("from", from)
+        .add_attribute("subtype", subtype)
+        .add_attribute("amount", amount))
+}
+
+fn execute_set_minter(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    account: String,
+    status: bool,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&account)?;
+    MINTERS.save(deps.storage, &addr, &status)?;
+    Ok(Response::new()
+        .add_attribute("action", "MinterUpdated")
+        .add_attribute("account", account)
+        .add_attribute("status", status.to_string()))
+}
+
+fn execute_set_burner(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    account: String,
+    status: bool,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&account)?;
+    BURNERS.save(deps.storage, &addr, &status)?;
+    Ok(Response::new()
+        .add_attribute("action", "BurnerUpdated")
+        .add_attribute("account", account)
+        .add_attribute("status", status.to_string()))
+}
+
+fn execute_set_lineage(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    user: String,
+    subtype: String,
+    lineage_id: u64,
+) -> StdResult<Response> {
+    only_owner_or_minter(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&user)?;
+    SUBTYPE_LINEAGE.save(deps.storage, (&addr, subtype.as_bytes()), &lineage_id)?;
+    Ok(Response::new()
+        .add_attribute("action", "SubtypeLineageUpdated")
+        .add_attribute("user", user)
+        .add_attribute("subtype", subtype)
+        .add_attribute("lineage_id", lineage_id.to_string()))
+}
 
 fn execute_redeem_for_meat(
     deps: DepsMut,
@@ -144,18 +367,6 @@ fn execute_redeem_for_meat(
         .add_attribute("user", info.sender)
         .add_attribute("amount", amount))
 }
-
-fn execute_set_goat(
-    mut deps: DepsMut,
-    info: MessageInfo,
-    goat_address: String,
-) -> StdResult<Response> {
-    only_owner(deps.branch(), &info)?;
-    let addr = deps.api.addr_validate(&goat_address)?;
-    GOAT_CONTRACT.save(deps.storage, &addr)?;
-    Ok(Response::new())
-}
-
 
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
@@ -185,6 +396,19 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Owner {} => {
             let owner = OWNER.load(deps.storage)?;
             to_json_binary(&owner.into_string())
+        }
+        QueryMsg::BalanceOfSubtypeWithLineage { user, subtype } => {
+            let addr = deps.api.addr_validate(&user)?;
+            let bal = SUBTYPE_BALANCES
+                .may_load(deps.storage, (&addr, subtype.as_bytes()))?
+                .unwrap_or_default();
+            let lineage = SUBTYPE_LINEAGE
+                .may_load(deps.storage, (&addr, subtype.as_bytes()))?
+                .unwrap_or_default();
+            to_json_binary(&BalanceSubtypeWithLineageResponse {
+                balance: bal,
+                lineage_id: lineage,
+            })
         }
     }
 }

--- a/wasm-contracts/meat/src/msg.rs
+++ b/wasm-contracts/meat/src/msg.rs
@@ -3,9 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-    pub goat_contract: String,
-}
+pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -26,8 +24,28 @@ pub enum ExecuteMsg {
     RedeemForMeat {
         amount: Uint128,
     },
-    SetGoatAddress {
-        goat_address: String,
+    MintSubtype {
+        to: String,
+        subtype: String,
+        amount: Uint128,
+    },
+    BurnSubtype {
+        from: String,
+        subtype: String,
+        amount: Uint128,
+    },
+    SetMinter {
+        account: String,
+        status: bool,
+    },
+    SetBurner {
+        account: String,
+        status: bool,
+    },
+    SetSubtypeLineage {
+        user: String,
+        subtype: String,
+        lineage_id: u64,
     },
 }
 
@@ -38,6 +56,7 @@ pub enum QueryMsg {
     Allowance { owner: String, spender: String },
     TokenInfo {},
     Owner {},
+    BalanceOfSubtypeWithLineage { user: String, subtype: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -58,3 +77,8 @@ pub struct TokenInfoResponse {
     pub total_supply: Uint128,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct BalanceSubtypeWithLineageResponse {
+    pub balance: Uint128,
+    pub lineage_id: u64,
+}

--- a/wasm-contracts/meat/src/state.rs
+++ b/wasm-contracts/meat/src/state.rs
@@ -6,11 +6,18 @@ pub const SYMBOL: &str = "MEAT";
 pub const DECIMALS: u8 = 18;
 
 pub const OWNER: Item<Addr> = Item::new("owner");
-pub const GOAT_CONTRACT: Item<Addr> = Item::new("goat_contract");
 
 pub const BALANCES: Map<&Addr, Uint128> = Map::new("balances");
 pub const ALLOWANCES: Map<(&Addr, &Addr), Uint128> = Map::new("allowances");
 pub const TOTAL_SUPPLY: Item<Uint128> = Item::new("total_supply");
+
+pub const MINTERS: Map<&Addr, bool> = Map::new("minters");
+pub const BURNERS: Map<&Addr, bool> = Map::new("burners");
+
+pub const SUBTYPE_BALANCES: Map<(&Addr, &[u8]), Uint128> = Map::new("subtype_balances");
+pub const SUBTYPE_TOTAL_SUPPLY: Map<&[u8], Uint128> = Map::new("subtype_total_supply");
+pub const SUBTYPE_LINEAGE: Map<(&Addr, &[u8]), u64> = Map::new("subtype_lineage");
+pub const USER_SUBTYPES: Map<&Addr, Vec<Vec<u8>>> = Map::new("user_subtypes");
 
 pub const DECIMAL_FACTOR: u128 = 1_000_000_000_000_000_000u128;
 pub const INITIAL_SUPPLY: u128 = 1_000u128 * DECIMAL_FACTOR;

--- a/wasm-contracts/meat/tests/subtype.rs
+++ b/wasm-contracts/meat/tests/subtype.rs
@@ -1,0 +1,102 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use meat::msg::{BalanceSubtypeWithLineageResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+use meat::{execute, instantiate, query};
+
+fn contract_meat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+#[test]
+fn mint_burn_and_lineage() {
+    let mut app = App::default();
+    let meat_id = app.store_code(contract_meat());
+
+    let meat_addr = app
+        .instantiate_contract(
+            meat_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg {},
+            &[],
+            "meat",
+            None,
+        )
+        .unwrap();
+
+    // owner is minter by default, mint to user
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &ExecuteMsg::MintSubtype {
+            to: "user".into(),
+            subtype: "GOATMEAT".into(),
+            amount: Uint128::new(10),
+        },
+        &[],
+    )
+    .unwrap();
+
+    // set lineage
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &ExecuteMsg::SetSubtypeLineage {
+            user: "user".into(),
+            subtype: "GOATMEAT".into(),
+            lineage_id: 1,
+        },
+        &[],
+    )
+    .unwrap();
+
+    // query
+    let res: BalanceSubtypeWithLineageResponse = app
+        .wrap()
+        .query_wasm_smart(
+            meat_addr.clone(),
+            &QueryMsg::BalanceOfSubtypeWithLineage {
+                user: "user".into(),
+                subtype: "GOATMEAT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.balance, Uint128::new(10));
+    assert_eq!(res.lineage_id, 1);
+
+    // grant burner and burn
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &ExecuteMsg::SetBurner {
+            account: "burner".into(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("burner"),
+        meat_addr.clone(),
+        &ExecuteMsg::BurnSubtype {
+            from: "user".into(),
+            subtype: "GOATMEAT".into(),
+            amount: Uint128::new(10),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res2: BalanceSubtypeWithLineageResponse = app
+        .wrap()
+        .query_wasm_smart(
+            meat_addr,
+            &QueryMsg::BalanceOfSubtypeWithLineage {
+                user: "user".into(),
+                subtype: "GOATMEAT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res2.balance, Uint128::zero());
+}

--- a/wasm-contracts/redeemengine/tests/basic.rs
+++ b/wasm-contracts/redeemengine/tests/basic.rs
@@ -1,7 +1,10 @@
-use cosmwasm_std::{coin, Addr, Empty, Uint128};
+use cosmwasm_std::{Addr, Empty, Uint128};
 use cw_multi_test::{App, ContractWrapper, Executor};
 
-use meat::msg::{ExecuteMsg as MeatExec, InstantiateMsg as MeatInstantiate};
+use meat::msg::{
+    ExecuteMsg as MeatExec,
+    InstantiateMsg as MeatInstantiate,
+};
 use meat::{execute as meat_execute, instantiate as meat_init, query as meat_query};
 use redeemengine::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RedeemConfigResponse};
 use redeemengine::{execute, instantiate, query};
@@ -21,17 +24,12 @@ fn contract_engine() -> Box<dyn cw_multi_test::Contract<Empty>> {
 
 #[test]
 fn redeem_burns_meat() {
-    let mut app = App::new(|router, _, storage| {
-        router
-            .bank
-            .init_balance(storage, &Addr::unchecked("user"), vec![coin(1000, "ucosm")])
-            .unwrap();
-    });
+    let mut app = App::default();
     let goat_id = app.store_code(contract_goat());
     let meat_id = app.store_code(contract_meat());
     let eng_id = app.store_code(contract_engine());
 
-    let goat_addr = app
+    let _goat_addr = app
         .instantiate_contract(
             goat_id,
             Addr::unchecked("owner"),
@@ -48,9 +46,7 @@ fn redeem_burns_meat() {
         .instantiate_contract(
             meat_id,
             Addr::unchecked("owner"),
-            &MeatInstantiate {
-                goat_contract: goat_addr.to_string(),
-            },
+            &MeatInstantiate {},
             &[],
             "meat",
             None,
@@ -71,10 +67,14 @@ fn redeem_burns_meat() {
         .unwrap();
 
     app.execute_contract(
-        Addr::unchecked("user"),
+        Addr::unchecked("owner"),
         meat_addr.clone(),
-        &MeatExec::MintWithNative {},
-        &[coin(1000, "ucosm")],
+        &MeatExec::MintSubtype {
+            to: "user".into(),
+            subtype: "GOATMEAT".into(),
+            amount: Uint128::new(1000),
+        },
+        &[],
     )
     .unwrap();
 
@@ -121,5 +121,5 @@ fn redeem_burns_meat() {
             },
         )
         .unwrap();
-    assert_eq!(bal.balance, Uint128::new(50));
+    assert_eq!(bal.balance, Uint128::new(950));
 }


### PR DESCRIPTION
## Summary
- support subtype balances and lineage in MEAT CosmWasm contract
- allow authorized mint/burn of subtypes and manage permissions
- expose lineage-aware balance query
- adjust RedeemEngine test for new minting flow
- add new MEAT contract tests

## Testing
- `cargo test --manifest-path wasm-contracts/meat/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/redeemengine/Cargo.toml`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c481f05808325b76cfcf1c47d1b34