### PR TITLE
codex: update docs with cosmwasm parity note

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ terelakkan:
   dan memeriksa kesegaran data berat seperti implementasi Solidity.
 - Mulai versi `v1.1`, implementasi CosmWasm sepenuhnya mendukung alur
   subtype-aware dan lineage-aware sehingga mencerminkan perilaku kontrak EVM.
+- Versi terbaru CosmWasm juga menegakkan batasan subtype dan perhitungan LOD yang sama dengan kontrak Solidity sehingga swap dan redeem mengikuti aturan identik.
 
 Secara umum kedua implementasi mempertahankan rasio reward yang sama
 agar perilaku ekonomi konsisten di EVM maupun Cosmos.

--- a/docs/governance-lod-engine.md
+++ b/docs/governance-lod-engine.md
@@ -17,6 +17,8 @@ Semua nilai tersebut kini hanya dimuat melalui fungsi `setCommodityRepresentatio
 Tidak ada fallback atau referensi ke `SwapConfig` maupun mapping lama lainnya.
 Panggilan fungsi tersebut memunculkan event `CommodityRepresentationUpdated(commodityId)` untuk menandai pembaruan data di blockchain.
 
+Versi CosmWasm dari `RateHandler`, `BarterEngine`, dan `RedeemEngine` kini menerapkan pembatasan subtype serta perhitungan LOD yang sama persis dengan implementasi Solidity.
+
 Lihat diagram *Canonical Reasoning Path* pada [architecture.md](../architecture.md#token-layer-separation--lod-engine-enforcement) bagian 4 untuk pemahaman menyeluruh mengenai pemisahan layer dan aturan swap.
 
 ---

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -38,10 +38,12 @@ Berdasarkan [goat-meat-lifecycle.md](goat-meat-lifecycle.md), setiap `GoatNFT` d
 
 1. Dibungkus menjadi GOAT untuk staking.
 2. Dibakar melalui hook yang mencetak subtype *MEAT* sesuai berat ternak.
-3. Token MEAT dapat dibarter ke produk lain dengan `BarterEngine` pada CosmWasm atau ditebus melalui `RedeemEngine`.
+3. Token MEAT dapat dibarter ke produk lain melalui `BarterEngine` yang menghitung rasio tukar memakai `RateHandler` dan hanya mengizinkan swap antar subtype yang sah. Penebusan dilakukan melalui `RedeemEngine` setelah verifikasi lineage.
 
 ## Governance dan LOD Engine
 White paper ini mengikuti panduan [governance-lod-engine.md](governance-lod-engine.md). LOD Engine menetapkan paritas komoditas melalui fungsi `setCommodityRepresentation`. Setiap pembaruan diwajibkan melewati pipeline governansi dan diuji dengan Hardhat.
+
+Implementasi CosmWasm dari kontrak-kontrak ini kini menegakkan batasan subtype dan perhitungan LOD yang sama persis seperti versi Solidity sehingga barter maupun redeem mengikuti aturan identik.
 
 ## Visi
 Repositori ini bertujuan mewujudkan *Monetary 5.0* – sistem transparan berbasis siklus hidup, anti inflasi, dan terbuka untuk adopsi komunitas. Nilai diikat pada aktivitas nyata dengan meniadakan mint/burn sewenang-wenang.


### PR DESCRIPTION
## Summary
- describe MEAT barter logic and redeem verification in the whitepaper
- clarify governance document that CosmWasm contracts enforce the same subtype and LOD rules
- mention CosmWasm parity with Solidity in README

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684c6a9b62d883259b8f6b08d516a195