### PR TITLE
Update RateHandler LOD registry

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -5,7 +5,7 @@ Proyek ini menyertakan implementasi CosmWasm untuk seluruh kontrak inti di direk
 - `starter` – token GOAT dengan logika staking
 - `meat` – token MEAT. Pencetakan dilakukan via pesan `mint_subtype` oleh kontrak terotorisasi dan penebusan menggunakan `redeem` pada `RedeemEngine`.
 - `goatnft` – kontrak NFT sederhana tempat setiap token menyimpan nilai berat yang dapat ditebus menjadi GOAT
-- `ratehandler` – utilitas kecil yang menyimpan rasio konversi terbaru dan memungkinkan pemilik memperbarui atau menonaktifkannya
+- `ratehandler` – modul LOD Engine yang menyimpan `CommodityRepresentation` dan menghitung rasio barter PRODUCT↔PRODUCT melalui `computeBarterRate`
 - `goatnftwrapper` – membungkus GoatNFT untuk mencetak GOAT, NFT dikunci hingga pengguna melakukan `unwrap`
 - `goatnftburnhook` – hook saat GoatNFT dibakar dan mencetak `GOATMEAT`
 - `sapinft` – NFT sapi yang menyimpan berat dan dapat dibakar menjadi `BEEFMEAT`

--- a/wasm-contracts/barterengine/src/lib.rs
+++ b/wasm-contracts/barterengine/src/lib.rs
@@ -69,7 +69,15 @@ fn execute_barter(deps: DepsMut, _env: Env, _info: MessageInfo, from_sub: String
     let rate_handler = RATE_HANDLER.load(deps.storage)?;
     let rate_resp: RateHandlerResponse = deps
         .querier
-        .query_wasm_smart(rate_handler, &RateQueryMsg::GetRate {})?;
+        .query_wasm_smart(
+            rate_handler,
+            &RateQueryMsg::GetRate {
+                from_commodity: from_sub.clone(),
+                from_layer: "PRODUCT".into(),
+                to_commodity: to_sub.clone(),
+                to_layer: "PRODUCT".into(),
+            },
+        )?;
     if rate_resp.rate.is_zero() {
         return Err(StdError::generic_err("Invalid barter rate"));
     }
@@ -85,11 +93,19 @@ fn execute_barter(deps: DepsMut, _env: Env, _info: MessageInfo, from_sub: String
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetRate { from_subtype: _, to_subtype: _ } => {
+        QueryMsg::GetRate { from_subtype, to_subtype } => {
             let addr = RATE_HANDLER.load(deps.storage)?;
             let resp: RateHandlerResponse = deps
                 .querier
-                .query_wasm_smart(addr, &RateQueryMsg::GetRate {})?;
+                .query_wasm_smart(
+                    addr,
+                    &RateQueryMsg::GetRate {
+                        from_commodity: from_subtype,
+                        from_layer: "PRODUCT".into(),
+                        to_commodity: to_subtype,
+                        to_layer: "PRODUCT".into(),
+                    },
+                )?;
             Ok(to_binary(&RateResponse { rate: resp.rate.u128() })?)
         }
         QueryMsg::Owner {} => {

--- a/wasm-contracts/barterengine/tests/basic.rs
+++ b/wasm-contracts/barterengine/tests/basic.rs
@@ -3,7 +3,10 @@ use cw_multi_test::{App, ContractWrapper, Executor};
 
 use barterengine::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RateResponse};
 use barterengine::{execute, instantiate, query};
-use ratehandler::{execute as rate_execute, instantiate as rate_inst, query as rate_query, InstantiateMsg as RHInstantiate, ExecuteMsg as RHExecute};
+use ratehandler::{
+    execute as rate_execute, instantiate as rate_inst, query as rate_query, CommodityRepresentation,
+    ExecuteMsg as RHExecute, InstantiateMsg as RHInstantiate, QueryMsg as RHQuery,
+};
 
 fn contract_engine() -> Box<dyn cw_multi_test::Contract<Empty>> {
     Box::new(ContractWrapper::new(execute, instantiate, query))
@@ -33,10 +36,60 @@ fn query_rate_forward() {
         )
         .unwrap();
 
+    let data_a = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: "0x0".into(),
+        token_product_subtype: "AMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(2),
+        lod_per_day_virtual: Uint128::new(2),
+        lod_per_day_product: Uint128::new(4),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+
+    let data_b = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: "0x0".into(),
+        token_product_subtype: "BMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(1),
+        lod_per_day_virtual: Uint128::new(1),
+        lod_per_day_product: Uint128::new(8),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+
     app.execute_contract(
         Addr::unchecked("owner"),
         rate_addr.clone(),
-        &RHExecute::UpdateRate { new_rate: Uint128::new(200) },
+        &RHExecute::SetCommodityRepresentation {
+            commodity_id: "A".into(),
+            data: data_a,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        rate_addr.clone(),
+        &RHExecute::SetCommodityRepresentation {
+            commodity_id: "B".into(),
+            data: data_b,
+        },
         &[],
     )
     .unwrap();
@@ -45,8 +98,8 @@ fn query_rate_forward() {
         .wrap()
         .query_wasm_smart(
             eng_addr,
-            &QueryMsg::GetRate { from_subtype: "a".into(), to_subtype: "b".into() },
+            &QueryMsg::GetRate { from_subtype: "A".into(), to_subtype: "B".into() },
         )
         .unwrap();
-    assert_eq!(rate.rate, 200u128);
+    assert_eq!(rate.rate, ((4u128 * 1_000_000_000_000_000_000u128) / 8u128));
 }

--- a/wasm-contracts/ratehandler/src/lib.rs
+++ b/wasm-contracts/ratehandler/src/lib.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{
     StdResult, Uint128,
 };
 use cw2::set_contract_version;
-use cw_storage_plus::Item;
+use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -16,29 +16,58 @@ pub struct InstantiateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    UpdateRate { new_rate: Uint128 },
-    InvalidateRate {},
+    SetCommodityRepresentation {
+        commodity_id: String,
+        data: CommodityRepresentation,
+    },
     TransferOwnership { new_owner: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetRate {},
+    GetLODPerDay { commodity_id: String, layer: String },
+    GetRate {
+        from_commodity: String,
+        from_layer: String,
+        to_commodity: String,
+        to_layer: String,
+    },
     Owner {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct RateResponse {
     pub rate: Uint128,
-    pub last_update: u64,
-    pub valid: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LODResponse {
+    pub lod_per_day: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct CommodityRepresentation {
+    pub nft_address: String,
+    pub token_virtual_address: String,
+    pub token_product_address: String,
+    pub token_product_subtype: String,
+    pub is_nft_active: bool,
+    pub is_token_virtual_active: bool,
+    pub is_token_product_active: bool,
+    pub lod_per_day_nft: Uint128,
+    pub lod_per_day_virtual: Uint128,
+    pub lod_per_day_product: Uint128,
+    pub protein_g_per_kg: Uint128,
+    pub fat_g_per_kg: Uint128,
+    pub micronutrient_index_x1000: Uint128,
+    pub yield_per_cycle_kg: Uint128,
+    pub cycle_time_days: Uint128,
 }
 
 pub const OWNER: Item<Addr> = Item::new("owner");
-pub const DYNAMIC_RATE: Item<Uint128> = Item::new("dynamic_rate");
-pub const LAST_UPDATE: Item<u64> = Item::new("last_update");
-pub const VALID: Item<bool> = Item::new("valid");
+pub const COMMODITY_REGISTRY: Map<&[u8], CommodityRepresentation> = Map::new("registry");
+pub const DECIMAL_FACTOR: u128 = 1_000_000_000_000_000_000u128;
 
 #[entry_point]
 pub fn instantiate(
@@ -48,9 +77,6 @@ pub fn instantiate(
     _msg: InstantiateMsg,
 ) -> StdResult<Response> {
     OWNER.save(deps.storage, &info.sender)?;
-    DYNAMIC_RATE.save(deps.storage, &Uint128::zero())?;
-    LAST_UPDATE.save(deps.storage, &0u64)?;
-    VALID.save(deps.storage, &false)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
@@ -64,35 +90,26 @@ fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
 }
 
 #[entry_point]
-pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+pub fn execute(deps: DepsMut, _env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     match msg {
-        ExecuteMsg::UpdateRate { new_rate } => execute_update_rate(deps, env, info, new_rate),
-        ExecuteMsg::InvalidateRate {} => execute_invalidate_rate(deps, info),
+        ExecuteMsg::SetCommodityRepresentation { commodity_id, data } => {
+            execute_set_commodity_representation(deps, info, commodity_id, data)
+        }
         ExecuteMsg::TransferOwnership { new_owner } => {
             execute_transfer_ownership(deps, info, new_owner)
         }
     }
 }
 
-fn execute_update_rate(
+
+fn execute_set_commodity_representation(
     mut deps: DepsMut,
-    env: Env,
     info: MessageInfo,
-    new_rate: Uint128,
+    commodity_id: String,
+    data: CommodityRepresentation,
 ) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;
-    if new_rate.is_zero() {
-        return Err(StdError::generic_err("Rate must be > 0"));
-    }
-    DYNAMIC_RATE.save(deps.storage, &new_rate)?;
-    LAST_UPDATE.save(deps.storage, &env.block.time.seconds())?;
-    VALID.save(deps.storage, &true)?;
-    Ok(Response::new())
-}
-
-fn execute_invalidate_rate(mut deps: DepsMut, info: MessageInfo) -> StdResult<Response> {
-    only_owner(deps.branch(), &info)?;
-    VALID.save(deps.storage, &false)?;
+    COMMODITY_REGISTRY.save(deps.storage, commodity_id.as_bytes(), &data)?;
     Ok(Response::new())
 }
 
@@ -109,15 +126,42 @@ fn execute_transfer_ownership(
 
 fn handle_query(deps: Deps, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetRate {} => {
-            let rate = DYNAMIC_RATE.load(deps.storage)?;
-            let last = LAST_UPDATE.load(deps.storage)?;
-            let valid = VALID.load(deps.storage)?;
-            to_json_binary(&RateResponse {
-                rate,
-                last_update: last,
-                valid,
-            })
+        QueryMsg::GetLODPerDay { commodity_id, layer } => {
+            let cr = COMMODITY_REGISTRY.load(deps.storage, commodity_id.as_bytes())?;
+            let lod = match layer.as_str() {
+                "NFT" => cr.lod_per_day_nft,
+                "VIRTUAL" => cr.lod_per_day_virtual,
+                "PRODUCT" => cr.lod_per_day_product,
+                _ => return Err(StdError::generic_err("Invalid layer")),
+            };
+            to_json_binary(&LODResponse { lod_per_day: lod })
+        }
+        QueryMsg::GetRate {
+            from_commodity,
+            from_layer,
+            to_commodity,
+            to_layer,
+        } => {
+            if from_layer != "PRODUCT" {
+                return Err(StdError::generic_err("FROM layer must be PRODUCT"));
+            }
+            if to_layer != "PRODUCT" {
+                return Err(StdError::generic_err("TO layer must be PRODUCT"));
+            }
+            let from_cr = COMMODITY_REGISTRY.load(deps.storage, from_commodity.as_bytes())?;
+            let to_cr = COMMODITY_REGISTRY.load(deps.storage, to_commodity.as_bytes())?;
+            let from_lod = from_cr.lod_per_day_product;
+            let to_lod = to_cr.lod_per_day_product;
+
+            if from_lod.is_zero() {
+                return Err(StdError::generic_err("Invalid FROM LOD"));
+            }
+            if to_lod.is_zero() {
+                return Err(StdError::generic_err("Invalid TO LOD"));
+            }
+
+            let rate = Uint128::from((from_lod.u128() * DECIMAL_FACTOR) / to_lod.u128());
+            to_json_binary(&RateResponse { rate })
         }
         QueryMsg::Owner {} => {
             let owner = OWNER.load(deps.storage)?;

--- a/wasm-contracts/ratehandler/tests/basic.rs
+++ b/wasm-contracts/ratehandler/tests/basic.rs
@@ -1,0 +1,139 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use ratehandler::{execute, instantiate, query, CommodityRepresentation, ExecuteMsg, InstantiateMsg, QueryMsg, LODResponse, RateResponse};
+
+fn contract_rate() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+#[test]
+fn registry_and_lod_queries() {
+    let mut app = App::default();
+    let code_id = app.store_code(contract_rate());
+    let addr = app
+        .instantiate_contract(code_id, Addr::unchecked("owner"), &InstantiateMsg {}, &[], "rate", None)
+        .unwrap();
+
+    let data = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: "0x0".into(),
+        token_product_subtype: "WHEATMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(2),
+        lod_per_day_virtual: Uint128::new(3),
+        lod_per_day_product: Uint128::new(4),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        addr.clone(),
+        &ExecuteMsg::SetCommodityRepresentation {
+            commodity_id: "WHEAT".into(),
+            data: data.clone(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res: LODResponse = app
+        .wrap()
+        .query_wasm_smart(
+            addr.clone(),
+            &QueryMsg::GetLODPerDay {
+                commodity_id: "WHEAT".into(),
+                layer: "NFT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.lod_per_day, Uint128::new(2));
+}
+
+#[test]
+fn compute_rate_product_product() {
+    let mut app = App::default();
+    let code_id = app.store_code(contract_rate());
+    let addr = app
+        .instantiate_contract(code_id, Addr::unchecked("owner"), &InstantiateMsg {}, &[], "rate", None)
+        .unwrap();
+
+    let wheat = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: "0x0".into(),
+        token_product_subtype: "WHEATMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(2),
+        lod_per_day_virtual: Uint128::new(2),
+        lod_per_day_product: Uint128::new(4),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+
+    let rice = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: "0x0".into(),
+        token_product_subtype: "RICEMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(1),
+        lod_per_day_virtual: Uint128::new(1),
+        lod_per_day_product: Uint128::new(10),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        addr.clone(),
+        &ExecuteMsg::SetCommodityRepresentation {
+            commodity_id: "WHEAT".into(),
+            data: wheat,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        addr.clone(),
+        &ExecuteMsg::SetCommodityRepresentation {
+            commodity_id: "RICE".into(),
+            data: rice,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let rate: RateResponse = app
+        .wrap()
+        .query_wasm_smart(
+            addr,
+            &QueryMsg::GetRate {
+                from_commodity: "WHEAT".into(),
+                from_layer: "PRODUCT".into(),
+                to_commodity: "RICE".into(),
+                to_layer: "PRODUCT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(rate.rate, Uint128::from((4u128 * 1_000_000_000_000_000_000u128) / 10u128));
+}


### PR DESCRIPTION
## Summary
- refactor RateHandler to use CommodityRepresentation registry
- update BarterEngine to request rates from new query
- add Rust unit tests for RateHandler
- refresh deploy docs

## Testing
- `cargo test --manifest-path wasm-contracts/ratehandler/Cargo.toml`
- `cargo test --manifest-path wasm-contracts/barterengine/Cargo.toml`
- `yes | npx hardhat test` *(fails: Hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4babfab08325863e8236e8aa5e9a