### PR TITLE
codex/solidity-parity-fix

### DIFF
--- a/wasm-contracts/meat/src/lib.rs
+++ b/wasm-contracts/meat/src/lib.rs
@@ -371,6 +371,16 @@ fn execute_burn_subtype(
         return Err(StdError::generic_err("Invalid params"));
     }
     let from_addr = deps.api.addr_validate(&from)?;
+    if info.sender != from_addr {
+        let mut allowance = ALLOWANCES
+            .may_load(deps.storage, (&from_addr, &info.sender))?
+            .unwrap_or_default();
+        if allowance < amount {
+            return Err(StdError::generic_err("Allowance exceeded"));
+        }
+        allowance -= amount;
+        ALLOWANCES.save(deps.storage, (&from_addr, &info.sender), &allowance)?;
+    }
     burn_subtype_internal(deps.storage, &from_addr, subtype.as_bytes(), amount)?;
     Ok(Response::new()
         .add_attribute("action", "SubtypeBurned")
@@ -433,10 +443,15 @@ fn execute_set_rate_handler(
 ) -> StdResult<Response> {
     only_owner(deps.branch(), &info)?;
     let addr = deps.api.addr_validate(&address)?;
+    let old = RATE_HANDLER.load(deps.storage)?;
     RATE_HANDLER.save(deps.storage, &Some(addr.clone()))?;
     Ok(Response::new()
         .add_attribute("action", "RateHandlerUpdated")
-        .add_attribute("address", addr.into_string()))
+        .add_attribute(
+            "old_address",
+            old.map(|a| a.into_string()).unwrap_or_default(),
+        )
+        .add_attribute("new_address", addr.into_string()))
 }
 
 fn execute_redeem_for_meat(

--- a/wasm-contracts/meat/tests/subtype.rs
+++ b/wasm-contracts/meat/tests/subtype.rs
@@ -76,6 +76,18 @@ fn mint_burn_and_lineage() {
     )
     .unwrap();
 
+    // user approves burner to burn tokens
+    app.execute_contract(
+        Addr::unchecked("user"),
+        meat_addr.clone(),
+        &ExecuteMsg::Approve {
+            spender: "burner".into(),
+            amount: Uint128::new(10),
+        },
+        &[],
+    )
+    .unwrap();
+
     app.execute_contract(
         Addr::unchecked("burner"),
         meat_addr.clone(),


### PR DESCRIPTION
## Summary
- enforce allowance in CosmWasm MEAT `burn_subtype`
- emit old/new address when updating `RateHandler`
- require approval in MEAT subtype test

## Testing
- `yes | npx hardhat test`
- `cargo test` in `wasm-contracts/meat`

------
https://chatgpt.com/codex/tasks/task_e_684cbfa4013c8325b24b7b3a1b83c4d4