### PR TITLE
Integrate RateHandler into BarterEngine

### DIFF
--- a/wasm-contracts/barterengine/src/lib.rs
+++ b/wasm-contracts/barterengine/src/lib.rs
@@ -1,4 +1,7 @@
-use cosmwasm_std::{entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
+use cosmwasm_std::{
+    entry_point, to_binary, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    StdError, StdResult, Uint128, WasmMsg,
+};
 use cw2::set_contract_version;
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RateResponse};
@@ -36,16 +39,26 @@ fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
 #[entry_point]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     match msg {
-        ExecuteMsg::SetRateHandler { rate_handler } => execute_set_rate_handler(deps, info, rate_handler),
-        ExecuteMsg::SetMeat { meat } => execute_set_meat(deps, info, meat),
-        ExecuteMsg::BarterProductToProduct { from_subtype, to_subtype, from_amount } => {
-            execute_barter(deps, env, info, from_subtype, to_subtype, from_amount)
+        ExecuteMsg::SetRateHandler { rate_handler } => {
+            execute_set_rate_handler(deps, info, rate_handler)
         }
-        ExecuteMsg::EmergencyWithdraw { subtype: _ } => only_owner(deps, &info).map(|_| Response::new()),
+        ExecuteMsg::SetMeat { meat } => execute_set_meat(deps, info, meat),
+        ExecuteMsg::BarterProductToProduct {
+            from_subtype,
+            to_subtype,
+            from_amount,
+        } => execute_barter(deps, env, info, from_subtype, to_subtype, from_amount),
+        ExecuteMsg::EmergencyWithdrawMEATSubtype { subtype } => {
+            execute_withdraw(deps, env, info, subtype)
+        }
     }
 }
 
-fn execute_set_rate_handler(mut deps: DepsMut, info: MessageInfo, rate_handler: String) -> StdResult<Response> {
+fn execute_set_rate_handler(
+    mut deps: DepsMut,
+    info: MessageInfo,
+    rate_handler: String,
+) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;
     let addr = deps.api.addr_validate(&rate_handler)?;
     RATE_HANDLER.save(deps.storage, &addr)?;
@@ -59,7 +72,14 @@ fn execute_set_meat(mut deps: DepsMut, info: MessageInfo, meat: String) -> StdRe
     Ok(Response::new())
 }
 
-fn execute_barter(deps: DepsMut, _env: Env, _info: MessageInfo, from_sub: String, to_sub: String, from_amount: u128) -> StdResult<Response> {
+fn execute_barter(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    from_sub: String,
+    to_sub: String,
+    from_amount: u128,
+) -> StdResult<Response> {
     if from_sub == to_sub {
         return Err(StdError::generic_err("Cannot swap same subtype"));
     }
@@ -67,22 +87,74 @@ fn execute_barter(deps: DepsMut, _env: Env, _info: MessageInfo, from_sub: String
         return Err(StdError::generic_err("Amount must be > 0"));
     }
     let rate_handler = RATE_HANDLER.load(deps.storage)?;
-    let rate_resp: RateHandlerResponse = deps
-        .querier
-        .query_wasm_smart(
-            rate_handler,
-            &RateQueryMsg::GetRate {
-                from_commodity: from_sub.clone(),
-                from_layer: "PRODUCT".into(),
-                to_commodity: to_sub.clone(),
-                to_layer: "PRODUCT".into(),
-            },
-        )?;
+    let rate_resp: RateHandlerResponse = deps.querier.query_wasm_smart(
+        rate_handler,
+        &RateQueryMsg::GetRate {
+            from_commodity: from_sub.clone(),
+            from_layer: "PRODUCT".into(),
+            to_commodity: to_sub.clone(),
+            to_layer: "PRODUCT".into(),
+        },
+    )?;
     if rate_resp.rate.is_zero() {
         return Err(StdError::generic_err("Invalid barter rate"));
     }
-    let to_amount = Uint128::new(from_amount) * rate_resp.rate / Uint128::new(1_000_000_000_000_000_000u128);
+    if rate_resp.rate.is_zero() {
+        return Err(StdError::generic_err("Invalid barter rate"));
+    }
+
+    let to_amount =
+        Uint128::new(from_amount) * rate_resp.rate / Uint128::new(1_000_000_000_000_000_000u128);
+
+    let meat = MEAT.load(deps.storage)?;
+    let bal: meat::msg::BalanceSubtypeWithLineageResponse = deps.querier.query_wasm_smart(
+        meat.clone(),
+        &meat::msg::QueryMsg::BalanceOfSubtypeWithLineage {
+            user: info.sender.to_string(),
+            subtype: from_sub.clone(),
+        },
+    )?;
+    if bal.balance < Uint128::new(from_amount) {
+        return Err(StdError::generic_err("Insufficient subtype balance"));
+    }
+    if bal.lineage_id == 0 {
+        return Err(StdError::generic_err("Invalid lineage"));
+    }
+
+    let burn = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::BurnSubtype {
+            from: info.sender.to_string(),
+            subtype: from_sub.clone(),
+            amount: Uint128::new(from_amount),
+        })?,
+        funds: vec![],
+    };
+
+    let mint = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::MintSubtype {
+            to: info.sender.to_string(),
+            subtype: to_sub.clone(),
+            amount: to_amount,
+        })?,
+        funds: vec![],
+    };
+
+    let lineage = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::SetSubtypeLineage {
+            user: info.sender.to_string(),
+            subtype: to_sub.clone(),
+            lineage_id: bal.lineage_id,
+        })?,
+        funds: vec![],
+    };
+
     Ok(Response::new()
+        .add_message(burn)
+        .add_message(mint)
+        .add_message(lineage)
         .add_attribute("action", "barter")
         .add_attribute("from", from_sub)
         .add_attribute("to", to_sub)
@@ -90,23 +162,73 @@ fn execute_barter(deps: DepsMut, _env: Env, _info: MessageInfo, from_sub: String
         .add_attribute("to_amount", to_amount))
 }
 
+fn execute_withdraw(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    subtype: String,
+) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    if subtype.is_empty() {
+        return Err(StdError::generic_err("Invalid subtype"));
+    }
+    let meat = MEAT.load(deps.storage)?;
+    let bal: meat::msg::BalanceSubtypeWithLineageResponse = deps.querier.query_wasm_smart(
+        meat.clone(),
+        &meat::msg::QueryMsg::BalanceOfSubtypeWithLineage {
+            user: env.contract.address.to_string(),
+            subtype: subtype.clone(),
+        },
+    )?;
+    if bal.balance.is_zero() {
+        return Err(StdError::generic_err("No subtype balance"));
+    }
+    let burn = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::BurnSubtype {
+            from: env.contract.address.to_string(),
+            subtype: subtype.clone(),
+            amount: bal.balance,
+        })?,
+        funds: vec![],
+    };
+    let mint = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::MintSubtype {
+            to: info.sender.to_string(),
+            subtype: subtype.clone(),
+            amount: bal.balance,
+        })?,
+        funds: vec![],
+    };
+    Ok(Response::new()
+        .add_message(burn)
+        .add_message(mint)
+        .add_attribute("action", "emergency_withdraw_meat_subtype")
+        .add_attribute("subtype", subtype)
+        .add_attribute("amount", bal.balance))
+}
+
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetRate { from_subtype, to_subtype } => {
+        QueryMsg::GetRate {
+            from_subtype,
+            to_subtype,
+        } => {
             let addr = RATE_HANDLER.load(deps.storage)?;
-            let resp: RateHandlerResponse = deps
-                .querier
-                .query_wasm_smart(
-                    addr,
-                    &RateQueryMsg::GetRate {
-                        from_commodity: from_subtype,
-                        from_layer: "PRODUCT".into(),
-                        to_commodity: to_subtype,
-                        to_layer: "PRODUCT".into(),
-                    },
-                )?;
-            Ok(to_binary(&RateResponse { rate: resp.rate.u128() })?)
+            let resp: RateHandlerResponse = deps.querier.query_wasm_smart(
+                addr,
+                &RateQueryMsg::GetRate {
+                    from_commodity: from_subtype,
+                    from_layer: "PRODUCT".into(),
+                    to_commodity: to_subtype,
+                    to_layer: "PRODUCT".into(),
+                },
+            )?;
+            Ok(to_binary(&RateResponse {
+                rate: resp.rate.u128(),
+            })?)
         }
         QueryMsg::Owner {} => {
             let owner = OWNER.load(deps.storage)?;

--- a/wasm-contracts/barterengine/src/msg.rs
+++ b/wasm-contracts/barterengine/src/msg.rs
@@ -10,20 +10,29 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    SetRateHandler { rate_handler: String },
-    SetMeat { meat: String },
+    SetRateHandler {
+        rate_handler: String,
+    },
+    SetMeat {
+        meat: String,
+    },
     BarterProductToProduct {
         from_subtype: String,
         to_subtype: String,
         from_amount: u128,
     },
-    EmergencyWithdraw { subtype: String },
+    EmergencyWithdrawMEATSubtype {
+        subtype: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetRate { from_subtype: String, to_subtype: String },
+    GetRate {
+        from_subtype: String,
+        to_subtype: String,
+    },
     Owner {},
 }
 

--- a/wasm-contracts/barterengine/tests/basic.rs
+++ b/wasm-contracts/barterengine/tests/basic.rs
@@ -3,9 +3,11 @@ use cw_multi_test::{App, ContractWrapper, Executor};
 
 use barterengine::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, RateResponse};
 use barterengine::{execute, instantiate, query};
+use meat::{execute as meat_execute, instantiate as meat_instantiate, query as meat_query};
 use ratehandler::{
-    execute as rate_execute, instantiate as rate_inst, query as rate_query, CommodityRepresentation,
-    ExecuteMsg as RHExecute, InstantiateMsg as RHInstantiate, QueryMsg as RHQuery,
+    execute as rate_execute, instantiate as rate_inst, query as rate_query,
+    CommodityRepresentation, ExecuteMsg as RHExecute, InstantiateMsg as RHInstantiate,
+    QueryMsg as RHQuery,
 };
 
 fn contract_engine() -> Box<dyn cw_multi_test::Contract<Empty>> {
@@ -16,6 +18,14 @@ fn contract_rate() -> Box<dyn cw_multi_test::Contract<Empty>> {
     Box::new(ContractWrapper::new(rate_execute, rate_inst, rate_query))
 }
 
+fn contract_meat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        meat_execute,
+        meat_instantiate,
+        meat_query,
+    ))
+}
+
 #[test]
 fn query_rate_forward() {
     let mut app = App::default();
@@ -23,13 +33,23 @@ fn query_rate_forward() {
     let eng_id = app.store_code(contract_engine());
 
     let rate_addr = app
-        .instantiate_contract(rate_id, Addr::unchecked("owner"), &RHInstantiate {}, &[], "rate", None)
+        .instantiate_contract(
+            rate_id,
+            Addr::unchecked("owner"),
+            &RHInstantiate {},
+            &[],
+            "rate",
+            None,
+        )
         .unwrap();
     let eng_addr = app
         .instantiate_contract(
             eng_id,
             Addr::unchecked("owner"),
-            &InstantiateMsg { rate_handler: rate_addr.to_string(), meat_contract: "meat".into() },
+            &InstantiateMsg {
+                rate_handler: rate_addr.to_string(),
+                meat_contract: "meat".into(),
+            },
             &[],
             "engine",
             None,
@@ -98,8 +118,237 @@ fn query_rate_forward() {
         .wrap()
         .query_wasm_smart(
             eng_addr,
-            &QueryMsg::GetRate { from_subtype: "A".into(), to_subtype: "B".into() },
+            &QueryMsg::GetRate {
+                from_subtype: "A".into(),
+                to_subtype: "B".into(),
+            },
         )
         .unwrap();
     assert_eq!(rate.rate, ((4u128 * 1_000_000_000_000_000_000u128) / 8u128));
+}
+
+#[test]
+fn barter_flow_and_admin() {
+    let mut app = App::default();
+    let rate_id = app.store_code(contract_rate());
+    let meat_id = app.store_code(contract_meat());
+    let eng_id = app.store_code(contract_engine());
+
+    let rate_addr = app
+        .instantiate_contract(
+            rate_id,
+            Addr::unchecked("owner"),
+            &RHInstantiate {},
+            &[],
+            "rate",
+            None,
+        )
+        .unwrap();
+    let meat_addr = app
+        .instantiate_contract(
+            meat_id,
+            Addr::unchecked("owner"),
+            &meat::msg::InstantiateMsg {},
+            &[],
+            "meat",
+            None,
+        )
+        .unwrap();
+    let eng_addr = app
+        .instantiate_contract(
+            eng_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg {
+                rate_handler: rate_addr.to_string(),
+                meat_contract: meat_addr.to_string(),
+            },
+            &[],
+            "engine",
+            None,
+        )
+        .unwrap();
+
+    // grant roles
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetMinter {
+            account: eng_addr.to_string(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetBurner {
+            account: eng_addr.to_string(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+
+    // set rate representations
+    let rep_a = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: meat_addr.to_string(),
+        token_product_subtype: "AMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(2),
+        lod_per_day_virtual: Uint128::new(2),
+        lod_per_day_product: Uint128::new(4),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+    let rep_b = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: meat_addr.to_string(),
+        token_product_subtype: "BMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::new(1),
+        lod_per_day_virtual: Uint128::new(1),
+        lod_per_day_product: Uint128::new(2),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        rate_addr.clone(),
+        &RHExecute::SetCommodityRepresentation {
+            commodity_id: "A".into(),
+            data: rep_a.clone(),
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        rate_addr.clone(),
+        &RHExecute::SetCommodityRepresentation {
+            commodity_id: "B".into(),
+            data: rep_b.clone(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::MintSubtype {
+            to: "user".into(),
+            subtype: "AMEAT".into(),
+            amount: Uint128::new(10),
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetSubtypeLineage {
+            user: "user".into(),
+            subtype: "AMEAT".into(),
+            lineage_id: 1,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let rate: ratehandler::RateResponse = app
+        .wrap()
+        .query_wasm_smart(
+            rate_addr.clone(),
+            &RHQuery::GetRate {
+                from_commodity: "A".into(),
+                from_layer: "PRODUCT".into(),
+                to_commodity: "B".into(),
+                to_layer: "PRODUCT".into(),
+            },
+        )
+        .unwrap();
+    let expected = Uint128::new(2) * rate.rate / Uint128::new(1_000_000_000_000_000_000u128);
+
+    let res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            eng_addr.clone(),
+            &ExecuteMsg::BarterProductToProduct {
+                from_subtype: "AMEAT".into(),
+                to_subtype: "BMEAT".into(),
+                from_amount: 2,
+            },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "barter")));
+
+    let bal_a: meat::msg::BalanceSubtypeWithLineageResponse = app
+        .wrap()
+        .query_wasm_smart(
+            meat_addr.clone(),
+            &meat::msg::QueryMsg::BalanceOfSubtypeWithLineage {
+                user: "user".into(),
+                subtype: "AMEAT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(bal_a.balance, Uint128::new(8));
+
+    let bal_b: meat::msg::BalanceSubtypeWithLineageResponse = app
+        .wrap()
+        .query_wasm_smart(
+            meat_addr.clone(),
+            &meat::msg::QueryMsg::BalanceOfSubtypeWithLineage {
+                user: "user".into(),
+                subtype: "BMEAT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(bal_b.balance, expected);
+    assert_eq!(bal_b.lineage_id, 1);
+
+    // emergency withdraw
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::MintSubtype {
+            to: eng_addr.to_string(),
+            subtype: "AMEAT".into(),
+            amount: Uint128::new(2),
+        },
+        &[],
+    )
+    .unwrap();
+    let res2 = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            eng_addr.clone(),
+            &ExecuteMsg::EmergencyWithdrawMEATSubtype {
+                subtype: "AMEAT".into(),
+            },
+            &[],
+        )
+        .unwrap();
+    assert!(res2.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "emergency_withdraw_meat_subtype")));
 }

--- a/wasm-contracts/barterengine/tests/goat_beef.rs
+++ b/wasm-contracts/barterengine/tests/goat_beef.rs
@@ -1,0 +1,287 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use barterengine::msg::{ExecuteMsg, InstantiateMsg};
+use barterengine::{execute, instantiate, query};
+use meat::{execute as meat_execute, instantiate as meat_instantiate, query as meat_query};
+use ratehandler::{
+    execute as rate_execute, instantiate as rate_inst, query as rate_query,
+    CommodityRepresentation, ExecuteMsg as RHExecute, InstantiateMsg as RHInstantiate,
+    QueryMsg as RHQuery,
+};
+
+fn contract_engine() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(execute, instantiate, query))
+}
+
+fn contract_rate() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(rate_execute, rate_inst, rate_query))
+}
+
+fn contract_meat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        meat_execute,
+        meat_instantiate,
+        meat_query,
+    ))
+}
+
+#[test]
+fn goat_to_beef_barter() {
+    let mut app = App::default();
+    let rate_id = app.store_code(contract_rate());
+    let meat_id = app.store_code(contract_meat());
+    let eng_id = app.store_code(contract_engine());
+
+    let rate_addr = app
+        .instantiate_contract(
+            rate_id,
+            Addr::unchecked("owner"),
+            &RHInstantiate {},
+            &[],
+            "rate",
+            None,
+        )
+        .unwrap();
+    let meat_addr = app
+        .instantiate_contract(
+            meat_id,
+            Addr::unchecked("owner"),
+            &meat::msg::InstantiateMsg {},
+            &[],
+            "meat",
+            None,
+        )
+        .unwrap();
+    let eng_addr = app
+        .instantiate_contract(
+            eng_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg {
+                rate_handler: rate_addr.to_string(),
+                meat_contract: meat_addr.to_string(),
+            },
+            &[],
+            "engine",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetMinter {
+            account: eng_addr.to_string(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetBurner {
+            account: eng_addr.to_string(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let rep_goat = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: meat_addr.to_string(),
+        token_product_subtype: "GOATMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::from(44_380000000000000000u128),
+        lod_per_day_virtual: Uint128::from(44_380000000000000000u128),
+        lod_per_day_product: Uint128::from(44_380000000000000000u128),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+    let rep_beef = CommodityRepresentation {
+        nft_address: "0x0".into(),
+        token_virtual_address: "0x0".into(),
+        token_product_address: meat_addr.to_string(),
+        token_product_subtype: "BEEFMEAT".into(),
+        is_nft_active: true,
+        is_token_virtual_active: true,
+        is_token_product_active: true,
+        lod_per_day_nft: Uint128::from(281_290000000000000000u128),
+        lod_per_day_virtual: Uint128::from(281_290000000000000000u128),
+        lod_per_day_product: Uint128::from(281_290000000000000000u128),
+        protein_g_per_kg: Uint128::new(1),
+        fat_g_per_kg: Uint128::new(1),
+        micronutrient_index_x1000: Uint128::new(1),
+        yield_per_cycle_kg: Uint128::new(1),
+        cycle_time_days: Uint128::new(1),
+    };
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        rate_addr.clone(),
+        &RHExecute::SetCommodityRepresentation {
+            commodity_id: "GOATMEAT".into(),
+            data: rep_goat.clone(),
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        rate_addr.clone(),
+        &RHExecute::SetCommodityRepresentation {
+            commodity_id: "BEEFMEAT".into(),
+            data: rep_beef.clone(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::MintSubtype {
+            to: "user".into(),
+            subtype: "GOATMEAT".into(),
+            amount: Uint128::new(10_000000000000000000u128),
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetSubtypeLineage {
+            user: "user".into(),
+            subtype: "GOATMEAT".into(),
+            lineage_id: 1,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            eng_addr.clone(),
+            &ExecuteMsg::BarterProductToProduct {
+                from_subtype: "GOATMEAT".into(),
+                to_subtype: "BEEFMEAT".into(),
+                from_amount: 2_000000000000000000u128,
+            },
+            &[],
+        )
+        .unwrap();
+    assert!(res.events.iter().any(|e| e
+        .attributes
+        .iter()
+        .any(|a| a.key == "action" && a.value == "barter")));
+
+    let bal: meat::msg::BalanceSubtypeWithLineageResponse = app
+        .wrap()
+        .query_wasm_smart(
+            meat_addr.clone(),
+            &meat::msg::QueryMsg::BalanceOfSubtypeWithLineage {
+                user: "user".into(),
+                subtype: "BEEFMEAT".into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(bal.lineage_id, 1);
+}
+
+#[test]
+fn goat_beef_lineage_missing() {
+    let mut app = App::default();
+    let rate_id = app.store_code(contract_rate());
+    let meat_id = app.store_code(contract_meat());
+    let eng_id = app.store_code(contract_engine());
+
+    let rate_addr = app
+        .instantiate_contract(
+            rate_id,
+            Addr::unchecked("owner"),
+            &RHInstantiate {},
+            &[],
+            "rate",
+            None,
+        )
+        .unwrap();
+    let meat_addr = app
+        .instantiate_contract(
+            meat_id,
+            Addr::unchecked("owner"),
+            &meat::msg::InstantiateMsg {},
+            &[],
+            "meat",
+            None,
+        )
+        .unwrap();
+    let eng_addr = app
+        .instantiate_contract(
+            eng_id,
+            Addr::unchecked("owner"),
+            &InstantiateMsg {
+                rate_handler: rate_addr.to_string(),
+                meat_contract: meat_addr.to_string(),
+            },
+            &[],
+            "engine",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetMinter {
+            account: eng_addr.to_string(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetBurner {
+            account: eng_addr.to_string(),
+            status: true,
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::MintSubtype {
+            to: "user".into(),
+            subtype: "GOATMEAT".into(),
+            amount: Uint128::new(1_000000000000000000u128),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            eng_addr,
+            &ExecuteMsg::BarterProductToProduct {
+                from_subtype: "GOATMEAT".into(),
+                to_subtype: "BEEFMEAT".into(),
+                from_amount: 1_000000000000000000u128,
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("Invalid lineage"));
+}


### PR DESCRIPTION
## Summary
- integrate `computeBarterRate` usage inside BarterEngine
- propagate subtype lineage and implement emergency withdrawal
- support new `EmergencyWithdrawMEATSubtype` message
- add CosmWasm tests for barter flows

## Testing
- `yes | npx hardhat test`
- `for d in wasm-contracts/*/; do (cd $d && cargo test >/dev/null); done`

------
https://chatgpt.com/codex/tasks/task_e_684c4e884f688325b59524058fe1626e