### PR TITLE
Add CosmWasm tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: yes | npx hardhat test
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Run CosmWasm tests
+        run: |
+          for dir in wasm-contracts/*; do
+            if [ -f "$dir/Cargo.toml" ]; then
+              (cd "$dir" && cargo test)
+            fi
+          done
+

--- a/wasm-contracts/goatnftburnhook/Cargo.toml
+++ b/wasm-contracts/goatnftburnhook/Cargo.toml
@@ -14,3 +14,7 @@ schemars = "0.8"
 cw-storage-plus = "1.1"
 meat = { path = "../meat" }
 
+[dev-dependencies]
+cw-multi-test = "0.16"
+goatnft = { path = "../goatnft" }
+

--- a/wasm-contracts/goatnftburnhook/tests/basic.rs
+++ b/wasm-contracts/goatnftburnhook/tests/basic.rs
@@ -1,0 +1,99 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use goatnftburnhook::{execute as hook_execute, instantiate as hook_instantiate, query as hook_query};
+use goatnftburnhook::msg as hook_msg;
+use goatnft::{execute as nft_execute, instantiate as nft_instantiate, query as nft_query};
+use meat::{execute as meat_execute, instantiate as meat_instantiate, query as meat_query};
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(nft_execute, nft_instantiate, nft_query))
+}
+
+fn contract_meat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(meat_execute, meat_instantiate, meat_query))
+}
+
+fn contract_hook() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(hook_execute, hook_instantiate, hook_query))
+}
+
+#[test]
+fn mint_on_burn() {
+    let mut app = App::default();
+    let nft_id = app.store_code(contract_nft());
+    let meat_id = app.store_code(contract_meat());
+    let hook_id = app.store_code(contract_hook());
+
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &goatnft::msg::InstantiateMsg {}, &[], "nft", None)
+        .unwrap();
+    let meat_addr = app
+        .instantiate_contract(meat_id, Addr::unchecked("owner"), &meat::msg::InstantiateMsg {}, &[], "meat", None)
+        .unwrap();
+    let hook_addr = app
+        .instantiate_contract(
+            hook_id,
+            Addr::unchecked("owner"),
+            &hook_msg::InstantiateMsg { nft_contract: nft_addr.to_string(), meat_contract: meat_addr.to_string() },
+            &[],
+            "hook",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        meat_addr.clone(),
+        &meat::msg::ExecuteMsg::SetMinter { account: hook_addr.to_string(), status: true },
+        &[],
+    ).unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        nft_addr.clone(),
+        &goatnft::msg::ExecuteMsg::SetBurnHook { hook: hook_addr.to_string() },
+        &[],
+    ).unwrap();
+
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &goatnft::msg::ExecuteMsg::Mint { to: "user".into(), nfc_id: "id".into(), breed: "Boer".into(), birth_year: 2024, weight: 500 },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap().attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &goatnft::msg::ExecuteMsg::UpdateWeight { token_id: token_id.to_string(), new_weight: 500 },
+        &[],
+    ).unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &goatnft::msg::ExecuteMsg::Burn { token_id: token_id.to_string() },
+        &[],
+    ).unwrap();
+
+    let bal: meat::msg::BalanceSubtypeWithLineageResponse = app
+        .wrap()
+        .query_wasm_smart(meat_addr, &meat::msg::QueryMsg::BalanceOfSubtypeWithLineage { user: "user".into(), subtype: "GOATMEAT".into() })
+        .unwrap();
+    assert_eq!(bal.balance, Uint128::new(30_000_000_000_000_000_000u128));
+}
+
+#[test]
+fn owner_query() {
+    let mut app = App::default();
+    let hook_id = app.store_code(contract_hook());
+    let addr = app
+        .instantiate_contract(hook_id, Addr::unchecked("owner"), &hook_msg::InstantiateMsg { nft_contract: "nft".into(), meat_contract: "meat".into() }, &[], "hook", None)
+        .unwrap();
+
+    let owner: String = app.wrap().query_wasm_smart(addr, &hook_msg::QueryMsg::Owner {}).unwrap();
+    assert_eq!(owner, "owner");
+}

--- a/wasm-contracts/goatnftwrapper/Cargo.toml
+++ b/wasm-contracts/goatnftwrapper/Cargo.toml
@@ -16,3 +16,8 @@ cw-storage-plus = "1.1"
 
 starter = { path = "../starter" }
 goatnft = { path = "../goatnft" }
+
+[dev-dependencies]
+cw-multi-test = "0.16"
+starter = { path = "../starter" }
+goatnft = { path = "../goatnft" }

--- a/wasm-contracts/goatnftwrapper/tests/wrapper.rs
+++ b/wasm-contracts/goatnftwrapper/tests/wrapper.rs
@@ -1,0 +1,153 @@
+use cosmwasm_std::{Addr, Empty, Uint128};
+use cw_multi_test::{App, ContractWrapper, Executor};
+
+use goatnft::{execute as nft_execute, instantiate as nft_instantiate, query as nft_query};
+use goatnftwrapper::{execute as wrap_execute, instantiate as wrap_instantiate, query as wrap_query};
+use goatnftwrapper::msg as wrap_msg;
+use starter::{execute as goat_execute, instantiate as goat_instantiate, query as goat_query};
+
+fn contract_goat() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(goat_execute, goat_instantiate, goat_query))
+}
+
+fn contract_nft() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(nft_execute, nft_instantiate, nft_query))
+}
+
+fn contract_wrapper() -> Box<dyn cw_multi_test::Contract<Empty>> {
+    Box::new(ContractWrapper::new(wrap_execute, wrap_instantiate, wrap_query))
+}
+
+#[test]
+fn wrap_and_unwrap() {
+    let mut app = App::default();
+    let goat_id = app.store_code(contract_goat());
+    let nft_id = app.store_code(contract_nft());
+    let wrap_id = app.store_code(contract_wrapper());
+
+    let goat_addr = app
+        .instantiate_contract(goat_id, Addr::unchecked("owner"), &starter::msg::InstantiateMsg {}, &[], "goat", None)
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &goatnft::msg::InstantiateMsg {}, &[], "nft", None)
+        .unwrap();
+    let wrapper_addr = app
+        .instantiate_contract(
+            wrap_id,
+            Addr::unchecked("owner"),
+            &wrap_msg::InstantiateMsg { nft_contract: nft_addr.to_string(), goat_contract: goat_addr.to_string() },
+            &[],
+            "wrapper",
+            None,
+        )
+        .unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        goat_addr.clone(),
+        &starter::msg::ExecuteMsg::SetWrapperContract { wrapper_address: wrapper_addr.to_string() },
+        &[],
+    ).unwrap();
+
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &goatnft::msg::ExecuteMsg::Mint { to: "user".into(), nfc_id: "id".into(), breed: "Boer".into(), birth_year: 2024, weight: 500 },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap().attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        nft_addr.clone(),
+        &goatnft::msg::ExecuteMsg::Approve { spender: wrapper_addr.to_string(), token_id: token_id.to_string() },
+        &[],
+    ).unwrap();
+
+    let wrap_res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            wrapper_addr.clone(),
+            &wrap_msg::ExecuteMsg::Wrap { token_id },
+            &[],
+        )
+        .unwrap();
+    assert!(wrap_res.events.iter().any(|e| e.attributes.iter().any(|a| a.key == "action" && a.value == "Wrapped")));
+
+    app.execute_contract(
+        Addr::unchecked("user"),
+        goat_addr.clone(),
+        &starter::msg::ExecuteMsg::Approve { spender: wrapper_addr.to_string(), amount: Uint128::new(117_647_058_823_529_400) },
+        &[],
+    ).unwrap();
+
+    let unwrap_res = app
+        .execute_contract(
+            Addr::unchecked("user"),
+            wrapper_addr.clone(),
+            &wrap_msg::ExecuteMsg::Unwrap { token_id },
+            &[],
+        )
+        .unwrap();
+    assert!(unwrap_res.events.iter().any(|e| e.attributes.iter().any(|a| a.key == "action" && a.value == "Unwrapped")));
+}
+
+#[test]
+fn unauthorized_actions() {
+    let mut app = App::default();
+    let goat_id = app.store_code(contract_goat());
+    let nft_id = app.store_code(contract_nft());
+    let wrap_id = app.store_code(contract_wrapper());
+
+    let goat_addr = app
+        .instantiate_contract(goat_id, Addr::unchecked("owner"), &starter::msg::InstantiateMsg {}, &[], "goat", None)
+        .unwrap();
+    let nft_addr = app
+        .instantiate_contract(nft_id, Addr::unchecked("owner"), &goatnft::msg::InstantiateMsg {}, &[], "nft", None)
+        .unwrap();
+    let wrapper_addr = app
+        .instantiate_contract(
+            wrap_id,
+            Addr::unchecked("owner"),
+            &wrap_msg::InstantiateMsg { nft_contract: nft_addr.to_string(), goat_contract: goat_addr.to_string() },
+            &[],
+            "wrapper",
+            None,
+        )
+        .unwrap();
+
+    let resp = app
+        .execute_contract(
+            Addr::unchecked("owner"),
+            nft_addr.clone(),
+            &goatnft::msg::ExecuteMsg::Mint { to: "owner".into(), nfc_id: "id".into(), breed: "Boer".into(), birth_year: 2024, weight: 500 },
+            &[],
+        )
+        .unwrap();
+    let token_id: u64 = resp.events.iter().find(|e| e.ty == "wasm").unwrap().attributes.iter().find(|a| a.key == "token_id").unwrap().value.parse().unwrap();
+    app.execute_contract(
+        Addr::unchecked("owner"),
+        nft_addr.clone(),
+        &goatnft::msg::ExecuteMsg::Approve { spender: wrapper_addr.to_string(), token_id: token_id.to_string() },
+        &[],
+    ).unwrap();
+
+    let err = app
+        .execute_contract(Addr::unchecked("user"), wrapper_addr.clone(), &wrap_msg::ExecuteMsg::Wrap { token_id }, &[])
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}
+
+#[test]
+fn owner_query() {
+    let mut app = App::default();
+    let wrap_id = app.store_code(contract_wrapper());
+    let addr = app
+        .instantiate_contract(wrap_id, Addr::unchecked("owner"), &wrap_msg::InstantiateMsg { nft_contract: "nft".into(), goat_contract: "goat".into() }, &[], "wrapper", None)
+        .unwrap();
+
+    let owner: String = app.wrap().query_wasm_smart(addr, &wrap_msg::QueryMsg::Owner {}).unwrap();
+    assert_eq!(owner, "owner");
+}

--- a/wasm-contracts/redeemengine/tests/basic.rs
+++ b/wasm-contracts/redeemengine/tests/basic.rs
@@ -33,9 +33,7 @@ fn redeem_burns_meat() {
         .instantiate_contract(
             goat_id,
             Addr::unchecked("owner"),
-            &starter::msg::InstantiateMsg {
-                meat_contract: "meat".into(),
-            },
+            &starter::msg::InstantiateMsg {},
             &[],
             "goat",
             None,
@@ -136,4 +134,50 @@ fn redeem_burns_meat() {
         .unwrap();
     assert_eq!(bal.balance, Uint128::new(950));
     assert_eq!(bal.lineage_id, 1);
+}
+
+#[test]
+fn lineage_not_set_rejected() {
+    let mut app = App::default();
+    let meat_id = app.store_code(contract_meat());
+    let eng_id = app.store_code(contract_engine());
+
+    let meat_addr = app
+        .instantiate_contract(meat_id, Addr::unchecked("owner"), &MeatInstantiate {}, &[], "meat", None)
+        .unwrap();
+    let eng_addr = app
+        .instantiate_contract(eng_id, Addr::unchecked("owner"), &InstantiateMsg { meat_contract: meat_addr.to_string() }, &[], "engine", None)
+        .unwrap();
+
+    app.execute_contract(Addr::unchecked("owner"), meat_addr.clone(), &MeatExec::MintSubtype { to: "user".into(), subtype: "GOATMEAT".into(), amount: Uint128::new(1000) }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("owner"), meat_addr.clone(), &MeatExec::SetBurner { account: eng_addr.to_string(), status: true }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("owner"), eng_addr.clone(), &ExecuteMsg::SetRedeemConfig { subtype: "GOATMEAT".into(), grams_per_token_unit: 100, active: true }, &[]).unwrap();
+
+    let err = app
+        .execute_contract(Addr::unchecked("user"), eng_addr.clone(), &ExecuteMsg::Redeem { subtype: "GOATMEAT".into(), amount: 10 }, &[])
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}
+
+#[test]
+fn owner_can_withdraw() {
+    let mut app = App::default();
+    let meat_id = app.store_code(contract_meat());
+    let eng_id = app.store_code(contract_engine());
+
+    let meat_addr = app
+        .instantiate_contract(meat_id, Addr::unchecked("owner"), &MeatInstantiate {}, &[], "meat", None)
+        .unwrap();
+    let eng_addr = app
+        .instantiate_contract(eng_id, Addr::unchecked("owner"), &InstantiateMsg { meat_contract: meat_addr.to_string() }, &[], "engine", None)
+        .unwrap();
+
+    app.execute_contract(Addr::unchecked("owner"), meat_addr.clone(), &MeatExec::SetMinter { account: eng_addr.to_string(), status: true }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("owner"), meat_addr.clone(), &MeatExec::SetBurner { account: eng_addr.to_string(), status: true }, &[]).unwrap();
+    app.execute_contract(Addr::unchecked("owner"), meat_addr.clone(), &MeatExec::MintSubtype { to: eng_addr.to_string(), subtype: "GOATMEAT".into(), amount: Uint128::new(50) }, &[]).unwrap();
+
+    let res = app
+        .execute_contract(Addr::unchecked("owner"), eng_addr.clone(), &ExecuteMsg::EmergencyWithdrawMEATSubtype { subtype: "GOATMEAT".into() }, &[])
+        .unwrap();
+    assert!(res.events.iter().any(|e| e.attributes.iter().any(|a| a.key == "action" && a.value == "emergency_withdraw_meat_subtype")));
 }


### PR DESCRIPTION
## Summary
- add new tests for GoatNFTWrapper and GoatNFTBurnHook
- enhance RedeemEngine tests and fix logic
- configure GitHub Actions to run hardhat and cargo tests

## Testing
- `npm install`
- `yes | npx hardhat test`
- `cargo test` for `goatnftburnhook`
- `cargo test` for `goatnftwrapper`
- `cargo test` for `redeemengine`


------
https://chatgpt.com/codex/tasks/task_e_684c6bfb98848325ac08d1f186213986