### PR TITLE
Add MEAT minting on NFT burn

### DIFF
--- a/docs/wasm-deploy.md
+++ b/docs/wasm-deploy.md
@@ -76,13 +76,13 @@ wasmd tx wasm instantiate <code_id_sapi_wrapper> '{"nft_contract":"<sapi_nft_add
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 
 # contoh instansiasi burn hook kambing
-wasmd tx wasm instantiate <code_id_hook> '{"nft_contract":"<nft_addr>"}' \
+wasmd tx wasm instantiate <code_id_hook> '{"nft_contract":"<nft_addr>","meat_contract":"<meat_addr>"}' \
   --from wallet --label "goat-burnhook" \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network
 
 # contoh instansiasi burn hook sapi
-wasmd tx wasm instantiate <code_id_sapi_hook> '{"nft_contract":"<sapi_nft_addr>"}' \
+wasmd tx wasm instantiate <code_id_sapi_hook> '{"nft_contract":"<sapi_nft_addr>","meat_contract":"<meat_addr>"}' \
   --from wallet --label "sapi-burnhook" \
   --gas-prices 0.025uatom --gas auto --gas-adjustment 1.3 \
   --chain-id testing-1 --node https://rpc.testnet.cosmos.network

--- a/wasm-contracts/goatnftburnhook/Cargo.toml
+++ b/wasm-contracts/goatnftburnhook/Cargo.toml
@@ -12,4 +12,5 @@ cw2 = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 schemars = "0.8"
 cw-storage-plus = "1.1"
+meat = { path = "../meat" }
 

--- a/wasm-contracts/goatnftburnhook/src/lib.rs
+++ b/wasm-contracts/goatnftburnhook/src/lib.rs
@@ -1,17 +1,19 @@
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
-    StdResult,
+    StdResult, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{GOAT_NFT, OWNER};
+use crate::state::{GOAT_NFT, MEAT, OWNER};
 
 pub mod msg;
 pub mod state;
 
 const CONTRACT_NAME: &str = "goatnftburnhook";
 const CONTRACT_VERSION: &str = "0.1.0";
+
+const GOATMEAT_SUBTYPE: &str = "GOATMEAT";
 
 const SLAUGHTER_YIELD_BPS: u64 = 6000;
 const WEIGHT_DECIMALS: u32 = 1;
@@ -25,6 +27,7 @@ pub fn instantiate(
 ) -> StdResult<Response> {
     OWNER.save(deps.storage, &info.sender)?;
     GOAT_NFT.save(deps.storage, &deps.api.addr_validate(&msg.nft_contract)?)?;
+    MEAT.save(deps.storage, &deps.api.addr_validate(&msg.meat_contract)?)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
@@ -57,7 +60,18 @@ fn execute_on_burn(
     let amount = weight as u128 * 1_000_000_000_000_000_000u128 * SLAUGHTER_YIELD_BPS as u128
         / 10u128.pow(WEIGHT_DECIMALS)
         / 10_000u128;
+    let meat = MEAT.load(deps.storage)?;
+    let mint = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::MintSubtype {
+            to: to.clone(),
+            subtype: GOATMEAT_SUBTYPE.into(),
+            amount: Uint128::new(amount),
+        })?,
+        funds: vec![],
+    };
     Ok(Response::new()
+        .add_message(mint)
         .add_attribute("action", "GoatMeatMinted")
         .add_attribute("to", to)
         .add_attribute("amount", amount.to_string()))

--- a/wasm-contracts/goatnftburnhook/src/msg.rs
+++ b/wasm-contracts/goatnftburnhook/src/msg.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub nft_contract: String,
+    pub meat_contract: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/wasm-contracts/goatnftburnhook/src/state.rs
+++ b/wasm-contracts/goatnftburnhook/src/state.rs
@@ -3,3 +3,4 @@ use cw_storage_plus::Item;
 
 pub const OWNER: Item<Addr> = Item::new("owner");
 pub const GOAT_NFT: Item<Addr> = Item::new("goat_nft");
+pub const MEAT: Item<Addr> = Item::new("meat");

--- a/wasm-contracts/sapinftburnhook/Cargo.toml
+++ b/wasm-contracts/sapinftburnhook/Cargo.toml
@@ -12,6 +12,7 @@ cw2 = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 schemars = "0.8"
 cw-storage-plus = "1.1"
+meat = { path = "../meat" }
 
 [dev-dependencies]
 cw-multi-test = "0.16"

--- a/wasm-contracts/sapinftburnhook/src/lib.rs
+++ b/wasm-contracts/sapinftburnhook/src/lib.rs
@@ -1,17 +1,19 @@
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
-    StdResult,
+    StdResult, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{OWNER, SAPI_NFT};
+use crate::state::{MEAT, OWNER, SAPI_NFT};
 
 pub mod msg;
 pub mod state;
 
 const CONTRACT_NAME: &str = "sapinftburnhook";
 const CONTRACT_VERSION: &str = "0.1.0";
+
+const BEEFMEAT_SUBTYPE: &str = "BEEFMEAT";
 
 const SLAUGHTER_YIELD_BPS: u64 = 6500;
 const WEIGHT_DECIMALS: u32 = 1;
@@ -25,6 +27,7 @@ pub fn instantiate(
 ) -> StdResult<Response> {
     OWNER.save(deps.storage, &info.sender)?;
     SAPI_NFT.save(deps.storage, &deps.api.addr_validate(&msg.nft_contract)?)?;
+    MEAT.save(deps.storage, &deps.api.addr_validate(&msg.meat_contract)?)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
@@ -57,7 +60,18 @@ fn execute_on_burn(
     let amount = weight as u128 * 1_000_000_000_000_000_000u128 * SLAUGHTER_YIELD_BPS as u128
         / 10u128.pow(WEIGHT_DECIMALS)
         / 10_000u128;
+    let meat = MEAT.load(deps.storage)?;
+    let mint = WasmMsg::Execute {
+        contract_addr: meat.to_string(),
+        msg: to_json_binary(&meat::msg::ExecuteMsg::MintSubtype {
+            to: to.clone(),
+            subtype: BEEFMEAT_SUBTYPE.into(),
+            amount: Uint128::new(amount),
+        })?,
+        funds: vec![],
+    };
     Ok(Response::new()
+        .add_message(mint)
         .add_attribute("action", "BeefMeatMinted")
         .add_attribute("to", to)
         .add_attribute("amount", amount.to_string()))

--- a/wasm-contracts/sapinftburnhook/src/msg.rs
+++ b/wasm-contracts/sapinftburnhook/src/msg.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub nft_contract: String,
+    pub meat_contract: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/wasm-contracts/sapinftburnhook/src/state.rs
+++ b/wasm-contracts/sapinftburnhook/src/state.rs
@@ -3,3 +3,4 @@ use cw_storage_plus::Item;
 
 pub const OWNER: Item<Addr> = Item::new("owner");
 pub const SAPI_NFT: Item<Addr> = Item::new("sapi_nft");
+pub const MEAT: Item<Addr> = Item::new("meat");

--- a/wasm-contracts/sapinftburnhook/tests/basic.rs
+++ b/wasm-contracts/sapinftburnhook/tests/basic.rs
@@ -16,7 +16,10 @@ fn owner_query_works() {
         .instantiate_contract(
             hook_id,
             Addr::unchecked("owner"),
-            &InstantiateMsg { nft_contract: "nft".into() },
+            &InstantiateMsg {
+                nft_contract: "nft".into(),
+                meat_contract: "meat".into(),
+            },
             &[],
             "hook",
             None,

--- a/wasm-contracts/sapinftwrapper/tests/wrapper.rs
+++ b/wasm-contracts/sapinftwrapper/tests/wrapper.rs
@@ -82,6 +82,7 @@ fn wrap_and_unwrap_flow() {
             Addr::unchecked("owner"),
             &hook_msg::InstantiateMsg {
                 nft_contract: nft_addr.to_string(),
+                meat_contract: "meat".into(),
             },
             &[],
             "hook",
@@ -198,6 +199,7 @@ fn burn_hook_emits_event() {
             Addr::unchecked("owner"),
             &hook_msg::InstantiateMsg {
                 nft_contract: "nft".into(),
+                meat_contract: "meat".into(),
             },
             &[],
             "hook",

--- a/wasm-contracts/starter/tests/wrapper.rs
+++ b/wasm-contracts/starter/tests/wrapper.rs
@@ -82,6 +82,7 @@ fn wrap_and_unwrap_flow() {
             Addr::unchecked("owner"),
             &hook_msg::InstantiateMsg {
                 nft_contract: nft_addr.to_string(),
+                meat_contract: "meat".into(),
             },
             &[],
             "hook",
@@ -198,6 +199,7 @@ fn burn_hook_emits_event() {
             Addr::unchecked("owner"),
             &hook_msg::InstantiateMsg {
                 nft_contract: "nft".into(),
+                meat_contract: "meat".into(),
             },
             &[],
             "hook",


### PR DESCRIPTION
## Summary
- store MEAT contract address in burn hooks
- mint MEAT subtype on burn
- update deploy docs
- provide MEAT address when instantiating burn hooks in tests

## Testing
- `cargo test --quiet` in `wasm-contracts/goatnftburnhook`
- `cargo test --quiet` in `wasm-contracts/sapinftburnhook`
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c55723e948325b0dc8eff590a9761