### PR TITLE
Update GOAT wasm access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Struktur dan hubungan antar kontrak:
   `birthYear`, `weight`, `mintedAt`) dan disimpan pada mapping `goatMetadata`.
   Pemilik dapat memperbarui berat melalui `updateWeight` (memancarkan `WeightUpdated`); berat terakhir harus
   masih valid (<=7 hari) saat dibakar. Fungsi `burn` kini hanya memicu `GoatNFTBurnHook` untuk mencetak `GOATMEAT`. Event `GoatBurned` tetap dipancarkan sebagai catatan berat dan rasio. Data dapat dibaca ulang melalui `getGoatData` dan dihapus setelah `burn`. Untuk mencegah *reentrancy*, data NFT dibersihkan dan `super.burn` dipanggil **sebelum** meneruskan kontrol ke `burnHook`.
-- `IGOAT` (`contracts/interfaces/IGOAT.sol`) mendefinisikan fungsi `mintTo` untuk dipanggil `GoatNFTWrapper` saat mencetak GOAT baru. `IGoatToken` dipakai oleh wrapper dan NFT untuk berinteraksi dengan kontrak GOAT.
+- `IGoatToken` (`contracts/interfaces/IGoatToken.sol`) mendefinisikan fungsi `mint` dan `burnFrom` yang dipanggil `GoatNFTWrapper` untuk mencetak maupun membakar GOAT saat proses wrap/unwrap.
 - `FailingGOAT` (`contracts/mocks/FailingGOAT.sol`) digunakan pada unit test
   guna mensimulasikan kegagalan `transfer`.
 - `emergencyUnstake` memungkinkan penarikan token yang di-stake tanpa reward kapan saja.

--- a/wasm-contracts/goatnftwrapper/src/lib.rs
+++ b/wasm-contracts/goatnftwrapper/src/lib.rs
@@ -67,7 +67,7 @@ fn execute_wrap(deps: DepsMut, env: Env, info: MessageInfo, token_id: u64) -> St
 
     let mint = WasmMsg::Execute {
         contract_addr: goat.to_string(),
-        msg: to_json_binary(&starter::msg::ExecuteMsg::MintTo {
+        msg: to_json_binary(&starter::msg::ExecuteMsg::Mint {
             to: info.sender.to_string(),
             amount: goat_amount,
         })?,
@@ -107,9 +107,8 @@ fn execute_unwrap(
 
     let burn = WasmMsg::Execute {
         contract_addr: goat.to_string(),
-        msg: to_json_binary(&starter::msg::ExecuteMsg::TransferFrom {
-            owner: info.sender.to_string(),
-            recipient: env.contract.address.to_string(),
+        msg: to_json_binary(&starter::msg::ExecuteMsg::BurnFrom {
+            from: info.sender.to_string(),
             amount: info_wrapped.goat_amount,
         })?,
         funds: vec![],

--- a/wasm-contracts/sapinftwrapper/src/lib.rs
+++ b/wasm-contracts/sapinftwrapper/src/lib.rs
@@ -67,7 +67,7 @@ fn execute_wrap(deps: DepsMut, env: Env, info: MessageInfo, token_id: u64) -> St
 
     let mint = WasmMsg::Execute {
         contract_addr: goat.to_string(),
-        msg: to_json_binary(&starter::msg::ExecuteMsg::MintTo {
+        msg: to_json_binary(&starter::msg::ExecuteMsg::Mint {
             to: info.sender.to_string(),
             amount: goat_amount,
         })?,
@@ -107,9 +107,8 @@ fn execute_unwrap(
 
     let burn = WasmMsg::Execute {
         contract_addr: goat.to_string(),
-        msg: to_json_binary(&starter::msg::ExecuteMsg::TransferFrom {
-            owner: info.sender.to_string(),
-            recipient: env.contract.address.to_string(),
+        msg: to_json_binary(&starter::msg::ExecuteMsg::BurnFrom {
+            from: info.sender.to_string(),
             amount: info_wrapped.goat_amount,
         })?,
         funds: vec![],

--- a/wasm-contracts/starter/src/lib.rs
+++ b/wasm-contracts/starter/src/lib.rs
@@ -1,6 +1,5 @@
-use cosmwasm_std::{entry_point, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg};
+use cosmwasm_std::{entry_point, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
 use cw2::set_contract_version;
-use cw721::Cw721ExecuteMsg;
 use crate::msg::{
     InstantiateMsg,
     ExecuteMsg,
@@ -11,8 +10,7 @@ use crate::msg::{
     StakingInfoResponse,
     PendingRewardResponse,
     NextClaimResponse,
-    GoatValueResponse,
-    GoatDataResponse,
+
 };
 use crate::state::*;
 
@@ -23,12 +21,10 @@ const CONTRACT_NAME: &str = "starter";
 const CONTRACT_VERSION: &str = "0.1.0";
 
 #[entry_point]
-pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: InstantiateMsg) -> StdResult<Response> {
+pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, _msg: InstantiateMsg) -> StdResult<Response> {
     let owner = info.sender.clone();
     OWNER.save(deps.storage, &owner)?;
-    let meat_addr = deps.api.addr_validate(&msg.meat_contract)?;
-    MEAT_CONTRACT.save(deps.storage, &meat_addr)?;
-    NFT_CONTRACT.save(deps.storage, &None)?;
+    WRAPPER_CONTRACT.save(deps.storage, &None)?;
     TOTAL_SUPPLY.save(deps.storage, &Uint128::zero())?;
     REWARD_RATE.save(deps.storage, &Uint128::new(5_000_000_000_000_000_000))?;
     REWARD_INTERVAL.save(deps.storage, &(365u64 * 24 * 60 * 60))?;
@@ -45,9 +41,9 @@ fn only_owner(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
     Ok(())
 }
 
-fn only_meat(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
-    let meat = MEAT_CONTRACT.load(deps.storage)?;
-    if info.sender != meat {
+fn only_wrapper(deps: DepsMut, info: &MessageInfo) -> StdResult<()> {
+    let wrapper = WRAPPER_CONTRACT.load(deps.storage)?.ok_or_else(|| StdError::generic_err("Wrapper not set"))?;
+    if info.sender != wrapper {
         return Err(StdError::generic_err("Unauthorized"));
     }
     Ok(())
@@ -72,15 +68,14 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::Transfer { recipient, amount } => execute_transfer(deps, info, recipient, amount),
         ExecuteMsg::Approve { spender, amount } => execute_approve(deps, info, spender, amount),
         ExecuteMsg::TransferFrom { owner, recipient, amount } => execute_transfer_from(deps, info, owner, recipient, amount),
-        ExecuteMsg::MintTo { to, amount } => execute_mint_to(deps, info, to, amount),
-        ExecuteMsg::BurnAndMint { token_id } => execute_burn_and_mint(deps, env, info, token_id),
+        ExecuteMsg::Mint { to, amount } => execute_mint(deps, info, to, amount),
+        ExecuteMsg::BurnFrom { from, amount } => execute_burn_from(deps, info, from, amount),
         ExecuteMsg::Stake { amount } => execute_stake(deps, env, info, amount),
         ExecuteMsg::EmergencyUnstake {} => execute_emergency_unstake(deps, env, info),
         ExecuteMsg::Unstake {} => execute_unstake(deps, env, info),
         ExecuteMsg::ClaimReward {} => execute_claim_reward(deps, env, info),
         ExecuteMsg::CompoundReward {} => execute_compound_reward(deps, env, info),
-        ExecuteMsg::SetMeatAddress { meat_address } => execute_set_meat(deps, info, meat_address),
-        ExecuteMsg::SetNftAddress { nft_address } => execute_set_nft(deps, info, nft_address),
+        ExecuteMsg::SetWrapperContract { wrapper_address } => execute_set_wrapper_contract(deps, info, wrapper_address),
         ExecuteMsg::SetRewardConfig { new_rate, new_interval, new_min_claim } => execute_set_reward_config(deps, info, new_rate, new_interval, new_min_claim),
     }
 }
@@ -112,8 +107,24 @@ fn execute_transfer_from(deps: DepsMut, info: MessageInfo, owner: String, recipi
     Ok(Response::new())
 }
 
-fn execute_mint_to(mut deps: DepsMut, info: MessageInfo, to: String, amount: Uint128) -> StdResult<Response> {
-    only_meat(deps.branch(), &info)?;
+fn execute_burn_from(mut deps: DepsMut, info: MessageInfo, from: String, amount: Uint128) -> StdResult<Response> {
+    only_wrapper(deps.branch(), &info)?;
+    let from_addr = deps.api.addr_validate(&from)?;
+    sub_balance(deps.storage, &from_addr, amount)?;
+    let supply = TOTAL_SUPPLY.load(deps.storage)?.checked_sub(amount)?;
+    TOTAL_SUPPLY.save(deps.storage, &supply)?;
+    Ok(Response::new())
+}
+
+fn execute_set_wrapper_contract(mut deps: DepsMut, info: MessageInfo, wrapper_address: String) -> StdResult<Response> {
+    only_owner(deps.branch(), &info)?;
+    let addr = deps.api.addr_validate(&wrapper_address)?;
+    WRAPPER_CONTRACT.save(deps.storage, &Some(addr))?;
+    Ok(Response::new())
+}
+
+fn execute_mint(mut deps: DepsMut, info: MessageInfo, to: String, amount: Uint128) -> StdResult<Response> {
+    only_wrapper(deps.branch(), &info)?;
     let to = deps.api.addr_validate(&to)?;
     add_balance(deps.storage, &to, amount)?;
     let supply = TOTAL_SUPPLY.load(deps.storage)? + amount;
@@ -121,56 +132,6 @@ fn execute_mint_to(mut deps: DepsMut, info: MessageInfo, to: String, amount: Uin
     Ok(Response::new())
 }
 
-fn execute_burn_and_mint(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    token_id: u64,
-) -> StdResult<Response> {
-    const WEIGHT_UPDATE_VALIDITY: u64 = 60 * 60 * 24 * 7;
-    let nft = NFT_CONTRACT
-        .load(deps.storage)?
-        .ok_or_else(|| StdError::generic_err("NFT not set"))?;
-
-    // query goat value
-    let query_val = to_json_binary(&serde_json::json!({"goat_value": {"token_id": token_id}}))?;
-    let resp: GoatValueResponse = deps.querier.query_wasm_smart(nft.clone(), &query_val)?;
-
-    // query last weight update timestamp via goat_data
-    let query_data = to_json_binary(&serde_json::json!({"goat_data": {"token_id": token_id}}))?;
-    let data: GoatDataResponse = deps.querier.query_wasm_smart(nft.clone(), &query_data)?;
-
-    if env.block.time.seconds().saturating_sub(data.minted_at) > WEIGHT_UPDATE_VALIDITY {
-        return Err(StdError::generic_err("Weight update too old"));
-    }
-
-    let burn = WasmMsg::Execute {
-        contract_addr: nft.to_string(),
-        msg: to_json_binary(&Cw721ExecuteMsg::Burn {
-            token_id: token_id.to_string(),
-        })?,
-        funds: vec![],
-    };
-
-    add_balance(deps.storage, &info.sender, resp.value)?;
-    let supply = TOTAL_SUPPLY.load(deps.storage)? + resp.value;
-    TOTAL_SUPPLY.save(deps.storage, &supply)?;
-    Ok(Response::new().add_message(burn))
-}
-
-fn execute_set_meat(mut deps: DepsMut, info: MessageInfo, meat_address: String) -> StdResult<Response> {
-    only_owner(deps.branch(), &info)?;
-    let addr = deps.api.addr_validate(&meat_address)?;
-    MEAT_CONTRACT.save(deps.storage, &addr)?;
-    Ok(Response::new())
-}
-
-fn execute_set_nft(mut deps: DepsMut, info: MessageInfo, nft_address: String) -> StdResult<Response> {
-    only_owner(deps.branch(), &info)?;
-    let addr = deps.api.addr_validate(&nft_address)?;
-    NFT_CONTRACT.save(deps.storage, &Some(addr))?;
-    Ok(Response::new())
-}
 
 fn execute_set_reward_config(mut deps: DepsMut, info: MessageInfo, new_rate: Uint128, new_interval: u64, new_min_claim: u64) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;

--- a/wasm-contracts/starter/src/msg.rs
+++ b/wasm-contracts/starter/src/msg.rs
@@ -3,24 +3,21 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-    pub meat_contract: String,
-}
+pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum ExecuteMsg {
     Transfer { recipient: String, amount: Uint128 },
     Approve { spender: String, amount: Uint128 },
     TransferFrom { owner: String, recipient: String, amount: Uint128 },
-    MintTo { to: String, amount: Uint128 },
-    BurnAndMint { token_id: u64 },
+    Mint { to: String, amount: Uint128 },
+    BurnFrom { from: String, amount: Uint128 },
     Stake { amount: Uint128 },
     EmergencyUnstake {},
     Unstake {},
     ClaimReward {},
     CompoundReward {},
-    SetMeatAddress { meat_address: String },
-    SetNftAddress { nft_address: String },
+    SetWrapperContract { wrapper_address: String },
     SetRewardConfig { new_rate: Uint128, new_interval: u64, new_min_claim: u64 },
 }
 

--- a/wasm-contracts/starter/src/state.rs
+++ b/wasm-contracts/starter/src/state.rs
@@ -6,8 +6,7 @@ pub const SYMBOL: &str = "GOAT";
 pub const DECIMALS: u8 = 18;
 
 pub const OWNER: Item<Addr> = Item::new("owner");
-pub const MEAT_CONTRACT: Item<Addr> = Item::new("meat_contract");
-pub const NFT_CONTRACT: Item<Option<Addr>> = Item::new("nft_contract");
+pub const WRAPPER_CONTRACT: Item<Option<Addr>> = Item::new("wrapper_contract");
 
 pub const BALANCES: Map<&Addr, Uint128> = Map::new("balances");
 pub const ALLOWANCES: Map<(&Addr, &Addr), Uint128> = Map::new("allowances");

--- a/wasm-contracts/starter/tests/goat.rs
+++ b/wasm-contracts/starter/tests/goat.rs
@@ -19,11 +19,28 @@ fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
 fn init_app() -> (App, Addr) {
     let mut app = App::default();
     let code_id = app.store_code(contract_goat());
-    let msg = InstantiateMsg { meat_contract: "meat".into() };
+    let msg = InstantiateMsg {};
     let addr = app
         .instantiate_contract(code_id, Addr::unchecked("owner"), &msg, &[], "goat", None)
         .unwrap();
     (app, addr)
+}
+
+fn mint_to(app: &mut App, addr: Addr, to: &str, amount: Uint128) {
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        addr.clone(),
+        &ExecuteMsg::SetWrapperContract { wrapper_address: "wrapper".into() },
+        &[],
+    )
+    .unwrap();
+    app.execute_contract(
+        Addr::unchecked("wrapper"),
+        addr,
+        &ExecuteMsg::Mint { to: to.into(), amount },
+        &[],
+    )
+    .unwrap();
 }
 
 #[test]
@@ -45,8 +62,7 @@ fn stake_and_claim() {
         &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 },
         &[]
     ).unwrap();
-    // mint and stake
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "staker", Uint128::new(100));
     let resp = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
     assert!(resp.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "Staked")));
     app.update_block(|b| b.time = b.time.plus_seconds(1));
@@ -65,7 +81,7 @@ fn stake_and_compound() {
         &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 },
         &[]
     ).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "staker", Uint128::new(100));
     let stake_res = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
     assert!(stake_res.events.iter().any(|e| e.ty == "wasm" && e.attributes.iter().any(|a| a.key == "action" && a.value == "Staked")));
     app.update_block(|b| b.time = b.time.plus_seconds(1));
@@ -83,7 +99,7 @@ fn stake_and_unstake() {
         &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 },
         &[]
     ).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "staker", Uint128::new(100));
     app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
     app.update_block(|b| b.time = b.time.plus_seconds(1));
     let unstake_res = app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Unstake {}, &[]).unwrap();
@@ -98,7 +114,7 @@ fn owner_only() {
     let _err = app.execute_contract(
         Addr::unchecked("not_owner"),
         addr.clone(),
-        &ExecuteMsg::SetMeatAddress { meat_address: "new".into() },
+        &ExecuteMsg::SetWrapperContract { wrapper_address: "x".into() },
         &[]
     ).unwrap_err();
     let _err = app.execute_contract(
@@ -109,133 +125,6 @@ fn owner_only() {
     ).unwrap_err();
 }
 
-#[test]
-fn burn_and_mint_emits_burn() {
-    let mut app = App::default();
-    let goat_id = app.store_code(contract_goat());
-    let nft_id = app.store_code(contract_nft());
-
-    let goat_addr = app
-        .instantiate_contract(goat_id, Addr::unchecked("owner"), &InstantiateMsg { meat_contract: "meat".into() }, &[], "goat", None)
-        .unwrap();
-    let nft_addr = app
-        .instantiate_contract(nft_id, Addr::unchecked("owner"), &nft_msg::InstantiateMsg {}, &[], "nft", None)
-        .unwrap();
-
-    app.execute_contract(
-        Addr::unchecked("owner"),
-        goat_addr.clone(),
-        &ExecuteMsg::SetNftAddress { nft_address: nft_addr.to_string() },
-        &[]
-    ).unwrap();
-
-
-    let resp = app.execute_contract(
-        Addr::unchecked("owner"),
-        nft_addr.clone(),
-        &nft_msg::ExecuteMsg::Mint {
-            to: "user".into(),
-            nfc_id: "nfc".into(),
-            breed: "breed".into(),
-            birth_year: 2024,
-            weight: 10,
-        },
-        &[]
-    ).unwrap();
-    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap()
-        .attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
-
-    app.execute_contract(
-        Addr::unchecked("user"),
-        nft_addr.clone(),
-        &nft_msg::ExecuteMsg::Approve {
-            spender: goat_addr.to_string(),
-            token_id: token_id.to_string(),
-        },
-        &[]
-    ).unwrap();
-
-    let res = app.execute_contract(
-        Addr::unchecked("user"),
-        goat_addr.clone(),
-        &ExecuteMsg::BurnAndMint { token_id },
-        &[]
-    ).unwrap();
-
-    let has_event = res.events.iter().any(|e| {
-        e.ty == "execute" && e.attributes.iter().any(|a| a.key == "_contract_addr" && a.value == nft_addr)
-    });
-    assert!(has_event, "burn message not sent");
-
-    let owner_res: Result<String, _> = app.wrap().query_wasm_smart(nft_addr, &nft_msg::QueryMsg::Owner { token_id });
-    assert!(owner_res.is_err());
-}
-
-#[test]
-fn burn_and_mint_fails_with_stale_update() {
-    let mut app = App::default();
-    let goat_id = app.store_code(contract_goat());
-    let nft_id = app.store_code(contract_nft());
-
-    let goat_addr = app
-        .instantiate_contract(goat_id, Addr::unchecked("owner"), &InstantiateMsg { meat_contract: "meat".into() }, &[], "goat", None)
-        .unwrap();
-    let nft_addr = app
-        .instantiate_contract(nft_id, Addr::unchecked("owner"), &nft_msg::InstantiateMsg {}, &[], "nft", None)
-        .unwrap();
-
-    app.execute_contract(
-        Addr::unchecked("owner"),
-        goat_addr.clone(),
-        &ExecuteMsg::SetNftAddress { nft_address: nft_addr.to_string() },
-        &[]
-    ).unwrap();
-
-    let resp = app.execute_contract(
-        Addr::unchecked("owner"),
-        nft_addr.clone(),
-        &nft_msg::ExecuteMsg::Mint {
-            to: "user".into(),
-            nfc_id: "nfc".into(),
-            breed: "breed".into(),
-            birth_year: 2024,
-            weight: 10,
-        },
-        &[]
-    ).unwrap();
-    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap()
-        .attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
-
-    app.execute_contract(
-        Addr::unchecked("user"),
-        nft_addr.clone(),
-        &nft_msg::ExecuteMsg::Approve {
-            spender: goat_addr.to_string(),
-            token_id: token_id.to_string(),
-        },
-        &[]
-    ).unwrap();
-
-    app.execute_contract(
-        Addr::unchecked("user"),
-        nft_addr.clone(),
-        &nft_msg::ExecuteMsg::UpdateWeight {
-            token_id: token_id.to_string(),
-            new_weight: 12,
-        },
-        &[]
-    ).unwrap();
-
-    app.update_block(|b| b.time = b.time.plus_seconds(WEIGHT_UPDATE_VALIDITY + 1));
-
-    let err = app.execute_contract(
-        Addr::unchecked("user"),
-        goat_addr.clone(),
-        &ExecuteMsg::BurnAndMint { token_id },
-        &[]
-    ).unwrap_err();
-    assert!(!err.to_string().is_empty());
-}
 
 #[test]
 fn claim_reward_multiple_times() {
@@ -246,7 +135,7 @@ fn claim_reward_multiple_times() {
         &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 },
         &[]
     ).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(100) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "staker", Uint128::new(100));
     app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(100) }, &[]).unwrap();
 
     app.update_block(|b| b.time = b.time.plus_seconds(1));
@@ -269,7 +158,7 @@ fn emergency_unstake_returns_only_stake() {
         &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 10 },
         &[]
     ).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "user".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "user", Uint128::new(50));
     app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
     app.update_block(|b| b.time = b.time.plus_seconds(5));
     app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::EmergencyUnstake {}, &[]).unwrap();
@@ -294,7 +183,7 @@ fn claim_without_stake_fails() {
 #[test]
 fn emergency_unstake_mints_shortfall() {
     let (mut app, addr) = init_app();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "user".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "user", Uint128::new(50));
     app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
     // drain contract balance
     app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(30) }, &[]).unwrap();
@@ -309,7 +198,7 @@ fn emergency_unstake_mints_shortfall() {
 fn unstake_mints_shortfall() {
     let (mut app, addr) = init_app();
     app.execute_contract(Addr::unchecked("owner"), addr.clone(), &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "user".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "user", Uint128::new(50));
     app.execute_contract(Addr::unchecked("user"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
     app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(30) }, &[]).unwrap();
     app.update_block(|b| b.time = b.time.plus_seconds(1));
@@ -324,7 +213,7 @@ fn unstake_mints_shortfall() {
 fn claim_reward_mints_shortfall() {
     let (mut app, addr) = init_app();
     app.execute_contract(Addr::unchecked("owner"), addr.clone(), &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "staker", Uint128::new(50));
     app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
     app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(40) }, &[]).unwrap();
     app.update_block(|b| b.time = b.time.plus_seconds(1));
@@ -339,7 +228,7 @@ fn claim_reward_mints_shortfall() {
 fn compound_reward_mints_shortfall() {
     let (mut app, addr) = init_app();
     app.execute_contract(Addr::unchecked("owner"), addr.clone(), &ExecuteMsg::SetRewardConfig { new_rate: Uint128::new(1_000_000_000_000_000_000), new_interval: 1, new_min_claim: 1 }, &[]).unwrap();
-    app.execute_contract(Addr::unchecked("meat"), addr.clone(), &ExecuteMsg::MintTo { to: "staker".into(), amount: Uint128::new(50) }, &[]).unwrap();
+    mint_to(&mut app, addr.clone(), "staker", Uint128::new(50));
     app.execute_contract(Addr::unchecked("staker"), addr.clone(), &ExecuteMsg::Stake { amount: Uint128::new(50) }, &[]).unwrap();
     app.execute_contract(addr.clone(), addr.clone(), &ExecuteMsg::Transfer { recipient: "other".into(), amount: Uint128::new(30) }, &[]).unwrap();
     app.update_block(|b| b.time = b.time.plus_seconds(1));

--- a/wasm-contracts/starter/tests/wrapper.rs
+++ b/wasm-contracts/starter/tests/wrapper.rs
@@ -105,7 +105,7 @@ fn wrap_and_unwrap_flow() {
     app.execute_contract(
         Addr::unchecked("owner"),
         goat_addr.clone(),
-        &goat_msg::ExecuteMsg::SetMeatAddress { meat_address: wrapper_addr.to_string() },
+        &goat_msg::ExecuteMsg::SetWrapperContract { wrapper_address: wrapper_addr.to_string() },
         &[],
     ).unwrap();
 
@@ -163,17 +163,6 @@ fn wrap_and_unwrap_flow() {
         .iter()
         .any(|a| a.key == "action" && a.value == "Wrapped")));
 
-    // approve goat burn
-    app.execute_contract(
-        Addr::unchecked("user"),
-        goat_addr.clone(),
-        &goat_msg::ExecuteMsg::Approve {
-            spender: wrapper_addr.to_string(),
-            amount: Uint128::new(117647058823529400),
-        },
-        &[],
-    )
-    .unwrap();
     let res = app
         .execute_contract(
             Addr::unchecked("user"),


### PR DESCRIPTION
## Summary
- restrict GOAT wasm contract so only the wrapper can mint or burn
- update NFT wrappers to use the new mint/burnFrom API
- adjust tests for the new permission model
- document new `IGoatToken` interface

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c65dca3c883258b58915813dc8281